### PR TITLE
fix(startup): add fallback when bootstrap analysis throws

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -242,6 +242,26 @@ describe("main", () => {
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
   });
 
+  it("falls back to default startup issue replenishment when repository analysis throws", async () => {
+    generateStartupIssueTemplatesMock.mockRejectedValueOnce(new Error("analysis boom"));
+    listOpenIssuesMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { number: 30, title: "Fallback issue", description: "fallback", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    replenishSelfImprovementIssuesMock.mockResolvedValueOnce({
+      created: [{ number: 30, title: "Fallback issue", description: "fallback", state: "open", labels: [] }],
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
+    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #30: Fallback issue\n\nfallback");
+  });
+
   it("closes outdated issues before selecting work", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,14 +51,29 @@ function logCreatedIssues(issues: IssueSummary[]): void {
 }
 
 async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<IssueSummary[]> {
-  const templates = await generateStartupIssueTemplates(WORK_DIR, { targetCount: MIN_REPLENISH_ISSUES });
-  const replenishment = await issueManager.replenishSelfImprovementIssues({
-    minimumIssueCount: MIN_REPLENISH_ISSUES,
-    maximumOpenIssues: MAX_OPEN_ISSUES,
-    templates,
-  });
+  try {
+    const templates = await generateStartupIssueTemplates(WORK_DIR, { targetCount: MIN_REPLENISH_ISSUES });
+    const replenishment = await issueManager.replenishSelfImprovementIssues({
+      minimumIssueCount: MIN_REPLENISH_ISSUES,
+      maximumOpenIssues: MAX_OPEN_ISSUES,
+      templates,
+    });
 
-  return replenishment.created;
+    return replenishment.created;
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Startup repository analysis failed: ${error.message}`);
+    } else {
+      console.error("Startup repository analysis failed with an unknown error.");
+    }
+
+    const replenishment = await issueManager.replenishSelfImprovementIssues({
+      minimumIssueCount: MIN_REPLENISH_ISSUES,
+      maximumOpenIssues: MAX_OPEN_ISSUES,
+    });
+
+    return replenishment.created;
+  }
 }
 
 function logGitHubFallback(error: unknown): void {


### PR DESCRIPTION
## Summary
- catch unexpected startup repository-analysis failures in bootstrap path
- fall back to default issue replenishment when analysis fails
- add regression test for exception-driven startup fallback

## Validation
- pnpm test

Closes #27