### PR TITLE
test(startup): add regression coverage for bootstrap issue analyzer

### DIFF
--- a/src/issues/startupIssueBootstrap.test.ts
+++ b/src/issues/startupIssueBootstrap.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { generateStartupIssueTemplates } from "./startupIssueBootstrap.js";
@@ -13,6 +13,7 @@ async function createTempRepo(): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(tempDirs.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
 });
 
@@ -71,5 +72,85 @@ describe("generateStartupIssueTemplates", () => {
 
     expect(templates).toHaveLength(3);
     expect(templates[0]?.title).toBe("Harden startup diagnostics when bootstrap issue creation fails");
+  });
+
+  it("returns deterministic bounded templates when repository files are mostly missing", async () => {
+    const repoRoot = await createTempRepo();
+
+    const first = await generateStartupIssueTemplates(repoRoot, { targetCount: 5 });
+    const second = await generateStartupIssueTemplates(repoRoot, { targetCount: 5 });
+
+    expect(first).toHaveLength(5);
+    expect(second).toEqual(first);
+    expect(first.map((template) => template.title)).toEqual([
+      "Add a dedicated typecheck script to validation workflow",
+      "Add CI workflow for build and test validation",
+      "Harden startup diagnostics when bootstrap issue creation fails",
+      "Add startup bootstrap integration test for empty-repo issue queue",
+      "Emit per-cycle summary logs for issue queue health",
+    ]);
+  });
+
+  it("handles unreadable README files without failing", async () => {
+    const repoRoot = await createTempRepo();
+    await mkdir(join(repoRoot, ".github", "workflows"), { recursive: true });
+    await mkdir(join(repoRoot, "src"), { recursive: true });
+    await writeFile(
+      join(repoRoot, "package.json"),
+      JSON.stringify(
+        {
+          name: "repo",
+          scripts: {
+            typecheck: "tsc --noEmit",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(join(repoRoot, "src", "index.ts"), "export const value = 1;\n");
+    await writeFile(join(repoRoot, "src", "index.test.ts"), "import { expect, it } from \"vitest\";\nit(\"ok\", () => { expect(true).toBe(true); });\n");
+    const readmePath = join(repoRoot, "README.md");
+    await writeFile(readmePath, "short");
+    await chmod(readmePath, 0o000);
+
+    const templates = await generateStartupIssueTemplates(repoRoot, { targetCount: 3 });
+
+    expect(templates).toHaveLength(3);
+    expect(templates[0]?.title).toBe("Harden startup diagnostics when bootstrap issue creation fails");
+  });
+
+  it("deduplicates duplicate fallback template titles", async () => {
+    const repoRoot = await createTempRepo();
+    await mkdir(join(repoRoot, ".github", "workflows"), { recursive: true });
+    await mkdir(join(repoRoot, "src"), { recursive: true });
+    await writeFile(
+      join(repoRoot, "package.json"),
+      JSON.stringify(
+        {
+          name: "repo",
+          scripts: {
+            typecheck: "tsc --noEmit",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(join(repoRoot, "README.md"), "This readme is intentionally long enough to skip docs bootstrap.".repeat(3));
+    await writeFile(join(repoRoot, "src", "index.ts"), "export const value = 1;\n");
+    await writeFile(join(repoRoot, "src", "index.test.ts"), "import { expect, it } from \"vitest\";\nit(\"ok\", () => { expect(true).toBe(true); });\n");
+
+    const templates = await generateStartupIssueTemplates(repoRoot, {
+      targetCount: 3,
+      fallbackTemplates: [
+        { title: "Alpha", description: "A" },
+        { title: " alpha ", description: "A duplicate with spacing and casing" },
+        { title: "Beta", description: "B" },
+        { title: "Gamma", description: "C" },
+      ],
+    });
+
+    expect(templates.map((template) => template.title)).toEqual(["Alpha", "Beta", "Gamma"]);
   });
 });

--- a/src/issues/startupIssueBootstrap.ts
+++ b/src/issues/startupIssueBootstrap.ts
@@ -89,7 +89,7 @@ function uniqueByTitle(templates: IssueTemplate[]): IssueTemplate[] {
 
 export async function generateStartupIssueTemplates(
   repoRoot: string,
-  options: { targetCount: number } = { targetCount: 3 },
+  options: { targetCount: number; fallbackTemplates?: IssueTemplate[] } = { targetCount: 3 },
 ): Promise<IssueTemplate[]> {
   const targetCount = Math.max(0, Math.floor(options.targetCount));
   if (targetCount === 0) {
@@ -155,6 +155,10 @@ export async function generateStartupIssueTemplates(
     }
   }
 
-  const combined = uniqueByTitle([...templates, ...FALLBACK_TEMPLATES]);
+  const fallbackTemplates =
+    options.fallbackTemplates && options.fallbackTemplates.length > 0
+      ? options.fallbackTemplates
+      : FALLBACK_TEMPLATES;
+  const combined = uniqueByTitle([...templates, ...fallbackTemplates]);
   return combined.slice(0, targetCount);
 }


### PR DESCRIPTION
## Summary
- add regression tests for startup issue template generation edge cases
- verify deterministic and bounded output when repository files are missing
- verify unreadable README handling does not break template generation
- verify duplicate fallback template titles are deduplicated consistently
- add optional `fallbackTemplates` input to make duplicate handling testable

## Validation
- pnpm test -- src/issues/startupIssueBootstrap.test.ts

Closes #21
