### PR TITLE
feat(validation): log command exit status and duration

### DIFF
--- a/src/agents/runCodingAgent.test.ts
+++ b/src/agents/runCodingAgent.test.ts
@@ -139,6 +139,53 @@ describe("runCodingAgent", () => {
     await expect(runCodingAgent("Merge and continue")).resolves.toEqual({ mergedPullRequest: true });
   });
 
+  it("logs command, exit code, and duration for command executions", async () => {
+    startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
+    runStreamedMock.mockResolvedValue(createEventStream([
+      {
+        type: "item.started",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "pnpm validate",
+          aggregated_output: "",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "pnpm validate",
+          exit_code: 1,
+          aggregated_output: "failed",
+          status: "failed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "2",
+          type: "agent_message",
+          text: "Validation failed, fix pending.",
+        },
+      },
+    ]));
+
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(1000)
+      .mockReturnValue(1450);
+
+    const { runCodingAgent } = await import("./runCodingAgent.js");
+
+    await expect(runCodingAgent("Run validation")).resolves.toEqual({ mergedPullRequest: false });
+
+    expect(console.log).toHaveBeenCalledWith(
+      "[command completed] command=\"pnpm validate\" name=pnpm exit=1 duration=450ms",
+    );
+  });
+
   it("flags successful pull request merges from agent messages", async () => {
     startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
     runStreamedMock.mockResolvedValue(createEventStream([

--- a/src/agents/runCodingAgent.ts
+++ b/src/agents/runCodingAgent.ts
@@ -13,6 +13,10 @@ export type CodingAgentRunResult = {
   mergedPullRequest: boolean;
 };
 
+type CommandExecutionLogDetails = {
+  startedAtMs?: number;
+};
+
 function getThread(): Thread {
   if (!activeThread) {
     activeThread = codex.startThread(CODING_AGENT_THREAD_OPTIONS);
@@ -30,7 +34,20 @@ function formatFileChanges(item: Extract<ThreadItem, { type: "file_change" }>): 
   return item.changes.map((change) => `${change.kind} ${change.path}`).join(", ");
 }
 
-function logCompletedItem(item: ThreadItem): void {
+function getCommandName(command: string): string {
+  const [commandName] = command.trim().split(/\s+/, 1);
+  return commandName || "unknown";
+}
+
+function formatDuration(durationMs: number | undefined): string {
+  if (durationMs === undefined || !Number.isFinite(durationMs) || durationMs < 0) {
+    return "unknown";
+  }
+
+  return `${Math.round(durationMs)}ms`;
+}
+
+function logCompletedItem(item: ThreadItem, details?: CommandExecutionLogDetails): void {
   if (item.type === "file_change") {
     console.log(`[file_change] ${formatFileChanges(item)}\n`);
     return;
@@ -38,7 +55,15 @@ function logCompletedItem(item: ThreadItem): void {
 
   if (item.type === "command_execution") {
     const output = item.aggregated_output.trim();
-    console.log(`[command completed] ${item.command} (exit ${item.exit_code ?? "unknown"})`);
+    const commandName = getCommandName(item.command);
+    const exitCode = item.exit_code ?? "unknown";
+    const duration = details?.startedAtMs !== undefined
+      ? formatDuration(Date.now() - details.startedAtMs)
+      : "unknown";
+
+    console.log(
+      `[command completed] command="${item.command}" name=${commandName} exit=${exitCode} duration=${duration}`,
+    );
 
     if (output) {
       console.log(`${output}\n`);
@@ -79,6 +104,7 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
 
   const startedItems = new Set<string>();
   const completedItems = new Set<string>();
+  const commandStartTimes = new Map<string, number>();
   let fileChangeSeen = false;
   let mergedPullRequest = false;
   let finalResponse = "";
@@ -90,6 +116,9 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
       }
 
       startedItems.add(event.item.id);
+      if (event.item.type === "command_execution") {
+        commandStartTimes.set(event.item.id, Date.now());
+      }
       logStartedItem(event.item);
       continue;
     }
@@ -130,7 +159,14 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
         mergedPullRequest = true;
       }
 
-      logCompletedItem(event.item);
+      const details = event.item.type === "command_execution"
+        ? { startedAtMs: commandStartTimes.get(event.item.id) }
+        : undefined;
+      if (event.item.type === "command_execution") {
+        commandStartTimes.delete(event.item.id);
+      }
+
+      logCompletedItem(event.item, details);
       continue;
     }
 


### PR DESCRIPTION
## Summary
- track command start times during agent runs
- enrich command completion logs with command, command name, exit status, and elapsed duration
- add regression test for failed validation command logging

Closes #36