### PR TITLE
feat: add explicit external repository workflow support

### DIFF
--- a/src/agents/codingAgent.test.ts
+++ b/src/agents/codingAgent.test.ts
@@ -30,6 +30,15 @@ describe("buildCodingPrompt", () => {
     expect(prompt).toContain("maximum of 5 open issues");
   });
 
+  it("includes explicit external repository mode rules", () => {
+    const prompt = buildCodingPrompt("Issue #40: Work on an external repository");
+
+    expect(prompt).toContain("When a task explicitly requires external repository work");
+    expect(prompt).toContain("keep strict separation between Evolvo's repository and the target repository");
+    expect(prompt).toContain("record the external repository URL and external PR URL");
+    expect(prompt).toContain("explicitly confirm whether the external PR was merged");
+  });
+
   it("keeps Codex configured for workspace-write execution", () => {
     expect(CODING_AGENT_THREAD_OPTIONS.sandboxMode).toBe("workspace-write");
     expect(CODING_AGENT_THREAD_OPTIONS.approvalPolicy).toBe("never");

--- a/src/agents/codingAgent.ts
+++ b/src/agents/codingAgent.ts
@@ -73,7 +73,9 @@ Seek the best next change.
 
 ## Scope
 
-You work only on your own codebase and task files.
+You default to working on your own codebase and task files.
+
+When a task explicitly requires external repository work, you may operate on one target repository for that issue.
 
 Your valid self-improvement surface includes your:
 - runtime
@@ -90,6 +92,17 @@ You are allowed to edit your core implementation files when doing so improves yo
 
 You must not act as though your core files are off-limits.
 Those files are the main surface through which you improve yourself.
+
+## External Repository Mode
+
+External repository work is allowed only when explicitly requested by the active issue.
+
+When in external repository mode:
+- keep strict separation between Evolvo's repository and the target repository
+- always confirm which repository and branch you are currently operating in before edit/commit/push actions
+- perform the full target-repo lifecycle: clone/access, inspect, branch, bounded change, validate, commit, push, PR, merge
+- record the external repository URL and external PR URL in Evolvo's own task PR evidence
+- do not mix unrelated changes across repositories
 
 ## What good work looks like
 
@@ -234,6 +247,11 @@ After an accept review:
 - stop after the merge succeeds
 - do not run checkout, pull, install, build, or restart commands after the merge
 - the outer host runtime is responsible for post-merge restart orchestration
+
+For external-repository tasks:
+- complete the same branch/PR/review/merge cycle on the target repository
+- include both links in Evolvo's own task PR: target repository URL and target PR URL
+- explicitly confirm whether the external PR was merged
 
 ## Required mindset
 

--- a/src/agents/runCodingAgent.test.ts
+++ b/src/agents/runCodingAgent.test.ts
@@ -36,6 +36,7 @@ describe("runCodingAgent", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -243,5 +244,97 @@ describe("runCodingAgent", () => {
         }),
       }),
     );
+  });
+
+  it("captures external repository and pull request evidence from command output", async () => {
+    vi.stubEnv("GITHUB_OWNER", "owner");
+    vi.stubEnv("GITHUB_REPO", "repo");
+    startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
+    runStreamedMock.mockResolvedValue(createEventStream([
+      {
+        type: "item.completed",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "gh pr create --repo other-org/other-repo --title \"test\" --body \"test\"",
+          exit_code: 0,
+          aggregated_output: "https://github.com/other-org/other-repo/pull/12",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "2",
+          type: "command_execution",
+          command: "gh pr merge https://github.com/other-org/other-repo/pull/12 --merge",
+          exit_code: 0,
+          aggregated_output: "Merged pull request https://github.com/other-org/other-repo/pull/12",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "3",
+          type: "file_change",
+          status: "completed",
+          changes: [{ kind: "add", path: "notes.md" }],
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "4",
+          type: "agent_message",
+          text: "done",
+        },
+      },
+    ]));
+
+    const { runCodingAgent } = await import("./runCodingAgent.js");
+
+    await expect(runCodingAgent("Complete external repo workflow")).resolves.toEqual(
+      expect.objectContaining({
+        mergedPullRequest: true,
+        summary: expect.objectContaining({
+          externalRepositories: ["https://github.com/other-org/other-repo"],
+          externalPullRequests: ["https://github.com/other-org/other-repo/pull/12"],
+          mergedExternalPullRequest: true,
+        }),
+      }),
+    );
+  });
+
+  it("does not capture pull requests from the configured repository as external evidence", async () => {
+    vi.stubEnv("GITHUB_OWNER", "owner");
+    vi.stubEnv("GITHUB_REPO", "repo");
+    startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
+    runStreamedMock.mockResolvedValue(createEventStream([
+      {
+        type: "item.completed",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "gh pr create --title \"self\" --body \"self\"",
+          exit_code: 0,
+          aggregated_output: "https://github.com/owner/repo/pull/88",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "2",
+          type: "file_change",
+          status: "completed",
+          changes: [{ kind: "add", path: "notes.md" }],
+        },
+      },
+    ]));
+
+    const { runCodingAgent } = await import("./runCodingAgent.js");
+    const result = await runCodingAgent("Create self repository pull request");
+
+    expect(result.summary.externalRepositories).toEqual([]);
+    expect(result.summary.externalPullRequests).toEqual([]);
+    expect(result.summary.mergedExternalPullRequest).toBe(false);
   });
 });

--- a/src/agents/runCodingAgent.ts
+++ b/src/agents/runCodingAgent.ts
@@ -9,6 +9,8 @@ let activeThread: Thread | null = null;
 const MERGE_PR_COMMAND_PATTERN = /\bgh\s+pr\s+merge\b/i;
 const MERGE_PR_MESSAGE_PATTERN = /\bmerged (the )?pull request\b|\bmerged .* into main\b/i;
 const CREATE_PR_COMMAND_PATTERN = /\bgh\s+pr\s+create\b/i;
+const GITHUB_REPOSITORY_URL_PATTERN = /https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:\.git)?(?:\/)?/gi;
+const GITHUB_PULL_REQUEST_URL_PATTERN = /https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/\d+/gi;
 const INSPECTION_COMMAND_PATTERN = /\b(rg|grep|cat|sed|ls|find|fd|tree|git\s+status|git\s+diff|git\s+show)\b/i;
 const VALIDATION_COMMAND_PATTERN = /\b(validate|test|vitest|jest|typecheck|lint|build|tsc|pytest|go test|cargo test)\b/i;
 
@@ -34,6 +36,9 @@ export type CodingAgentRunSummary = {
   failedValidationCommands: CommandExecutionSummary[];
   reviewOutcome: "accepted" | "amended";
   pullRequestCreated: boolean;
+  externalRepositories: string[];
+  externalPullRequests: string[];
+  mergedExternalPullRequest: boolean;
   finalResponse: string;
 };
 
@@ -106,6 +111,51 @@ function summarizeReviewOutcome(validationCommands: CommandExecutionSummary[]): 
   return validationCommands.some((command) => command.exitCode !== 0) ? "amended" : "accepted";
 }
 
+function normalizeRepositoryUrl(url: string): string {
+  const cleanUrl = url.trim().replace(/\/+$/, "");
+  return cleanUrl.endsWith(".git") ? cleanUrl.slice(0, -4) : cleanUrl;
+}
+
+function extractGitHubRepositoryUrls(text: string): string[] {
+  const urls = new Set<string>();
+  const matches = text.matchAll(GITHUB_REPOSITORY_URL_PATTERN);
+
+  for (const match of matches) {
+    urls.add(normalizeRepositoryUrl(match[0]));
+  }
+
+  return [...urls];
+}
+
+function extractGitHubPullRequestUrls(text: string): string[] {
+  const urls = new Set<string>();
+  const matches = text.matchAll(GITHUB_PULL_REQUEST_URL_PATTERN);
+
+  for (const match of matches) {
+    urls.add(match[0].replace(/\/+$/, ""));
+  }
+
+  return [...urls];
+}
+
+function getConfiguredRepositoryUrl(): string | null {
+  const owner = process.env.GITHUB_OWNER?.trim();
+  const repo = process.env.GITHUB_REPO?.trim();
+  if (!owner || !repo) {
+    return null;
+  }
+
+  return `https://github.com/${owner}/${repo}`;
+}
+
+function isExternalRepositoryUrl(url: string, configuredRepositoryUrl: string | null): boolean {
+  if (!configuredRepositoryUrl) {
+    return true;
+  }
+
+  return normalizeRepositoryUrl(url).toLowerCase() !== normalizeRepositoryUrl(configuredRepositoryUrl).toLowerCase();
+}
+
 function logCompletedItem(item: ThreadItem, details?: CommandExecutionLogDetails): void {
   if (item.type === "file_change") {
     console.log(`[file_change] ${formatFileChanges(item)}\n`);
@@ -166,12 +216,35 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
   const commandStartTimes = new Map<string, number>();
   const inspectedAreas = new Set<string>();
   const editedFiles = new Set<string>();
+  const externalRepositories = new Set<string>();
+  const externalPullRequests = new Set<string>();
   const validationCommands: CommandExecutionSummary[] = [];
   const failedValidationCommands: CommandExecutionSummary[] = [];
   let fileChangeSeen = false;
   let mergedPullRequest = false;
+  let mergedExternalPullRequest = false;
   let pullRequestCreated = false;
   let finalResponse = "";
+  const configuredRepositoryUrl = getConfiguredRepositoryUrl();
+
+  function captureExternalReferences(text: string): void {
+    for (const repositoryUrl of extractGitHubRepositoryUrls(text)) {
+      if (isExternalRepositoryUrl(repositoryUrl, configuredRepositoryUrl)) {
+        externalRepositories.add(repositoryUrl);
+      }
+    }
+
+    for (const pullRequestUrl of extractGitHubPullRequestUrls(text)) {
+      const pullRequestRepositoryUrl = pullRequestUrl.replace(/\/pull\/\d+$/, "");
+      if (isExternalRepositoryUrl(pullRequestRepositoryUrl, configuredRepositoryUrl)) {
+        externalPullRequests.add(pullRequestUrl);
+        externalRepositories.add(pullRequestRepositoryUrl);
+        if (MERGE_PR_MESSAGE_PATTERN.test(text)) {
+          mergedExternalPullRequest = true;
+        }
+      }
+    }
+  }
 
   for await (const event of events) {
     if (event.type === "item.started") {
@@ -190,6 +263,7 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
     if (event.type === "item.updated") {
       if (event.item.type === "agent_message") {
         finalResponse = event.item.text;
+        captureExternalReferences(event.item.text);
         if (MERGE_PR_MESSAGE_PATTERN.test(event.item.text)) {
           mergedPullRequest = true;
         }
@@ -210,6 +284,7 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
 
       if (event.item.type === "agent_message") {
         finalResponse = event.item.text;
+        captureExternalReferences(event.item.text);
         if (MERGE_PR_MESSAGE_PATTERN.test(event.item.text)) {
           mergedPullRequest = true;
         }
@@ -221,10 +296,17 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
         MERGE_PR_COMMAND_PATTERN.test(event.item.command)
       ) {
         mergedPullRequest = true;
+        if (externalPullRequests.size > 0) {
+          mergedExternalPullRequest = true;
+        }
       }
 
       if (event.item.type === "command_execution" && CREATE_PR_COMMAND_PATTERN.test(event.item.command)) {
         pullRequestCreated = true;
+      }
+      if (event.item.type === "command_execution") {
+        captureExternalReferences(event.item.command);
+        captureExternalReferences(event.item.aggregated_output);
       }
 
       if (event.item.type === "command_execution" && INSPECTION_COMMAND_PATTERN.test(event.item.command)) {
@@ -286,6 +368,9 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
         failedValidationCommands,
         reviewOutcome: summarizeReviewOutcome(validationCommands),
         pullRequestCreated,
+        externalRepositories: [...externalRepositories],
+        externalPullRequests: [...externalPullRequests],
+        mergedExternalPullRequest,
         finalResponse,
       },
     };
@@ -306,6 +391,9 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
       failedValidationCommands,
       reviewOutcome: summarizeReviewOutcome(validationCommands),
       pullRequestCreated,
+      externalRepositories: [...externalRepositories],
+      externalPullRequests: [...externalPullRequests],
+      mergedExternalPullRequest,
       finalResponse,
     },
   };

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -21,6 +21,9 @@ const DEFAULT_RUN_RESULT = {
     failedValidationCommands: [],
     reviewOutcome: "accepted" as const,
     pullRequestCreated: false,
+    externalRepositories: [],
+    externalPullRequests: [],
+    mergedExternalPullRequest: false,
     finalResponse: "done",
   },
 };
@@ -346,6 +349,39 @@ describe("main", () => {
     await main();
 
     expect(addProgressCommentMock).toHaveBeenCalledWith(55, expect.stringContaining("## Task Execution Problem"));
+  });
+
+  it("logs external repository evidence in the task execution comment", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 57, title: "External work", description: "external", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    runCodingAgentMock.mockResolvedValueOnce({
+      ...DEFAULT_RUN_RESULT,
+      summary: {
+        ...DEFAULT_RUN_RESULT.summary,
+        externalRepositories: ["https://github.com/other-org/other-repo"],
+        externalPullRequests: ["https://github.com/other-org/other-repo/pull/12"],
+        mergedExternalPullRequest: true,
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      57,
+      expect.stringContaining("### External Repository Evidence"),
+    );
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      57,
+      expect.stringContaining("https://github.com/other-org/other-repo/pull/12"),
+    );
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      57,
+      expect.stringContaining("External pull request merged: yes"),
+    );
   });
 
   it("continues execution when lifecycle comment posting fails", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,13 @@ function buildIssueExecutionComment(issue: IssueSummary, result: CodingAgentRunR
     `- PR created: ${result.summary.pullRequestCreated ? "yes" : "no"}.`,
     `- PR merged into main: ${result.mergedPullRequest ? "yes" : "no"}.`,
   ];
+  const externalRepositoryLines = result.summary.externalRepositories.length > 0
+    ? result.summary.externalRepositories.map((url) => `- ${url}`)
+    : ["- No external repository link captured."];
+  const externalPullRequestLines = result.summary.externalPullRequests.length > 0
+    ? result.summary.externalPullRequests.map((url) => `- ${url}`)
+    : ["- No external pull request link captured."];
+  const externalMergeLine = `- External pull request merged: ${result.summary.mergedExternalPullRequest ? "yes" : "no"}.`;
 
   return [
     "## Task Execution Log",
@@ -123,6 +130,13 @@ function buildIssueExecutionComment(issue: IssueSummary, result: CodingAgentRunR
     "",
     "### Pull Request",
     ...prLines,
+    "",
+    "### External Repository Evidence",
+    "#### External Repository",
+    ...externalRepositoryLines,
+    "#### External Pull Request",
+    ...externalPullRequestLines,
+    externalMergeLine,
     "",
     "### Completion Summary",
     `- Issue #${issue.number} execution cycle finished with outcome: ${result.summary.reviewOutcome}.`,


### PR DESCRIPTION
## Summary
Implements Issue #40 by adding explicit external-repository operating guidance and runtime evidence capture for external repository + external PR links.

## Changes
- add external-repository mode rules in agent instructions
- capture external repository and PR URLs from run events
- record external workflow evidence in task execution comments
- add regression tests for external evidence extraction and self-repo exclusion

## Validation
- pnpm validate

## Issue
- Closes #40

## External Workflow Proof
- External repository: https://github.com/evolvo-auto/evolvo-issue-40-external-demo
- External PR: https://github.com/evolvo-auto/evolvo-issue-40-external-demo/pull/1
- External PR merged: yes (MERGED at 2026-03-07T11:46:28Z)
