### PR TITLE
feat(runtime): add post-merge self-restart workflow

### DIFF
--- a/src/agents/codingAgent.test.ts
+++ b/src/agents/codingAgent.test.ts
@@ -18,6 +18,9 @@ describe("buildCodingPrompt", () => {
     expect(prompt).toContain("open a pull request linked to the issue");
     expect(prompt).toContain("continue the reject/fix/re-review cycle until the review outcome is accept");
     expect(prompt).toContain("merge the pull request into main");
+    expect(prompt).toContain("run `pnpm i`");
+    expect(prompt).toContain("run `pnpm build`");
+    expect(prompt).toContain("run `pnpm start`");
   });
 
   it("requires a continuous issue loop after each completion", () => {

--- a/src/agents/codingAgent.ts
+++ b/src/agents/codingAgent.ts
@@ -233,6 +233,10 @@ After an accept review:
 - merge the pull request into main
 - checkout main
 - pull latest main before starting the next cycle
+- run \`pnpm i\`
+- run \`pnpm build\`
+- run \`pnpm start\`
+- confirm the restart succeeded before continuing
 
 ## Required mindset
 

--- a/src/agents/runCodingAgent.test.ts
+++ b/src/agents/runCodingAgent.test.ts
@@ -65,7 +65,7 @@ describe("runCodingAgent", () => {
 
     await expect(
       runCodingAgent("Create src/utils/add.ts"),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ mergedPullRequest: false });
 
     expect(startThreadMock).toHaveBeenCalledTimes(1);
     expect(runStreamedMock).toHaveBeenCalledWith("PROMPT:Create src/utils/add.ts");
@@ -108,6 +108,34 @@ describe("runCodingAgent", () => {
 
     await expect(
       runCodingAgent("Summarize the repository"),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ mergedPullRequest: false });
+  });
+
+  it("flags successful pull request merges from command events", async () => {
+    startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
+    runStreamedMock.mockResolvedValue(createEventStream([
+      {
+        type: "item.completed",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "gh pr merge 15 --merge --delete-branch",
+          exit_code: 0,
+          aggregated_output: "Merged",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "2",
+          type: "agent_message",
+          text: "done",
+        },
+      },
+    ]));
+
+    const { runCodingAgent } = await import("./runCodingAgent.js");
+
+    await expect(runCodingAgent("Merge and continue")).resolves.toEqual({ mergedPullRequest: true });
   });
 });

--- a/src/agents/runCodingAgent.ts
+++ b/src/agents/runCodingAgent.ts
@@ -6,6 +6,11 @@ import {
 
 const codex = new Codex();
 let activeThread: Thread | null = null;
+const MERGE_PR_COMMAND_PATTERN = /\bgh\s+pr\s+merge\b/i;
+
+export type CodingAgentRunResult = {
+  mergedPullRequest: boolean;
+};
 
 function getThread(): Thread {
   if (!activeThread) {
@@ -64,7 +69,7 @@ function logStartedItem(item: ThreadItem): void {
   }
 }
 
-export async function runCodingAgent(prompt: string): Promise<void> {
+export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResult> {
   console.log("=== Run starting ===");
   console.log(`[user] ${prompt}\n`);
 
@@ -74,6 +79,7 @@ export async function runCodingAgent(prompt: string): Promise<void> {
   const startedItems = new Set<string>();
   const completedItems = new Set<string>();
   let fileChangeSeen = false;
+  let mergedPullRequest = false;
   let finalResponse = "";
 
   for await (const event of events) {
@@ -109,6 +115,14 @@ export async function runCodingAgent(prompt: string): Promise<void> {
         finalResponse = event.item.text;
       }
 
+      if (
+        event.item.type === "command_execution" &&
+        event.item.exit_code === 0 &&
+        MERGE_PR_COMMAND_PATTERN.test(event.item.command)
+      ) {
+        mergedPullRequest = true;
+      }
+
       logCompletedItem(event.item);
       continue;
     }
@@ -128,7 +142,7 @@ export async function runCodingAgent(prompt: string): Promise<void> {
 
   if (fileChangeSeen) {
     console.log("\n[file_change] One or more repository edits were executed.");
-    return;
+    return { mergedPullRequest };
   }
 
   console.log("\n[file_change] No repository edits were detected.");
@@ -136,4 +150,6 @@ export async function runCodingAgent(prompt: string): Promise<void> {
   if (isFileEditRequest(prompt)) {
     throw new Error("The Codex run did not make repository edits for a file-edit request.");
   }
+
+  return { mergedPullRequest };
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,6 +8,7 @@ const listOpenIssuesMock = vi.fn();
 const markInProgressMock = vi.fn();
 const closeIssueMock = vi.fn();
 const replenishSelfImprovementIssuesMock = vi.fn();
+const runPostMergeSelfRestartMock = vi.fn();
 
 vi.mock("./environment.js", () => ({
   GITHUB_OWNER: "owner",
@@ -20,6 +21,10 @@ vi.mock("./constants/workDir.js", () => ({
 
 vi.mock("./agents/runCodingAgent.js", () => ({
   runCodingAgent: runCodingAgentMock,
+}));
+
+vi.mock("./runtime/selfRestart.js", () => ({
+  runPostMergeSelfRestart: runPostMergeSelfRestartMock,
 }));
 
 vi.mock("./issues/runIssueCommand.js", () => ({
@@ -56,7 +61,9 @@ describe("main", () => {
   beforeEach(() => {
     vi.resetModules();
     runCodingAgentMock.mockReset();
-    runCodingAgentMock.mockResolvedValue(undefined);
+    runCodingAgentMock.mockResolvedValue({ mergedPullRequest: false });
+    runPostMergeSelfRestartMock.mockReset();
+    runPostMergeSelfRestartMock.mockResolvedValue(undefined);
     runIssueCommandMock.mockReset();
     runIssueCommandMock.mockResolvedValue(false);
     getGitHubConfigMock.mockReset();
@@ -142,6 +149,31 @@ describe("main", () => {
 
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #7: First\n\nfirst");
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #8: Second\n\nsecond");
+  });
+
+  it("runs post-merge restart workflow when a pull request merge is detected", async () => {
+    listOpenIssuesMock.mockResolvedValueOnce([
+      { number: 11, title: "Restart flow", description: "Restart", state: "open", labels: [] },
+    ]);
+    runCodingAgentMock.mockResolvedValueOnce({ mergedPullRequest: true });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runPostMergeSelfRestartMock).toHaveBeenCalledWith("/tmp/evolvo");
+  });
+
+  it("logs restart failures clearly and exits current runtime", async () => {
+    listOpenIssuesMock.mockResolvedValueOnce([
+      { number: 21, title: "Restart fail path", description: "Restart", state: "open", labels: [] },
+    ]);
+    runCodingAgentMock.mockResolvedValueOnce({ mergedPullRequest: true });
+    runPostMergeSelfRestartMock.mockRejectedValueOnce(new Error("restart failed"));
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(console.error).toHaveBeenCalledWith("restart failed");
   });
 
   it("replenishes issues and continues when queue is empty", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import "dotenv/config";
 import { pathToFileURL } from "node:url";
 import { WORK_DIR } from "./constants/workDir.js";
 import { runCodingAgent } from "./agents/runCodingAgent.js";
+import { runPostMergeSelfRestart } from "./runtime/selfRestart.js";
 import { runIssueCommand } from "./issues/runIssueCommand.js";
 import { getGitHubConfig } from "./github/githubConfig.js";
 import { GitHubApiError, GitHubClient } from "./github/githubClient.js";
@@ -127,9 +128,26 @@ export async function main(): Promise<void> {
       const prompt = buildPromptFromIssue(selectedIssue);
       console.log(`Prompt: ${prompt}`);
 
-      await runCodingAgent(prompt).catch((error) => {
+      const runResult = await runCodingAgent(prompt).catch((error) => {
         console.error("Error running the coding agent:", error);
+        return null;
       });
+
+      if (runResult?.mergedPullRequest) {
+        console.log("Merged pull request detected. Running post-merge restart workflow.");
+        try {
+          await runPostMergeSelfRestart(WORK_DIR);
+          console.log("Post-merge restart workflow completed. Exiting current runtime.");
+        } catch (error) {
+          if (error instanceof Error) {
+            console.error(error.message);
+          } else {
+            console.error("Post-merge restart failed with an unknown error.");
+          }
+        }
+
+        return;
+      }
     } catch (error) {
       logGitHubFallback(error);
       if (cycle === 1) {

--- a/src/runtime/selfRestart.test.ts
+++ b/src/runtime/selfRestart.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.fn();
+const spawnMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+  spawn: spawnMock,
+}));
+
+function createChildProcessStub(overrides: {
+  pid?: number;
+  once?: (event: string, handler: (...args: unknown[]) => void) => void;
+  removeListener?: (event: string, handler: (...args: unknown[]) => void) => void;
+  unref?: () => void;
+} = {}) {
+  return {
+    pid: overrides.pid ?? 999,
+    once: overrides.once ?? vi.fn(),
+    removeListener: overrides.removeListener ?? vi.fn(),
+    unref: overrides.unref ?? vi.fn(),
+  };
+}
+
+describe("runPostMergeSelfRestart", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    execFileMock.mockReset();
+    spawnMock.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("runs checkout, pull, install, build and starts runtime", async () => {
+    execFileMock.mockImplementation((_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+      callback(null, "", "");
+    });
+    const onceHandlers: Record<string, (...args: unknown[]) => void> = {};
+    const child = createChildProcessStub({
+      once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        onceHandlers[event] = handler;
+      }),
+    });
+    spawnMock.mockReturnValue(child);
+
+    const { runPostMergeSelfRestart } = await import("./selfRestart.js");
+    const restartPromise = runPostMergeSelfRestart("/tmp/evolvo");
+    await vi.advanceTimersByTimeAsync(3000);
+    await expect(restartPromise).resolves.toBeUndefined();
+
+    expect(execFileMock).toHaveBeenNthCalledWith(1, "git", ["checkout", "main"], { cwd: "/tmp/evolvo" }, expect.any(Function));
+    expect(execFileMock).toHaveBeenNthCalledWith(2, "git", ["pull", "--ff-only"], { cwd: "/tmp/evolvo" }, expect.any(Function));
+    expect(execFileMock).toHaveBeenNthCalledWith(3, "pnpm", ["i"], { cwd: "/tmp/evolvo" }, expect.any(Function));
+    expect(execFileMock).toHaveBeenNthCalledWith(4, "pnpm", ["build"], { cwd: "/tmp/evolvo" }, expect.any(Function));
+    expect(spawnMock).toHaveBeenCalledWith("pnpm", ["start"], {
+      cwd: "/tmp/evolvo",
+      detached: true,
+      stdio: "ignore",
+    });
+    expect(child.unref).toHaveBeenCalledTimes(1);
+    expect(onceHandlers.error).toBeTypeOf("function");
+    expect(onceHandlers.exit).toBeTypeOf("function");
+  });
+
+  it("fails with diagnostics when a restart step command fails", async () => {
+    execFileMock.mockImplementationOnce((_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+      const error = Object.assign(new Error("failed"), { stderr: "checkout failed" });
+      callback(error, "", "checkout failed");
+    });
+
+    const { runPostMergeSelfRestart } = await import("./selfRestart.js");
+
+    await expect(runPostMergeSelfRestart("/tmp/evolvo")).rejects.toThrow(
+      "Post-merge restart step failed: git checkout main. Output: checkout failed",
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("fails when pnpm start exits before startup timeout", async () => {
+    execFileMock.mockImplementation((_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+      callback(null, "", "");
+    });
+
+    const child = createChildProcessStub({
+      once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "exit") {
+          handler(1, null);
+        }
+      }),
+    });
+    spawnMock.mockReturnValue(child);
+
+    const { runPostMergeSelfRestart } = await import("./selfRestart.js");
+    await expect(runPostMergeSelfRestart("/tmp/evolvo")).rejects.toThrow(
+      "Post-merge restart failed: pnpm start exited early with code 1.",
+    );
+  });
+});

--- a/src/runtime/selfRestart.ts
+++ b/src/runtime/selfRestart.ts
@@ -1,0 +1,78 @@
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const STARTUP_TIMEOUT_MS = 3000;
+
+type ExecFailure = Error & { stdout?: string | Buffer; stderr?: string | Buffer };
+
+function formatOutput(value: string | Buffer | undefined): string {
+  if (value === undefined) {
+    return "";
+  }
+
+  return String(value).trim();
+}
+
+async function runStep(command: string, args: string[], workingDirectory: string): Promise<void> {
+  console.log(`[restart] Running: ${command} ${args.join(" ")}`);
+
+  try {
+    await execFileAsync(command, args, { cwd: workingDirectory });
+  } catch (error) {
+    const execError = error as ExecFailure;
+    const stderr = formatOutput(execError.stderr);
+    const stdout = formatOutput(execError.stdout);
+    const output = stderr || stdout;
+    const detail = output ? ` Output: ${output}` : "";
+    throw new Error(`Post-merge restart step failed: ${command} ${args.join(" ")}.${detail}`);
+  }
+}
+
+async function startUpdatedRuntime(workingDirectory: string): Promise<void> {
+  console.log("[restart] Running: pnpm start");
+
+  const child = spawn("pnpm", ["start"], {
+    cwd: workingDirectory,
+    detached: true,
+    stdio: "ignore",
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, STARTUP_TIMEOUT_MS);
+
+    function cleanup(): void {
+      clearTimeout(timeout);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+    }
+
+    function onError(error: Error): void {
+      cleanup();
+      reject(new Error(`Post-merge restart failed to launch runtime: ${error.message}`));
+    }
+
+    function onExit(code: number | null, signal: NodeJS.Signals | null): void {
+      cleanup();
+      const reason = code !== null ? `code ${code}` : `signal ${signal ?? "unknown"}`;
+      reject(new Error(`Post-merge restart failed: pnpm start exited early with ${reason}.`));
+    }
+
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+
+  child.unref();
+  console.log(`[restart] Started updated runtime process (pid ${child.pid ?? "unknown"}).`);
+}
+
+export async function runPostMergeSelfRestart(workingDirectory: string): Promise<void> {
+  await runStep("git", ["checkout", "main"], workingDirectory);
+  await runStep("git", ["pull", "--ff-only"], workingDirectory);
+  await runStep("pnpm", ["i"], workingDirectory);
+  await runStep("pnpm", ["build"], workingDirectory);
+  await startUpdatedRuntime(workingDirectory);
+}


### PR DESCRIPTION
## Summary
Implements Issue #13 by adding a post-merge self-restart workflow so Evolvo can continue from updated `main` after a successful PR merge.

## Changes
- Detect successful `gh pr merge` commands in `runCodingAgent`
- Add `runPostMergeSelfRestart` runtime flow:
  - `git checkout main`
  - `git pull --ff-only`
  - `pnpm i`
  - `pnpm build`
  - start updated runtime with `pnpm start`
- Wire restart execution into `main` when merge is detected
- Add clear failure diagnostics for restart-step failures and early runtime exit
- Update agent instructions to include restart steps in standard post-merge lifecycle
- Add tests for merge detection, restart flow, and main integration

## Validation
- `pnpm test -- src/main.test.ts src/agents/runCodingAgent.test.ts src/runtime/selfRestart.test.ts src/agents/codingAgent.test.ts`

Closes #13
