### PR TITLE
fix(issues): enforce strict issue number parsing

### DIFF
--- a/src/issues/runIssueCommand.test.ts
+++ b/src/issues/runIssueCommand.test.ts
@@ -140,6 +140,23 @@ describe("runIssueCommand", () => {
     expect(console.error).toHaveBeenCalledWith("Issue number must be a positive integer.");
   });
 
+  it.each(["1abc", "01x", " 1", "1 ", "1.5", "-1", "0"])(
+    "rejects malformed issue number input: %s",
+    async (issueNumber) => {
+      const { runIssueCommand } = await import("./runIssueCommand.js");
+
+      await runIssueCommand(["issues", "start", issueNumber]);
+
+      expect(console.error).toHaveBeenCalledWith("Issue number must be a positive integer.");
+      expect(markInProgressMock).not.toHaveBeenCalled();
+      expect(addProgressCommentMock).not.toHaveBeenCalled();
+      expect(markCompletedMock).not.toHaveBeenCalled();
+      expect(closeIssueMock).not.toHaveBeenCalled();
+      expect(createIssueMock).not.toHaveBeenCalled();
+      expect(listOpenIssuesMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("logs GitHub API errors", async () => {
     listOpenIssuesMock.mockRejectedValue(
       new GitHubApiError("GitHub API request failed (401): Bad credentials", 401, null),

--- a/src/issues/runIssueCommand.ts
+++ b/src/issues/runIssueCommand.ts
@@ -3,7 +3,12 @@ import { GitHubApiError, GitHubClient } from "../github/githubClient.js";
 import { TaskIssueManager } from "./taskIssueManager.js";
 
 function parseIssueNumber(value: string | undefined): number {
-  const issueNumber = Number.parseInt(value ?? "", 10);
+  const rawValue = value ?? "";
+  if (!/^\d+$/.test(rawValue)) {
+    throw new Error("Issue number must be a positive integer.");
+  }
+
+  const issueNumber = Number(rawValue);
 
   if (!Number.isInteger(issueNumber) || issueNumber < 1) {
     throw new Error("Issue number must be a positive integer.");


### PR DESCRIPTION
## Summary
- enforce strict issue number parsing for issue CLI commands
- reject malformed values before numeric conversion while keeping existing validation message
- add regression tests for malformed inputs and no-op behavior on invalid start values

## Validation
- pnpm vitest src/issues/runIssueCommand.test.ts

Closes #7