### PR TITLE
feat(challenges): add challenge learning metrics and reporting

### DIFF
--- a/src/challenges/challengeMetrics.test.ts
+++ b/src/challenges/challengeMetrics.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  formatChallengeMetricsReport,
+  readChallengeMetrics,
+  recordChallengeAttemptMetrics,
+} from "./challengeMetrics.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "challenge-metrics-"));
+}
+
+describe("challengeMetrics", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it("returns default metrics when no metrics file exists", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await expect(readChallengeMetrics(workDir)).resolves.toEqual({
+      total: 0,
+      success: 0,
+      failure: 0,
+      attemptsToSuccess: {
+        total: 0,
+        samples: 0,
+        average: 0,
+      },
+      categoryCounts: {},
+      pendingAttemptsByChallenge: {},
+    });
+  });
+
+  it("records failed attempts with deterministic category and pending-attempt tracking", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const metrics = await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 101,
+      success: false,
+      failureCategory: "validation_failure",
+    });
+
+    expect(metrics).toEqual({
+      total: 1,
+      success: 0,
+      failure: 1,
+      attemptsToSuccess: {
+        total: 0,
+        samples: 0,
+        average: 0,
+      },
+      categoryCounts: {
+        validation_failure: 1,
+      },
+      pendingAttemptsByChallenge: {
+        101: 1,
+      },
+    });
+  });
+
+  it("tracks attempts-to-success across retries and clears pending attempts on success", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 22,
+      success: false,
+      failureCategory: "workflow_failure",
+    });
+    const metrics = await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 22,
+      success: true,
+    });
+
+    expect(metrics).toEqual({
+      total: 2,
+      success: 1,
+      failure: 1,
+      attemptsToSuccess: {
+        total: 2,
+        samples: 1,
+        average: 2,
+      },
+      categoryCounts: {
+        workflow_failure: 1,
+      },
+      pendingAttemptsByChallenge: {},
+    });
+  });
+
+  it("stores metrics file with deterministic key ordering", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 44,
+      success: false,
+      failureCategory: "zeta",
+    });
+    await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 33,
+      success: false,
+      failureCategory: "alpha",
+    });
+
+    const raw = await readFile(join(workDir, ".evolvo", "challenge-metrics.json"), "utf8");
+    const parsed = JSON.parse(raw) as {
+      categoryCounts: Record<string, number>;
+      pendingAttemptsByChallenge: Record<string, number>;
+    };
+
+    expect(Object.keys(parsed.categoryCounts)).toEqual(["alpha", "zeta"]);
+    expect(Object.keys(parsed.pendingAttemptsByChallenge)).toEqual(["33", "44"]);
+  });
+
+  it("formats report output from stored metrics accurately", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 8,
+      success: false,
+      failureCategory: "execution_error",
+    });
+    const metrics = await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 8,
+      success: true,
+    });
+
+    expect(formatChallengeMetricsReport(metrics)).toBe([
+      "## Challenge Metrics",
+      "- total attempts: 2",
+      "- successful attempts: 1",
+      "- failed attempts: 1",
+      "- success rate: 50.00%",
+      "- attempts-to-success avg: 2.00 (samples=1)",
+      "- failure categories: execution_error:1",
+      "- active pending challenge attempts: 0",
+    ].join("\n"));
+  });
+
+  it("normalizes empty failure categories to unknown", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const metrics = await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 77,
+      success: false,
+      failureCategory: " ",
+    });
+
+    expect(metrics.categoryCounts).toEqual({ unknown: 1 });
+  });
+});
+

--- a/src/challenges/challengeMetrics.ts
+++ b/src/challenges/challengeMetrics.ts
@@ -1,0 +1,187 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+const EVOLVO_DIRECTORY_NAME = ".evolvo";
+const CHALLENGE_METRICS_FILE_NAME = "challenge-metrics.json";
+
+export type ChallengeMetrics = {
+  total: number;
+  success: number;
+  failure: number;
+  attemptsToSuccess: {
+    total: number;
+    samples: number;
+    average: number;
+  };
+  categoryCounts: Record<string, number>;
+  pendingAttemptsByChallenge: Record<string, number>;
+};
+
+export type ChallengeAttemptMetricsUpdate = {
+  challengeIssueNumber: number;
+  success: boolean;
+  failureCategory?: string;
+};
+
+function createDefaultMetrics(): ChallengeMetrics {
+  return {
+    total: 0,
+    success: 0,
+    failure: 0,
+    attemptsToSuccess: {
+      total: 0,
+      samples: 0,
+      average: 0,
+    },
+    categoryCounts: {},
+    pendingAttemptsByChallenge: {},
+  };
+}
+
+function toFiniteNonNegativeInteger(value: unknown): number {
+  const asNumber = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(asNumber) || asNumber < 0) {
+    return 0;
+  }
+
+  return Math.floor(asNumber);
+}
+
+function normalizeCategory(category: string | undefined): string {
+  const normalized = category?.trim().toLowerCase();
+  return normalized ? normalized : "unknown";
+}
+
+function sortNumericRecord(record: Record<string, number>): Record<string, number> {
+  const entries = Object.entries(record)
+    .filter(([key, value]) => key.trim().length > 0 && Number.isFinite(value) && value > 0)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  return Object.fromEntries(entries);
+}
+
+function normalizeMetricsShape(metrics: unknown): ChallengeMetrics {
+  if (typeof metrics !== "object" || metrics === null) {
+    return createDefaultMetrics();
+  }
+
+  const candidate = metrics as Partial<ChallengeMetrics>;
+  const total = toFiniteNonNegativeInteger(candidate.total);
+  const success = toFiniteNonNegativeInteger(candidate.success);
+  const failure = toFiniteNonNegativeInteger(candidate.failure);
+  const attemptsToSuccessTotal = toFiniteNonNegativeInteger(candidate.attemptsToSuccess?.total);
+  const attemptsToSuccessSamples = toFiniteNonNegativeInteger(candidate.attemptsToSuccess?.samples);
+  const attemptsToSuccessAverage = attemptsToSuccessSamples === 0
+    ? 0
+    : Number((attemptsToSuccessTotal / attemptsToSuccessSamples).toFixed(2));
+  const categoryCounts = sortNumericRecord(
+    Object.fromEntries(
+      Object.entries(candidate.categoryCounts ?? {}).map(([key, value]) => [key, toFiniteNonNegativeInteger(value)]),
+    ),
+  );
+  const pendingAttemptsByChallenge = sortNumericRecord(
+    Object.fromEntries(
+      Object.entries(candidate.pendingAttemptsByChallenge ?? {}).map(([key, value]) => [key, toFiniteNonNegativeInteger(value)]),
+    ),
+  );
+
+  return {
+    total,
+    success,
+    failure,
+    attemptsToSuccess: {
+      total: attemptsToSuccessTotal,
+      samples: attemptsToSuccessSamples,
+      average: attemptsToSuccessAverage,
+    },
+    categoryCounts,
+    pendingAttemptsByChallenge,
+  };
+}
+
+function getMetricsPath(workDir: string): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, CHALLENGE_METRICS_FILE_NAME);
+}
+
+export async function readChallengeMetrics(workDir: string): Promise<ChallengeMetrics> {
+  const metricsPath = getMetricsPath(workDir);
+
+  try {
+    const raw = await fs.readFile(metricsPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    return normalizeMetricsShape(parsed);
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return createDefaultMetrics();
+    }
+
+    throw error;
+  }
+}
+
+async function writeChallengeMetrics(workDir: string, metrics: ChallengeMetrics): Promise<void> {
+  const metricsPath = getMetricsPath(workDir);
+  await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
+  await fs.writeFile(metricsPath, `${JSON.stringify(normalizeMetricsShape(metrics), null, 2)}\n`, "utf8");
+}
+
+export async function recordChallengeAttemptMetrics(
+  workDir: string,
+  update: ChallengeAttemptMetricsUpdate,
+): Promise<ChallengeMetrics> {
+  const metrics = await readChallengeMetrics(workDir);
+  const challengeKey = String(Math.floor(update.challengeIssueNumber));
+  const previousPendingAttempts = toFiniteNonNegativeInteger(metrics.pendingAttemptsByChallenge[challengeKey]);
+  const currentAttemptCount = previousPendingAttempts + 1;
+
+  metrics.total += 1;
+
+  if (update.success) {
+    metrics.success += 1;
+    metrics.attemptsToSuccess.total += currentAttemptCount;
+    metrics.attemptsToSuccess.samples += 1;
+    metrics.attemptsToSuccess.average = Number(
+      (metrics.attemptsToSuccess.total / metrics.attemptsToSuccess.samples).toFixed(2),
+    );
+    delete metrics.pendingAttemptsByChallenge[challengeKey];
+  } else {
+    metrics.failure += 1;
+    metrics.pendingAttemptsByChallenge[challengeKey] = currentAttemptCount;
+    const category = normalizeCategory(update.failureCategory);
+    metrics.categoryCounts[category] = toFiniteNonNegativeInteger(metrics.categoryCounts[category]) + 1;
+  }
+
+  const normalized = normalizeMetricsShape(metrics);
+  await writeChallengeMetrics(workDir, normalized);
+  return normalized;
+}
+
+function formatRate(numerator: number, denominator: number): string {
+  if (denominator <= 0) {
+    return "0.00%";
+  }
+
+  return `${((numerator / denominator) * 100).toFixed(2)}%`;
+}
+
+export function formatChallengeMetricsReport(metrics: ChallengeMetrics): string {
+  const normalized = normalizeMetricsShape(metrics);
+  const failureCategoryEntries = Object.entries(normalized.categoryCounts);
+  const pendingChallenges = Object.keys(normalized.pendingAttemptsByChallenge).length;
+  const failureCategoryLine = failureCategoryEntries.length === 0
+    ? "- none"
+    : failureCategoryEntries.map(([category, count]) => `${category}:${count}`).join(", ");
+
+  return [
+    "## Challenge Metrics",
+    `- total attempts: ${normalized.total}`,
+    `- successful attempts: ${normalized.success}`,
+    `- failed attempts: ${normalized.failure}`,
+    `- success rate: ${formatRate(normalized.success, normalized.total)}`,
+    `- attempts-to-success avg: ${normalized.attemptsToSuccess.average.toFixed(2)} (samples=${normalized.attemptsToSuccess.samples})`,
+    `- failure categories: ${failureCategoryLine}`,
+    `- active pending challenge attempts: ${pendingChallenges}`,
+  ].join("\n");
+}
+

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -11,6 +11,8 @@ const closeIssueMock = vi.fn();
 const replenishSelfImprovementIssuesMock = vi.fn();
 const generateStartupIssueTemplatesMock = vi.fn();
 const runPostMergeSelfRestartMock = vi.fn();
+const recordChallengeAttemptMetricsMock = vi.fn();
+const formatChallengeMetricsReportMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -47,6 +49,11 @@ vi.mock("./runtime/selfRestart.js", () => ({
 
 vi.mock("./issues/startupIssueBootstrap.js", () => ({
   generateStartupIssueTemplates: generateStartupIssueTemplatesMock,
+}));
+
+vi.mock("./challenges/challengeMetrics.js", () => ({
+  recordChallengeAttemptMetrics: recordChallengeAttemptMetricsMock,
+  formatChallengeMetricsReport: formatChallengeMetricsReportMock,
 }));
 
 vi.mock("./issues/runIssueCommand.js", () => ({
@@ -108,6 +115,17 @@ describe("main", () => {
     replenishSelfImprovementIssuesMock.mockResolvedValue({ created: [] });
     generateStartupIssueTemplatesMock.mockReset();
     generateStartupIssueTemplatesMock.mockResolvedValue([]);
+    recordChallengeAttemptMetricsMock.mockReset();
+    recordChallengeAttemptMetricsMock.mockResolvedValue({
+      total: 1,
+      success: 1,
+      failure: 0,
+      attemptsToSuccess: { total: 1, samples: 1, average: 1 },
+      categoryCounts: {},
+      pendingAttemptsByChallenge: {},
+    });
+    formatChallengeMetricsReportMock.mockReset();
+    formatChallengeMetricsReportMock.mockReturnValue("## Challenge Metrics");
     process.argv = ["node", "src/main.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -145,7 +163,10 @@ describe("main", () => {
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Start"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Execution Log"));
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #12: Fix login redirect\n\nHandle callback URL.");
-    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
+    expect(recordChallengeAttemptMetricsMock).not.toHaveBeenCalled();
+    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ minimumIssueCount: 3, maximumOpenIssues: 5 }),
+    );
   });
 
   it("prefers an issue already in progress", async () => {
@@ -397,5 +418,48 @@ describe("main", () => {
 
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #56: Comment failure\n\nContinue anyway");
     expect(console.error).toHaveBeenCalledWith("Could not add lifecycle comment to issue #56: comment post failed");
+  });
+
+  it("records challenge metrics for accepted challenge attempts", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 88, title: "Challenge pass", description: "solve", state: "open", labels: ["challenge"] },
+      ])
+      .mockResolvedValueOnce([]);
+    runCodingAgentMock.mockResolvedValueOnce({
+      ...DEFAULT_RUN_RESULT,
+      summary: {
+        ...DEFAULT_RUN_RESULT.summary,
+        reviewOutcome: "accepted",
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(recordChallengeAttemptMetricsMock).toHaveBeenCalledWith("/tmp/evolvo", {
+      challengeIssueNumber: 88,
+      success: true,
+      failureCategory: undefined,
+    });
+    expect(formatChallengeMetricsReportMock).toHaveBeenCalled();
+  });
+
+  it("records challenge metrics for challenge runtime failures", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 89, title: "Challenge fail", description: "break", state: "open", labels: ["challenge"] },
+      ])
+      .mockResolvedValueOnce([]);
+    runCodingAgentMock.mockRejectedValueOnce(new Error("run blew up"));
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(recordChallengeAttemptMetricsMock).toHaveBeenCalledWith("/tmp/evolvo", {
+      challengeIssueNumber: 89,
+      success: false,
+      failureCategory: "execution_error",
+    });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,10 @@ import { getGitHubConfig } from "./github/githubConfig.js";
 import { GitHubApiError, GitHubClient } from "./github/githubClient.js";
 import { TaskIssueManager, type IssueSummary } from "./issues/taskIssueManager.js";
 import { generateStartupIssueTemplates } from "./issues/startupIssueBootstrap.js";
+import {
+  formatChallengeMetricsReport,
+  recordChallengeAttemptMetrics,
+} from "./challenges/challengeMetrics.js";
 import type { CodingAgentRunResult, CommandExecutionSummary } from "./agents/runCodingAgent.js";
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
@@ -44,6 +48,62 @@ function buildPromptFromIssue(issue: IssueSummary): string {
 
 function formatIssueForLog(issue: IssueSummary): string {
   return `#${issue.number} ${issue.title}`;
+}
+
+function isChallengeIssue(issue: IssueSummary): boolean {
+  return hasLabel(issue, "challenge");
+}
+
+function classifyChallengeFailure(
+  runError: unknown,
+  runResult: CodingAgentRunResult | null,
+): string {
+  if (runError) {
+    return "execution_error";
+  }
+
+  if (!runResult) {
+    return "unknown";
+  }
+
+  if (runResult.summary.failedValidationCommands.length > 0) {
+    return "validation_failure";
+  }
+
+  if (runResult.summary.reviewOutcome === "amended") {
+    return "review_rejection";
+  }
+
+  return "unknown";
+}
+
+async function updateChallengeMetrics(
+  issue: IssueSummary,
+  runError: unknown,
+  runResult: CodingAgentRunResult | null,
+): Promise<void> {
+  if (!isChallengeIssue(issue)) {
+    return;
+  }
+
+  const success = runError === null && runResult !== null && runResult.summary.reviewOutcome === "accepted";
+  const failureCategory = success ? undefined : classifyChallengeFailure(runError, runResult);
+
+  try {
+    const metrics = await recordChallengeAttemptMetrics(WORK_DIR, {
+      challengeIssueNumber: issue.number,
+      success,
+      failureCategory,
+    });
+    console.log(formatChallengeMetricsReport(metrics));
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Could not update challenge metrics for issue #${issue.number}: ${error.message}`);
+      return;
+    }
+
+    console.error(`Could not update challenge metrics for issue #${issue.number}: unknown error.`);
+  }
 }
 
 function formatDuration(durationMs: number | null): string {
@@ -309,11 +369,13 @@ export async function main(): Promise<void> {
       });
 
       if (runError) {
+        await updateChallengeMetrics(selectedIssue, runError, runResult);
         await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueFailureComment(selectedIssue, runError));
         continue;
       }
 
       if (runResult) {
+        await updateChallengeMetrics(selectedIssue, runError, runResult);
         await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueExecutionComment(selectedIssue, runResult));
       }
 


### PR DESCRIPTION
## Summary\n- add challenge metrics persistence in .evolvo/challenge-metrics.json\n- update metrics after each challenge attempt from runtime execution flow\n- add challenge metrics report formatter for periodic log/comment visibility\n- add tests for aggregation, persistence determinism, and edge cases\n\n## Validation\n- pnpm validate\n\nCloses #48