### PR TITLE
chore(validation): add unified validate script to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Test
-        run: pnpm test
+      - name: Validate
+        run: pnpm validate

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "validate": "pnpm typecheck && pnpm build && pnpm test",
     "dev": "tsx src/main.ts",
     "start": "node dist/main.js",
     "lint": "eslint . --ext .ts",


### PR DESCRIPTION
## Summary
- add a root `validate` script that runs typecheck, build, then tests in a stable order
- update CI to run `pnpm validate` instead of separate validation steps
- keep existing `build`, `typecheck`, and `test` scripts intact

## Validation
- `pnpm validate`

Closes #25
