### PR TITLE
feat(issue-loop): replenish issues when queue is empty

### DIFF
--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -103,6 +103,57 @@ describe("TaskIssueManager", () => {
     ]);
   });
 
+  it("replenishes empty queue with at least three unique self-improvement issues", async () => {
+    const client = createClientMock();
+    client.get
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    client.post
+      .mockResolvedValueOnce(createIssue({ number: 21, title: "Harden run loop retry handling for transient GitHub failures" }))
+      .mockResolvedValueOnce(createIssue({ number: 22, title: "Add regression test for empty-queue issue replenishment flow" }))
+      .mockResolvedValueOnce(createIssue({ number: 23, title: "Improve validation reporting with command, exit code, and duration" }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.replenishSelfImprovementIssues({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+    });
+
+    expect(result.created).toHaveLength(3);
+    expect(result.created.map((issue) => issue.number)).toEqual([21, 22, 23]);
+    expect(client.get).toHaveBeenNthCalledWith(1, "?state=open&per_page=100&page=1");
+    expect(client.get).toHaveBeenNthCalledWith(2, "?state=closed&sort=updated&direction=desc&per_page=100&page=1");
+  });
+
+  it("avoids duplicates against recent issue history and limits creations by open slots", async () => {
+    const client = createClientMock();
+    client.get
+      .mockResolvedValueOnce([
+        createIssue({ number: 1, title: "Existing open issue" }),
+        createIssue({ number: 2, title: "Another open issue" }),
+        createIssue({ number: 3, title: "Third open issue" }),
+      ])
+      .mockResolvedValueOnce([
+        createIssue({ number: 4, state: "closed", title: "Harden run loop retry handling for transient GitHub failures" }),
+      ]);
+    client.post.mockResolvedValue(createIssue({ number: 31, title: "Harden run loop retry handling for transient GitHub failures (follow-up 1)" }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.replenishSelfImprovementIssues({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 4,
+    });
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]?.number).toBe(31);
+    expect(result.created[0]?.title).toBe("Harden run loop retry handling for transient GitHub failures (follow-up 1)");
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({ title: "Harden run loop retry handling for transient GitHub failures (follow-up 1)" }),
+    );
+  });
+
   it("marks an issue in progress", async () => {
     const client = createClientMock();
     client.get.mockResolvedValue(createIssue({ labels: [{ name: "bug" }] }));

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -30,6 +30,55 @@ export type IssueActionResult = {
   issue?: IssueSummary;
 };
 
+export type ReplenishIssuesOptions = {
+  minimumIssueCount: number;
+  maximumOpenIssues: number;
+};
+
+export type ReplenishIssuesResult = {
+  created: IssueSummary[];
+};
+
+type IssueTemplate = {
+  title: string;
+  description: string;
+};
+
+const SELF_IMPROVEMENT_ISSUE_TEMPLATES: IssueTemplate[] = [
+  {
+    title: "Harden run loop retry handling for transient GitHub failures",
+    description:
+      "Add bounded retry/backoff around transient GitHub API errors in the run loop and cover the failure/recovery paths with tests.",
+  },
+  {
+    title: "Add regression test for empty-queue issue replenishment flow",
+    description:
+      "Add an integration-style runtime test that validates queue replenishment creates new issues and continues processing without exiting.",
+  },
+  {
+    title: "Improve validation reporting with command, exit code, and duration",
+    description:
+      "Enhance validation logs to include command name, exit status, and elapsed time to improve debugging after failed runs.",
+  },
+  {
+    title: "Guard commit staging to reject unrelated modified files",
+    description:
+      "Add a pre-commit safeguard that verifies staged files match the active task scope and blocks accidental unrelated changes.",
+  },
+  {
+    title: "Add structured lifecycle logging for issue cycle transitions",
+    description:
+      "Emit structured logs for issue selection, implementation start/end, review outcome, and merge transition to improve observability.",
+  },
+];
+
+function buildFollowUpTemplate(template: IssueTemplate, sequence: number): IssueTemplate {
+  return {
+    title: `${template.title} (follow-up ${sequence})`,
+    description: `${template.description}\n\nFollow-up: address remaining gaps discovered after earlier work.`,
+  };
+}
+
 function formatIssue(issue: GitHubIssue): IssueSummary {
   return {
     number: issue.number,
@@ -101,6 +150,64 @@ export class TaskIssueManager {
     }
 
     return issues.filter((issue) => issue.pull_request === undefined).map(formatIssue);
+  }
+
+  public async replenishSelfImprovementIssues(options: ReplenishIssuesOptions): Promise<ReplenishIssuesResult> {
+    const minimumIssueCount = Math.max(0, Math.floor(options.minimumIssueCount));
+    const maximumOpenIssues = Math.max(0, Math.floor(options.maximumOpenIssues));
+
+    if (minimumIssueCount === 0 || maximumOpenIssues === 0) {
+      return { created: [] };
+    }
+
+    const openIssues = await this.listOpenIssues();
+    const remainingOpenSlots = maximumOpenIssues - openIssues.length;
+    if (remainingOpenSlots <= 0) {
+      return { created: [] };
+    }
+
+    const recentClosed = await this.client.get<GitHubIssue[]>(
+      `?state=closed&sort=updated&direction=desc&per_page=${TaskIssueManager.ISSUES_PER_PAGE}&page=1`,
+    );
+    const existingTitles = new Set(
+      [...openIssues.map((issue) => issue.title), ...recentClosed.map((issue) => issue.title)].map((title) =>
+        title.trim().toLowerCase(),
+      ),
+    );
+
+    const toCreateCount = Math.min(remainingOpenSlots, minimumIssueCount);
+    const templates: IssueTemplate[] = [];
+    let followUpSequence = 1;
+    for (const template of SELF_IMPROVEMENT_ISSUE_TEMPLATES) {
+      if (templates.length >= toCreateCount) {
+        break;
+      }
+
+      const normalizedTitle = template.title.trim().toLowerCase();
+      if (!existingTitles.has(normalizedTitle)) {
+        templates.push(template);
+        existingTitles.add(normalizedTitle);
+        continue;
+      }
+
+      const followUpTemplate = buildFollowUpTemplate(template, followUpSequence);
+      followUpSequence += 1;
+      const normalizedFollowUpTitle = followUpTemplate.title.trim().toLowerCase();
+      if (!existingTitles.has(normalizedFollowUpTitle)) {
+        templates.push(followUpTemplate);
+        existingTitles.add(normalizedFollowUpTitle);
+      }
+    }
+
+    const created: IssueSummary[] = [];
+    for (const template of templates) {
+      const result = await this.createIssue(template.title, template.description);
+      if (result.ok && result.issue) {
+        created.push(result.issue);
+      }
+    }
+
+    return { created };
   }
 
   public async markInProgress(issueNumber: number): Promise<IssueActionResult> {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -7,6 +7,7 @@ const getGitHubConfigMock = vi.fn();
 const listOpenIssuesMock = vi.fn();
 const markInProgressMock = vi.fn();
 const closeIssueMock = vi.fn();
+const replenishSelfImprovementIssuesMock = vi.fn();
 
 vi.mock("./environment.js", () => ({
   GITHUB_OWNER: "owner",
@@ -45,6 +46,7 @@ vi.mock("./issues/taskIssueManager.js", () => ({
     listOpenIssues = listOpenIssuesMock;
     markInProgress = markInProgressMock;
     closeIssue = closeIssueMock;
+    replenishSelfImprovementIssues = replenishSelfImprovementIssuesMock;
   },
 }));
 
@@ -70,6 +72,8 @@ describe("main", () => {
     markInProgressMock.mockResolvedValue({ ok: true, message: "ok" });
     closeIssueMock.mockReset();
     closeIssueMock.mockResolvedValue({ ok: true, message: "closed" });
+    replenishSelfImprovementIssuesMock.mockReset();
+    replenishSelfImprovementIssuesMock.mockResolvedValue({ created: [] });
     process.argv = ["node", "src/main.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -105,6 +109,7 @@ describe("main", () => {
     expect(runIssueCommandMock).toHaveBeenCalledWith([]);
     expect(markInProgressMock).toHaveBeenCalledWith(12);
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #12: Fix login redirect\n\nHandle callback URL.");
+    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
   });
 
   it("prefers an issue already in progress", async () => {
@@ -139,12 +144,32 @@ describe("main", () => {
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #8: Second\n\nsecond");
   });
 
-  it("logs and exits when there are no open issues", async () => {
+  it("replenishes issues and continues when queue is empty", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { number: 19, title: "Generated", description: "generated", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    replenishSelfImprovementIssuesMock.mockResolvedValueOnce({
+      created: [{ number: 19, title: "Generated", description: "generated", state: "open", labels: [] }],
+    });
+    const { DEFAULT_PROMPT, main } = await import("./main.js");
+
+    await main();
+
+    expect(DEFAULT_PROMPT).toBeDefined();
+    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #19: Generated\n\ngenerated");
+  });
+
+  it("logs and exits when no issues are open and replenishment creates nothing", async () => {
     const { DEFAULT_PROMPT, main } = await import("./main.js");
 
     await main();
 
     expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
   });
 
@@ -174,7 +199,7 @@ describe("main", () => {
 
     expect(runCodingAgentMock).not.toHaveBeenCalled();
     expect(markInProgressMock).not.toHaveBeenCalled();
-    expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
+    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
   });
 
   it("falls back cleanly when GitHub credentials are invalid", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import { TaskIssueManager, type IssueSummary } from "./issues/taskIssueManager.j
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
 const MAX_ISSUE_CYCLES = 25;
 const OUTDATED_LABELS = new Set(["outdated", "obsolete", "wontfix", "invalid", "duplicate"]);
+const MIN_REPLENISH_ISSUES = 3;
+const MAX_OPEN_ISSUES = 5;
 
 function hasLabel(issue: IssueSummary, label: string): boolean {
   return issue.labels.some((currentLabel) => currentLabel.toLowerCase() === label.toLowerCase());
@@ -39,6 +41,11 @@ function buildPromptFromIssue(issue: IssueSummary): string {
 
 function formatIssueForLog(issue: IssueSummary): string {
   return `#${issue.number} ${issue.title}`;
+}
+
+function logCreatedIssues(issues: IssueSummary[]): void {
+  const issueList = issues.map((issue) => formatIssueForLog(issue)).join(", ");
+  console.log(`Created ${issues.length} self-improvement issue(s): ${issueList}.`);
 }
 
 function logGitHubFallback(error: unknown): void {
@@ -92,10 +99,20 @@ export async function main(): Promise<void> {
       const selectedIssue = selectIssueForWork(actionableIssues);
 
       if (!selectedIssue) {
+        const replenishment = await issueManager.replenishSelfImprovementIssues({
+          minimumIssueCount: MIN_REPLENISH_ISSUES,
+          maximumOpenIssues: MAX_OPEN_ISSUES,
+        });
+
+        if (replenishment.created.length > 0) {
+          logCreatedIssues(replenishment.created);
+          continue;
+        }
+
         if (cycle === 1) {
           console.log(DEFAULT_PROMPT);
         } else {
-          console.log("No actionable open issues remaining. Issue loop stopped.");
+          console.log("No actionable open issues remaining and no new issues were created. Issue loop stopped.");
         }
         return;
       }


### PR DESCRIPTION
## Summary
Implements Issue #14 by adding autonomous issue replenishment when no actionable issues remain.

## Changes
- Add `replenishSelfImprovementIssues` in `TaskIssueManager`
- Replenish with at least 3 bounded self-improvement issues (up to max open issue cap)
- Avoid title duplication against open/recently-closed issues with explicit follow-up variants
- Update run loop to continue after replenishment instead of exiting
- Add tests for replenish behavior in manager and main loop

## Validation
- `pnpm test -- src/main.test.ts src/issues/taskIssueManager.test.ts`

Closes #14
