### PR TITLE
feat(validation): integrate typecheck into validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Test
         run: pnpm test

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "dev": "tsx src/main.ts",
     "start": "node dist/main.js",
     "lint": "eslint . --ext .ts",

--- a/src/agents/codingAgent.test.ts
+++ b/src/agents/codingAgent.test.ts
@@ -20,6 +20,7 @@ describe("buildCodingPrompt", () => {
     expect(prompt).toContain("merge the pull request into main");
     expect(prompt).toContain("run `pnpm i`");
     expect(prompt).toContain("run `pnpm build`");
+    expect(prompt).toContain("run `pnpm typecheck`");
     expect(prompt).toContain("run `pnpm start`");
   });
 

--- a/src/agents/codingAgent.ts
+++ b/src/agents/codingAgent.ts
@@ -235,6 +235,7 @@ After an accept review:
 - pull latest main before starting the next cycle
 - run \`pnpm i\`
 - run \`pnpm build\`
+- run \`pnpm typecheck\`
 - run \`pnpm start\`
 - confirm the restart succeeded before continuing
 


### PR DESCRIPTION
## Summary
- add a dedicated typecheck script to package scripts
- include typecheck in CI validation before tests
- update coding-agent validation orchestration to run typecheck
- adjust prompt test coverage for the new validation command

## Validation
- pnpm typecheck
- pnpm build
- pnpm test

Closes #19