### PR TITLE
fix(github-client): add timeout and transient retry policy

### DIFF
--- a/src/github/githubClient.test.ts
+++ b/src/github/githubClient.test.ts
@@ -3,6 +3,22 @@ import { GitHubApiError, GitHubClient } from "./githubClient.js";
 
 const fetchMock = vi.fn();
 
+function createClient(overrides?: {
+  requestTimeoutMs?: number;
+  maxRetries?: number;
+  retryBaseDelayMs?: number;
+}): GitHubClient {
+  return new GitHubClient({
+    token: "secret-token",
+    owner: "owner",
+    repo: "repo",
+    apiBaseUrl: "https://api.github.com",
+    requestTimeoutMs: overrides?.requestTimeoutMs,
+    maxRetries: overrides?.maxRetries,
+    retryBaseDelayMs: overrides?.retryBaseDelayMs,
+  });
+}
+
 describe("GitHubClient", () => {
   beforeEach(() => {
     fetchMock.mockReset();
@@ -22,12 +38,7 @@ describe("GitHubClient", () => {
       }),
     );
 
-    const client = new GitHubClient({
-      token: "secret-token",
-      owner: "owner",
-      repo: "repo",
-      apiBaseUrl: "https://api.github.com",
-    });
+    const client = createClient();
 
     const result = await client.get<Array<{ number: number }>>("?state=open");
 
@@ -52,12 +63,7 @@ describe("GitHubClient", () => {
       }),
     );
 
-    const client = new GitHubClient({
-      token: "secret-token",
-      owner: "owner",
-      repo: "repo",
-      apiBaseUrl: "https://api.github.com",
-    });
+    const client = createClient();
 
     await expect(client.get("/999")).rejects.toEqual(
       expect.objectContaining({
@@ -66,17 +72,13 @@ describe("GitHubClient", () => {
         message: "GitHub API request failed (404): Not Found",
       }),
     );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("handles 204 responses for delete operations", async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
 
-    const client = new GitHubClient({
-      token: "secret-token",
-      owner: "owner",
-      repo: "repo",
-      apiBaseUrl: "https://api.github.com",
-    });
+    const client = createClient();
 
     await expect(client.delete("/1/labels/in%20progress")).resolves.toBeUndefined();
   });
@@ -89,15 +91,102 @@ describe("GitHubClient", () => {
       }),
     );
 
-    const client = new GitHubClient({
-      token: "secret-token",
-      owner: "owner",
-      repo: "repo",
-      apiBaseUrl: "https://api.github.com",
-    });
+    const client = createClient({ maxRetries: 0 });
 
     const result = client.get("/1");
     await expect(result).rejects.toBeInstanceOf(GitHubApiError);
     await expect(result).rejects.toThrow("GitHub API request failed with status 503.");
+  });
+
+  it("retries retryable statuses and can recover", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "Service unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ number: 1 }]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const client = createClient({ maxRetries: 2, retryBaseDelayMs: 1 });
+
+    const result = await client.get<Array<{ number: number }>>("?state=open");
+
+    expect(result).toEqual([{ number: 1 }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-retryable statuses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Bad credentials" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const client = createClient({ maxRetries: 3, retryBaseDelayMs: 1 });
+
+    await expect(client.get("/1")).rejects.toThrow(
+      "GitHub API request failed (401): Bad credentials",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries timeout failures and surfaces explicit timeout when exhausted", async () => {
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    fetchMock.mockRejectedValue(abortError);
+
+    const client = createClient({ requestTimeoutMs: 5, maxRetries: 1, retryBaseDelayMs: 1 });
+
+    await expect(client.get("/1")).rejects.toThrow("GitHub API request timed out after 5ms.");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries network errors and succeeds", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ number: 2 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const client = createClient({ maxRetries: 2, retryBaseDelayMs: 1 });
+
+    await expect(client.get<{ number: number }>("/2")).resolves.toEqual({ number: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects invalid timeout config values", () => {
+    expect(
+      () =>
+        new GitHubClient({
+          token: "secret-token",
+          owner: "owner",
+          repo: "repo",
+          apiBaseUrl: "https://api.github.com",
+          requestTimeoutMs: 0,
+        }),
+    ).toThrow("requestTimeoutMs must be a positive integer.");
+  });
+
+  it("rejects negative retry config values", () => {
+    expect(
+      () =>
+        new GitHubClient({
+          token: "secret-token",
+          owner: "owner",
+          repo: "repo",
+          apiBaseUrl: "https://api.github.com",
+          maxRetries: -1,
+        }),
+    ).toThrow("maxRetries must be a non-negative integer.");
   });
 });

--- a/src/github/githubClient.ts
+++ b/src/github/githubClient.ts
@@ -17,14 +17,57 @@ type RequestOptions = {
   body?: unknown;
 };
 
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_RETRY_BASE_DELAY_MS = 250;
+
+function readPositiveInteger(value: number | undefined, fallback: number, name: string): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return value;
+}
+
+function readNonNegativeInteger(value: number | undefined, fallback: number, name: string): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+
+  return value;
+}
+
 export class GitHubClient {
   private readonly baseIssueUrl: string;
   private readonly token: string;
+  private readonly requestTimeoutMs: number;
+  private readonly maxRetries: number;
+  private readonly retryBaseDelayMs: number;
 
   public constructor(config: GitHubConfig) {
     const apiBase = config.apiBaseUrl.replace(/\/+$/, "");
     this.baseIssueUrl = `${apiBase}/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/issues`;
     this.token = config.token;
+    this.requestTimeoutMs = readPositiveInteger(
+      config.requestTimeoutMs,
+      DEFAULT_REQUEST_TIMEOUT_MS,
+      "requestTimeoutMs",
+    );
+    this.maxRetries = readNonNegativeInteger(config.maxRetries, DEFAULT_MAX_RETRIES, "maxRetries");
+    this.retryBaseDelayMs = readNonNegativeInteger(
+      config.retryBaseDelayMs,
+      DEFAULT_RETRY_BASE_DELAY_MS,
+      "retryBaseDelayMs",
+    );
   }
 
   public async get<T>(path: string): Promise<T> {
@@ -45,25 +88,92 @@ export class GitHubClient {
 
   private async request<T>(path: string, options: RequestOptions): Promise<T> {
     const url = `${this.baseIssueUrl}${path}`;
-    const response = await fetch(url, {
-      method: options.method ?? "GET",
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${this.token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-        "Content-Type": "application/json",
-      },
-      body: options.body === undefined ? undefined : JSON.stringify(options.body),
-    });
+    const totalAttempts = this.maxRetries + 1;
 
-    const responseBody = await this.readResponseBody(response);
+    for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
+      try {
+        const response = await this.fetchWithTimeout(url, options);
+        const responseBody = await this.readResponseBody(response);
 
-    if (!response.ok) {
-      const message = this.getErrorMessage(responseBody, response.status);
-      throw new GitHubApiError(message, response.status, responseBody);
+        if (!response.ok) {
+          const message = this.getErrorMessage(responseBody, response.status);
+          throw new GitHubApiError(message, response.status, responseBody);
+        }
+
+        return responseBody as T;
+      } catch (error) {
+        const shouldRetry = attempt < totalAttempts && this.isRetryableError(error);
+        if (!shouldRetry) {
+          throw error;
+        }
+
+        await this.waitBeforeRetry(attempt);
+      }
     }
 
-    return responseBody as T;
+    throw new Error("Unexpected request flow.");
+  }
+
+  private async fetchWithTimeout(url: string, options: RequestOptions): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+
+    try {
+      return await fetch(url, {
+        method: options.method ?? "GET",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${this.token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+        },
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (this.isAbortError(error)) {
+        throw new Error(`GitHub API request timed out after ${this.requestTimeoutMs}ms.`);
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private isRetryableError(error: unknown): boolean {
+    if (error instanceof GitHubApiError) {
+      return RETRYABLE_STATUS_CODES.has(error.status);
+    }
+
+    if (error instanceof Error) {
+      if (error.message.startsWith("GitHub API request timed out")) {
+        return true;
+      }
+
+      return error instanceof TypeError;
+    }
+
+    return false;
+  }
+
+  private isAbortError(error: unknown): boolean {
+    if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+      return error.name === "AbortError";
+    }
+
+    if (error instanceof Error) {
+      return error.name === "AbortError";
+    }
+
+    return false;
+  }
+
+  private async waitBeforeRetry(attempt: number): Promise<void> {
+    const delayMs = this.retryBaseDelayMs * attempt;
+    await new Promise((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
   }
 
   private async readResponseBody(response: Response): Promise<unknown> {

--- a/src/github/githubConfig.test.ts
+++ b/src/github/githubConfig.test.ts
@@ -23,6 +23,9 @@ describe("getGitHubConfig", () => {
       owner: "owner",
       repo: "repo",
       apiBaseUrl: "https://api.github.com",
+      requestTimeoutMs: undefined,
+      maxRetries: undefined,
+      retryBaseDelayMs: undefined,
     });
   });
 
@@ -46,6 +49,38 @@ describe("getGitHubConfig", () => {
 
     expect(() => getGitHubConfig()).toThrow(
       "GITHUB_TOKEN is not set in the environment variables.",
+    );
+  });
+
+  it("reads optional retry and timeout env values", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_OWNER", "owner");
+    vi.stubEnv("GITHUB_REPO", "repo");
+    vi.stubEnv("GITHUB_REQUEST_TIMEOUT_MS", "7000");
+    vi.stubEnv("GITHUB_REQUEST_MAX_RETRIES", "0");
+    vi.stubEnv("GITHUB_RETRY_BASE_DELAY_MS", "0");
+
+    const { getGitHubConfig } = await importConfig();
+
+    expect(getGitHubConfig()).toEqual(
+      expect.objectContaining({
+        requestTimeoutMs: 7000,
+        maxRetries: 0,
+        retryBaseDelayMs: 0,
+      }),
+    );
+  });
+
+  it("throws when optional retry/timeout env values are invalid", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "token");
+    vi.stubEnv("GITHUB_OWNER", "owner");
+    vi.stubEnv("GITHUB_REPO", "repo");
+    vi.stubEnv("GITHUB_REQUEST_MAX_RETRIES", "-1");
+
+    const { getGitHubConfig } = await importConfig();
+
+    expect(() => getGitHubConfig()).toThrow(
+      "GITHUB_REQUEST_MAX_RETRIES must be a non-negative integer when set.",
     );
   });
 });

--- a/src/github/githubConfig.ts
+++ b/src/github/githubConfig.ts
@@ -13,7 +13,38 @@ export type GitHubConfig = {
   owner: string;
   repo: string;
   apiBaseUrl: string;
+  requestTimeoutMs?: number;
+  maxRetries?: number;
+  retryBaseDelayMs?: number;
 };
+
+function readOptionalPositiveInteger(name: string): number | undefined {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer when set.`);
+  }
+
+  return parsed;
+}
+
+function readOptionalNonNegativeInteger(name: string): number | undefined {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer when set.`);
+  }
+
+  return parsed;
+}
 
 export function getGitHubConfig(): GitHubConfig {
   return {
@@ -21,5 +52,8 @@ export function getGitHubConfig(): GitHubConfig {
     owner: requireEnv("GITHUB_OWNER"),
     repo: requireEnv("GITHUB_REPO"),
     apiBaseUrl: process.env.GITHUB_API_BASE_URL?.trim() || "https://api.github.com",
+    requestTimeoutMs: readOptionalPositiveInteger("GITHUB_REQUEST_TIMEOUT_MS"),
+    maxRetries: readOptionalNonNegativeInteger("GITHUB_REQUEST_MAX_RETRIES"),
+    retryBaseDelayMs: readOptionalNonNegativeInteger("GITHUB_RETRY_BASE_DELAY_MS"),
   };
 }


### PR DESCRIPTION
## Summary
- add configurable timeout and retry settings to GitHub request config
- apply AbortController timeouts to each API call
- retry transient failures (429/500/502/503/504), timeouts, and network errors with bounded backoff
- keep non-retryable status failures as fast-fail
- add regression tests for timeout, retryable status recovery, non-retryable fast-fail, and exhausted retry behavior

## Validation
- pnpm vitest src/github/githubClient.test.ts src/github/githubConfig.test.ts

Closes #6