### PR TITLE
fix(issues): paginate open issue listing

### DIFF
--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -78,6 +78,31 @@ describe("TaskIssueManager", () => {
     expect(result[0]?.number).toBe(1);
   });
 
+  it("aggregates open issues across pages and excludes pull requests from all pages", async () => {
+    const client = createClientMock();
+    const firstPage = Array.from({ length: 100 }, (_, index) => createIssue({ number: index + 1 }));
+    firstPage[3] = createIssue({ number: 4, pull_request: { url: "pr-1" } });
+
+    client.get
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([
+        createIssue({ number: 101 }),
+        createIssue({ number: 102, pull_request: { url: "pr-2" } }),
+      ]);
+
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.listOpenIssues();
+
+    expect(client.get).toHaveBeenNthCalledWith(1, "?state=open&per_page=100&page=1");
+    expect(client.get).toHaveBeenNthCalledWith(2, "?state=open&per_page=100&page=2");
+    expect(result.map((issue) => issue.number)).toEqual([
+      ...Array.from({ length: 3 }, (_, index) => index + 1),
+      ...Array.from({ length: 96 }, (_, index) => index + 5),
+      101,
+    ]);
+  });
+
   it("marks an issue in progress", async () => {
     const client = createClientMock();
     client.get.mockResolvedValue(createIssue({ labels: [{ name: "bug" }] }));

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -62,6 +62,8 @@ function buildLabels(issue: GitHubIssue, options: { inProgress: boolean; complet
 }
 
 export class TaskIssueManager {
+  private static readonly ISSUES_PER_PAGE = 100;
+
   public constructor(private readonly client: GitHubClient) {}
 
   public async createIssue(title: string, description: string): Promise<IssueActionResult> {
@@ -82,7 +84,22 @@ export class TaskIssueManager {
   }
 
   public async listOpenIssues(): Promise<IssueSummary[]> {
-    const issues = await this.client.get<GitHubIssue[]>("?state=open&per_page=100");
+    const issues: GitHubIssue[] = [];
+    let page = 1;
+
+    while (true) {
+      const batch = await this.client.get<GitHubIssue[]>(
+        `?state=open&per_page=${TaskIssueManager.ISSUES_PER_PAGE}&page=${page}`,
+      );
+      issues.push(...batch);
+
+      if (batch.length < TaskIssueManager.ISSUES_PER_PAGE) {
+        break;
+      }
+
+      page += 1;
+    }
+
     return issues.filter((issue) => issue.pull_request === undefined).map(formatIssue);
   }
 


### PR DESCRIPTION
## Summary
- paginate open issue retrieval in task issue manager using page + per_page=100
- aggregate all open issues before filtering out pull requests
- add regression test for multi-page aggregation and PR filtering across pages

## Validation
- pnpm vitest src/issues/taskIssueManager.test.ts
- pnpm vitest src/main.test.ts src/issues/taskIssueManager.test.ts

Closes #5