### PR TITLE
feat(challenges): implement retry gating and blocked-state handling

### DIFF
--- a/src/challenges/retryGate.test.ts
+++ b/src/challenges/retryGate.test.ts
@@ -1,0 +1,194 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import type { IssueSummary } from "../issues/taskIssueManager.js";
+import {
+  CHALLENGE_BLOCKED_LABEL,
+  CHALLENGE_FAILED_LABEL,
+  CHALLENGE_READY_TO_RETRY_LABEL,
+  evaluateChallengeRetryEligibility,
+  readChallengeRetryState,
+  recordChallengeAttemptOutcome,
+} from "./retryGate.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "challenge-retry-gate-"));
+}
+
+function createIssue(overrides: Partial<IssueSummary> = {}): IssueSummary {
+  return {
+    number: 1,
+    title: "Challenge issue",
+    description: "Description",
+    state: "open",
+    labels: ["challenge"],
+    ...overrides,
+  };
+}
+
+describe("retryGate", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it("treats a fresh challenge as eligible first attempt", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const issue = createIssue();
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, issue, [issue], {
+      maxAttempts: 3,
+      cooldownMs: 60_000,
+      nowMs: 1_000,
+    });
+
+    expect(decision).toEqual({
+      eligible: true,
+      reason: "first-attempt",
+      attemptCount: 0,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      addLabels: [],
+      removeLabels: [],
+    });
+  });
+
+  it("rejects retry when corrective issues are still open", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 10,
+      success: false,
+      nowMs: 1_000,
+    });
+    const challenge = createIssue({ number: 10, labels: ["challenge", CHALLENGE_FAILED_LABEL] });
+    const corrective = createIssue({
+      number: 999,
+      title: "Corrective issue",
+      labels: [],
+      description: "Relates-to-Challenge: #10",
+    });
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, challenge, [challenge, corrective], {
+      maxAttempts: 3,
+      cooldownMs: 0,
+      nowMs: 2_000,
+    });
+
+    expect(decision.eligible).toBe(false);
+    expect(decision.reason).toBe("awaiting-corrective-issues");
+    expect(decision.openCorrectiveIssueNumbers).toEqual([999]);
+    expect(decision.addLabels).toEqual([]);
+    expect(decision.removeLabels).toEqual([]);
+  });
+
+  it("rejects retry while cooldown is active", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 11,
+      success: false,
+      nowMs: 10_000,
+    });
+    const challenge = createIssue({ number: 11, labels: ["challenge", CHALLENGE_FAILED_LABEL] });
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, challenge, [challenge], {
+      maxAttempts: 3,
+      cooldownMs: 60_000,
+      nowMs: 20_000,
+    });
+
+    expect(decision.eligible).toBe(false);
+    expect(decision.reason).toBe("cooldown-active");
+    expect(decision.cooldownRemainingMs).toBe(50_000);
+  });
+
+  it("allows retry and adds ready label after cooldown with no open corrective issues", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 12,
+      success: false,
+      nowMs: 1_000,
+    });
+    const challenge = createIssue({ number: 12, labels: ["challenge", CHALLENGE_FAILED_LABEL] });
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, challenge, [challenge], {
+      maxAttempts: 3,
+      cooldownMs: 60_000,
+      nowMs: 70_000,
+    });
+
+    expect(decision).toEqual({
+      eligible: true,
+      reason: "ready-to-retry",
+      attemptCount: 1,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      addLabels: [CHALLENGE_READY_TO_RETRY_LABEL],
+      removeLabels: [],
+    });
+  });
+
+  it("blocks challenge when max attempts are reached", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 13,
+      success: false,
+      nowMs: 1_000,
+    });
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 13,
+      success: false,
+      nowMs: 2_000,
+    });
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 13,
+      success: false,
+      nowMs: 3_000,
+    });
+    const challenge = createIssue({ number: 13, labels: ["challenge", CHALLENGE_FAILED_LABEL] });
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, challenge, [challenge], {
+      maxAttempts: 3,
+      cooldownMs: 0,
+      nowMs: 4_000,
+    });
+
+    expect(decision.eligible).toBe(false);
+    expect(decision.reason).toBe("max-attempts-reached");
+    expect(decision.addLabels).toEqual([CHALLENGE_BLOCKED_LABEL]);
+    expect(decision.removeLabels).toEqual([]);
+  });
+
+  it("clears retry state after success", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 21,
+      success: false,
+      nowMs: 10,
+    });
+    const stateAfterFailure = await readChallengeRetryState(workDir);
+    expect(stateAfterFailure.failuresByChallenge["21"]).toEqual({ attempts: 1, lastFailureAtMs: 10 });
+
+    await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 21,
+      success: true,
+      nowMs: 20,
+    });
+    const stateAfterSuccess = await readChallengeRetryState(workDir);
+    expect(stateAfterSuccess.failuresByChallenge).toEqual({});
+  });
+});
+

--- a/src/challenges/retryGate.ts
+++ b/src/challenges/retryGate.ts
@@ -1,0 +1,253 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import type { IssueSummary } from "../issues/taskIssueManager.js";
+
+const EVOLVO_DIRECTORY_NAME = ".evolvo";
+const CHALLENGE_RETRY_STATE_FILE_NAME = "challenge-retry-state.json";
+
+export const CHALLENGE_FAILED_LABEL = "challenge:failed";
+export const CHALLENGE_READY_TO_RETRY_LABEL = "challenge:ready-to-retry";
+export const CHALLENGE_BLOCKED_LABEL = "challenge:blocked";
+const MANAGED_CHALLENGE_RETRY_LABELS = [
+  CHALLENGE_FAILED_LABEL,
+  CHALLENGE_READY_TO_RETRY_LABEL,
+  CHALLENGE_BLOCKED_LABEL,
+] as const;
+
+type ChallengeRetryState = {
+  failuresByChallenge: Record<string, { attempts: number; lastFailureAtMs: number }>;
+};
+
+export type ChallengeRetryDecision = {
+  eligible: boolean;
+  reason:
+    | "not-challenge"
+    | "first-attempt"
+    | "awaiting-corrective-issues"
+    | "cooldown-active"
+    | "ready-to-retry"
+    | "max-attempts-reached";
+  attemptCount: number;
+  cooldownRemainingMs: number;
+  openCorrectiveIssueNumbers: number[];
+  addLabels: string[];
+  removeLabels: string[];
+};
+
+export type RetryGateOptions = {
+  maxAttempts: number;
+  cooldownMs: number;
+  nowMs?: number;
+};
+
+export type RecordChallengeAttemptOutcomeInput = {
+  challengeIssueNumber: number;
+  success: boolean;
+  nowMs?: number;
+};
+
+function createDefaultRetryState(): ChallengeRetryState {
+  return {
+    failuresByChallenge: {},
+  };
+}
+
+function toFiniteNonNegativeInteger(value: unknown): number {
+  const asNumber = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(asNumber) || asNumber < 0) {
+    return 0;
+  }
+
+  return Math.floor(asNumber);
+}
+
+function normalizeRetryState(state: unknown): ChallengeRetryState {
+  if (typeof state !== "object" || state === null) {
+    return createDefaultRetryState();
+  }
+
+  const failuresByChallenge = Object.fromEntries(
+    Object.entries((state as Partial<ChallengeRetryState>).failuresByChallenge ?? {})
+      .map(([challengeNumber, value]) => {
+        const attempts = toFiniteNonNegativeInteger(value?.attempts);
+        const lastFailureAtMs = toFiniteNonNegativeInteger(value?.lastFailureAtMs);
+        return [challengeNumber, { attempts, lastFailureAtMs }] as const;
+      })
+      .filter(([, value]) => value.attempts > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+
+  return { failuresByChallenge };
+}
+
+function hasLabel(issue: IssueSummary, label: string): boolean {
+  return issue.labels.some((existing) => existing.toLowerCase() === label.toLowerCase());
+}
+
+function isChallengeIssue(issue: IssueSummary): boolean {
+  return hasLabel(issue, "challenge");
+}
+
+function getRetryStatePath(workDir: string): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, CHALLENGE_RETRY_STATE_FILE_NAME);
+}
+
+function parseCorrectiveChallengeLink(description: string): number | null {
+  const match = description.match(/Relates-to-Challenge:\s*#(\d+)/i);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const challengeNumber = Number(match[1]);
+  return Number.isInteger(challengeNumber) && challengeNumber > 0 ? challengeNumber : null;
+}
+
+function getManagedLabelChanges(issue: IssueSummary, addLabels: string[]): { addLabels: string[]; removeLabels: string[] } {
+  const addSet = new Set(addLabels.map((label) => label.toLowerCase()));
+  const removeLabels = MANAGED_CHALLENGE_RETRY_LABELS
+    .filter((label) => !addSet.has(label.toLowerCase()) && hasLabel(issue, label));
+  const existingLowerCase = new Set(issue.labels.map((label) => label.toLowerCase()));
+  const dedupedAddLabels = addLabels.filter((label) => !existingLowerCase.has(label.toLowerCase()));
+
+  return {
+    addLabels: dedupedAddLabels,
+    removeLabels,
+  };
+}
+
+export async function readChallengeRetryState(workDir: string): Promise<ChallengeRetryState> {
+  const retryStatePath = getRetryStatePath(workDir);
+
+  try {
+    const raw = await fs.readFile(retryStatePath, "utf8");
+    return normalizeRetryState(JSON.parse(raw) as unknown);
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return createDefaultRetryState();
+    }
+
+    throw error;
+  }
+}
+
+async function writeChallengeRetryState(workDir: string, state: ChallengeRetryState): Promise<void> {
+  await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
+  await fs.writeFile(
+    getRetryStatePath(workDir),
+    `${JSON.stringify(normalizeRetryState(state), null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export async function recordChallengeAttemptOutcome(
+  workDir: string,
+  input: RecordChallengeAttemptOutcomeInput,
+): Promise<ChallengeRetryState> {
+  const nowMs = toFiniteNonNegativeInteger(input.nowMs ?? Date.now());
+  const challengeKey = String(Math.floor(input.challengeIssueNumber));
+  const state = await readChallengeRetryState(workDir);
+  const current = state.failuresByChallenge[challengeKey];
+
+  if (input.success) {
+    delete state.failuresByChallenge[challengeKey];
+  } else {
+    state.failuresByChallenge[challengeKey] = {
+      attempts: toFiniteNonNegativeInteger(current?.attempts) + 1,
+      lastFailureAtMs: nowMs,
+    };
+  }
+
+  const normalized = normalizeRetryState(state);
+  await writeChallengeRetryState(workDir, normalized);
+  return normalized;
+}
+
+export async function evaluateChallengeRetryEligibility(
+  workDir: string,
+  issue: IssueSummary,
+  openIssues: IssueSummary[],
+  options: RetryGateOptions,
+): Promise<ChallengeRetryDecision> {
+  if (!isChallengeIssue(issue)) {
+    return {
+      eligible: true,
+      reason: "not-challenge",
+      attemptCount: 0,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      addLabels: [],
+      removeLabels: [],
+    };
+  }
+
+  const nowMs = toFiniteNonNegativeInteger(options.nowMs ?? Date.now());
+  const maxAttempts = Math.max(1, toFiniteNonNegativeInteger(options.maxAttempts));
+  const cooldownMs = toFiniteNonNegativeInteger(options.cooldownMs);
+  const state = await readChallengeRetryState(workDir);
+  const retryEntry = state.failuresByChallenge[String(issue.number)];
+  const attemptCount = toFiniteNonNegativeInteger(retryEntry?.attempts);
+
+  const failedLabelPresent = hasLabel(issue, CHALLENGE_FAILED_LABEL) || attemptCount > 0;
+  if (!failedLabelPresent) {
+    return {
+      eligible: true,
+      reason: "first-attempt",
+      attemptCount,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      ...getManagedLabelChanges(issue, []),
+    };
+  }
+
+  if (attemptCount >= maxAttempts) {
+    return {
+      eligible: false,
+      reason: "max-attempts-reached",
+      attemptCount,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      ...getManagedLabelChanges(issue, [CHALLENGE_FAILED_LABEL, CHALLENGE_BLOCKED_LABEL]),
+    };
+  }
+
+  const openCorrectiveIssueNumbers = openIssues
+    .filter((openIssue) => openIssue.number !== issue.number)
+    .filter((openIssue) => parseCorrectiveChallengeLink(openIssue.description) === issue.number)
+    .map((openIssue) => openIssue.number)
+    .sort((left, right) => left - right);
+
+  if (openCorrectiveIssueNumbers.length > 0) {
+    return {
+      eligible: false,
+      reason: "awaiting-corrective-issues",
+      attemptCount,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers,
+      ...getManagedLabelChanges(issue, [CHALLENGE_FAILED_LABEL]),
+    };
+  }
+
+  const lastFailureAtMs = toFiniteNonNegativeInteger(retryEntry?.lastFailureAtMs);
+  const cooldownRemainingMs = Math.max(0, lastFailureAtMs + cooldownMs - nowMs);
+  if (cooldownRemainingMs > 0) {
+    return {
+      eligible: false,
+      reason: "cooldown-active",
+      attemptCount,
+      cooldownRemainingMs,
+      openCorrectiveIssueNumbers: [],
+      ...getManagedLabelChanges(issue, [CHALLENGE_FAILED_LABEL]),
+    };
+  }
+
+  return {
+    eligible: true,
+    reason: "ready-to-retry",
+    attemptCount,
+    cooldownRemainingMs: 0,
+    openCorrectiveIssueNumbers: [],
+    ...getManagedLabelChanges(issue, [CHALLENGE_FAILED_LABEL, CHALLENGE_READY_TO_RETRY_LABEL]),
+  };
+}
+

--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -391,6 +391,70 @@ describe("TaskIssueManager", () => {
     });
   });
 
+  it("updates labels by adding and removing managed challenge labels", async () => {
+    const client = createClientMock();
+    client.get.mockResolvedValue(
+      createIssue({
+        labels: [{ name: "challenge" }, { name: "in progress" }, { name: "challenge:ready-to-retry" }],
+      }),
+    );
+    client.patch.mockResolvedValue(
+      createIssue({
+        labels: [{ name: "challenge" }, { name: "challenge:failed" }],
+      }),
+    );
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.updateLabels(1, {
+      add: ["challenge:failed"],
+      remove: ["in progress", "challenge:ready-to-retry"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(client.patch).toHaveBeenCalledWith("/1", {
+      labels: ["challenge", "challenge:failed"],
+    });
+  });
+
+  it("returns without patch when labels are already up to date", async () => {
+    const client = createClientMock();
+    client.get.mockResolvedValue(createIssue({ labels: [{ name: "challenge" }, { name: "challenge:failed" }] }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.updateLabels(1, {
+      add: ["challenge:failed"],
+      remove: [],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Issue #1 labels already up to date.",
+      issue: {
+        number: 1,
+        title: "Issue",
+        description: "Description",
+        state: "open",
+        labels: ["challenge", "challenge:failed"],
+      },
+    });
+    expect(client.patch).not.toHaveBeenCalled();
+  });
+
+  it("prevents relabeling a closed issue", async () => {
+    const client = createClientMock();
+    client.get.mockResolvedValue(createIssue({ state: "closed" }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.updateLabels(1, {
+      add: ["challenge:failed"],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Issue #1 is closed and cannot be relabeled.",
+    });
+  });
+
   it("returns not found if GitHub returns 404", async () => {
     const client = createClientMock();
     client.get.mockRejectedValue(new GitHubApiError("not found", 404, null));

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -40,6 +40,11 @@ export type ReplenishIssuesResult = {
   created: IssueSummary[];
 };
 
+export type UpdateIssueLabelsOptions = {
+  add?: string[];
+  remove?: string[];
+};
+
 type IssueTemplate = {
   title: string;
   description: string;
@@ -298,6 +303,58 @@ export class TaskIssueManager {
       ok: true,
       message: `Issue #${issueNumber} closed successfully.`,
       issue: formatIssue({ ...issue, state: "closed" }),
+    };
+  }
+
+  public async updateLabels(issueNumber: number, options: UpdateIssueLabelsOptions): Promise<IssueActionResult> {
+    const issue = await this.getIssue(issueNumber);
+
+    if (!issue) {
+      return { ok: false, message: `Issue #${issueNumber} was not found.` };
+    }
+
+    if (issue.state === "closed") {
+      return { ok: false, message: `Issue #${issueNumber} is closed and cannot be relabeled.` };
+    }
+
+    const currentLabels = issue.labels.map((label) => label.name);
+    const labelMap = new Map(currentLabels.map((label) => [label.toLowerCase(), label] as const));
+    const removeSet = new Set((options.remove ?? []).map((label) => label.trim().toLowerCase()).filter(Boolean));
+
+    for (const removeLabel of removeSet) {
+      labelMap.delete(removeLabel);
+    }
+
+    for (const addLabel of options.add ?? []) {
+      const trimmed = addLabel.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      labelMap.set(trimmed.toLowerCase(), trimmed);
+    }
+
+    const nextLabels = [...labelMap.values()];
+    const unchanged =
+      nextLabels.length === currentLabels.length &&
+      nextLabels.every((label, index) => label === currentLabels[index]);
+
+    if (unchanged) {
+      return {
+        ok: true,
+        message: `Issue #${issueNumber} labels already up to date.`,
+        issue: formatIssue(issue),
+      };
+    }
+
+    const updated = await this.client.patch<GitHubIssue>(`/${issueNumber}`, {
+      labels: nextLabels,
+    });
+
+    return {
+      ok: true,
+      message: `Issue #${issueNumber} labels updated.`,
+      issue: formatIssue(updated),
     };
   }
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -13,6 +13,9 @@ const generateStartupIssueTemplatesMock = vi.fn();
 const runPostMergeSelfRestartMock = vi.fn();
 const recordChallengeAttemptMetricsMock = vi.fn();
 const formatChallengeMetricsReportMock = vi.fn();
+const evaluateChallengeRetryEligibilityMock = vi.fn();
+const recordChallengeAttemptOutcomeMock = vi.fn();
+const updateLabelsMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -56,6 +59,14 @@ vi.mock("./challenges/challengeMetrics.js", () => ({
   formatChallengeMetricsReport: formatChallengeMetricsReportMock,
 }));
 
+vi.mock("./challenges/retryGate.js", () => ({
+  CHALLENGE_BLOCKED_LABEL: "challenge:blocked",
+  CHALLENGE_FAILED_LABEL: "challenge:failed",
+  CHALLENGE_READY_TO_RETRY_LABEL: "challenge:ready-to-retry",
+  evaluateChallengeRetryEligibility: evaluateChallengeRetryEligibilityMock,
+  recordChallengeAttemptOutcome: recordChallengeAttemptOutcomeMock,
+}));
+
 vi.mock("./issues/runIssueCommand.js", () => ({
   runIssueCommand: runIssueCommandMock,
 }));
@@ -82,6 +93,7 @@ vi.mock("./issues/taskIssueManager.js", () => ({
     addProgressComment = addProgressCommentMock;
     closeIssue = closeIssueMock;
     replenishSelfImprovementIssues = replenishSelfImprovementIssuesMock;
+    updateLabels = updateLabelsMock;
   },
 }));
 
@@ -126,6 +138,20 @@ describe("main", () => {
     });
     formatChallengeMetricsReportMock.mockReset();
     formatChallengeMetricsReportMock.mockReturnValue("## Challenge Metrics");
+    evaluateChallengeRetryEligibilityMock.mockReset();
+    evaluateChallengeRetryEligibilityMock.mockResolvedValue({
+      eligible: true,
+      reason: "not-challenge",
+      attemptCount: 0,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      addLabels: [],
+      removeLabels: [],
+    });
+    recordChallengeAttemptOutcomeMock.mockReset();
+    recordChallengeAttemptOutcomeMock.mockResolvedValue({ failuresByChallenge: {} });
+    updateLabelsMock.mockReset();
+    updateLabelsMock.mockResolvedValue({ ok: true, message: "labels updated" });
     process.argv = ["node", "src/main.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -442,6 +468,13 @@ describe("main", () => {
       success: true,
       failureCategory: undefined,
     });
+    expect(recordChallengeAttemptOutcomeMock).toHaveBeenCalledWith("/tmp/evolvo", {
+      challengeIssueNumber: 88,
+      success: true,
+    });
+    expect(updateLabelsMock).toHaveBeenCalledWith(88, {
+      remove: ["challenge:failed", "challenge:ready-to-retry", "challenge:blocked"],
+    });
     expect(formatChallengeMetricsReportMock).toHaveBeenCalled();
   });
 
@@ -461,5 +494,68 @@ describe("main", () => {
       success: false,
       failureCategory: "execution_error",
     });
+    expect(updateLabelsMock).toHaveBeenCalledWith(89, {
+      add: ["challenge:failed"],
+      remove: ["challenge:ready-to-retry", "challenge:blocked"],
+    });
+  });
+
+  it("skips challenge retries when retry gate is not eligible", async () => {
+    listOpenIssuesMock.mockResolvedValue([
+      { number: 90, title: "Retry gated", description: "gated", state: "open", labels: ["challenge", "challenge:failed"] },
+    ]);
+    evaluateChallengeRetryEligibilityMock.mockResolvedValue({
+      eligible: false,
+      reason: "cooldown-active",
+      attemptCount: 1,
+      cooldownRemainingMs: 1000,
+      openCorrectiveIssueNumbers: [],
+      addLabels: [],
+      removeLabels: [],
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("allows challenge retry when retry gate is eligible", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        {
+          number: 91,
+          title: "Retry allowed",
+          description: "allowed",
+          state: "open",
+          labels: ["challenge", "challenge:failed"],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    evaluateChallengeRetryEligibilityMock.mockResolvedValueOnce({
+      eligible: true,
+      reason: "ready-to-retry",
+      attemptCount: 1,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      addLabels: ["challenge:ready-to-retry"],
+      removeLabels: [],
+    });
+    updateLabelsMock.mockResolvedValueOnce({
+      ok: true,
+      message: "updated",
+      issue: {
+        number: 91,
+        title: "Retry allowed",
+        description: "allowed",
+        state: "open",
+        labels: ["challenge", "challenge:failed", "challenge:ready-to-retry"],
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #91: Retry allowed\n\nallowed");
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,14 @@ import {
   formatChallengeMetricsReport,
   recordChallengeAttemptMetrics,
 } from "./challenges/challengeMetrics.js";
+import {
+  CHALLENGE_BLOCKED_LABEL,
+  CHALLENGE_FAILED_LABEL,
+  CHALLENGE_READY_TO_RETRY_LABEL,
+  evaluateChallengeRetryEligibility,
+  recordChallengeAttemptOutcome,
+  type ChallengeRetryDecision,
+} from "./challenges/retryGate.js";
 import type { CodingAgentRunResult, CommandExecutionSummary } from "./agents/runCodingAgent.js";
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
@@ -20,6 +28,8 @@ const MAX_ISSUE_CYCLES = 25;
 const OUTDATED_LABELS = new Set(["outdated", "obsolete", "wontfix", "invalid", "duplicate"]);
 const MIN_REPLENISH_ISSUES = 3;
 const MAX_OPEN_ISSUES = 5;
+const CHALLENGE_MAX_ATTEMPTS = 3;
+const CHALLENGE_RETRY_COOLDOWN_MS = 60 * 60 * 1000;
 
 function hasLabel(issue: IssueSummary, label: string): boolean {
   return issue.labels.some((currentLabel) => currentLabel.toLowerCase() === label.toLowerCase());
@@ -78,6 +88,7 @@ function classifyChallengeFailure(
 }
 
 async function updateChallengeMetrics(
+  issueManager: TaskIssueManager,
   issue: IssueSummary,
   runError: unknown,
   runResult: CodingAgentRunResult | null,
@@ -95,6 +106,28 @@ async function updateChallengeMetrics(
       success,
       failureCategory,
     });
+
+    const retryState = await recordChallengeAttemptOutcome(WORK_DIR, {
+      challengeIssueNumber: issue.number,
+      success,
+    });
+    const failureAttempts = retryState.failuresByChallenge[String(issue.number)]?.attempts ?? 0;
+    const labelUpdate = success
+      ? await issueManager.updateLabels(issue.number, {
+          remove: [CHALLENGE_FAILED_LABEL, CHALLENGE_READY_TO_RETRY_LABEL, CHALLENGE_BLOCKED_LABEL],
+        })
+      : await issueManager.updateLabels(issue.number, {
+          add: failureAttempts >= CHALLENGE_MAX_ATTEMPTS
+            ? [CHALLENGE_FAILED_LABEL, CHALLENGE_BLOCKED_LABEL]
+            : [CHALLENGE_FAILED_LABEL],
+          remove: failureAttempts >= CHALLENGE_MAX_ATTEMPTS
+            ? [CHALLENGE_READY_TO_RETRY_LABEL]
+            : [CHALLENGE_READY_TO_RETRY_LABEL, CHALLENGE_BLOCKED_LABEL],
+        });
+    if (!labelUpdate.ok) {
+      console.error(`Could not update challenge retry labels for issue #${issue.number}: ${labelUpdate.message}`);
+    }
+
     console.log(formatChallengeMetricsReport(metrics));
   } catch (error) {
     if (error instanceof Error) {
@@ -104,6 +137,57 @@ async function updateChallengeMetrics(
 
     console.error(`Could not update challenge metrics for issue #${issue.number}: unknown error.`);
   }
+}
+
+function formatRetryDecisionLog(issue: IssueSummary, decision: ChallengeRetryDecision): string {
+  const corrective = decision.openCorrectiveIssueNumbers.length > 0
+    ? ` correctiveOpen=${decision.openCorrectiveIssueNumbers.join(",")}`
+    : "";
+  const cooldownSuffix = decision.cooldownRemainingMs > 0
+    ? ` cooldownRemainingMs=${decision.cooldownRemainingMs}`
+    : "";
+  return `Challenge retry decision for issue #${issue.number}: eligible=${decision.eligible} reason=${decision.reason} attempts=${decision.attemptCount}/${CHALLENGE_MAX_ATTEMPTS}${cooldownSuffix}${corrective}`;
+}
+
+async function applyChallengeRetryGate(
+  issueManager: TaskIssueManager,
+  openIssues: IssueSummary[],
+  issues: IssueSummary[],
+): Promise<IssueSummary[]> {
+  const eligible: IssueSummary[] = [];
+
+  for (const issue of issues) {
+    if (!isChallengeIssue(issue)) {
+      eligible.push(issue);
+      continue;
+    }
+
+    const decision = await evaluateChallengeRetryEligibility(WORK_DIR, issue, openIssues, {
+      maxAttempts: CHALLENGE_MAX_ATTEMPTS,
+      cooldownMs: CHALLENGE_RETRY_COOLDOWN_MS,
+    });
+    console.log(formatRetryDecisionLog(issue, decision));
+
+    let nextIssue = issue;
+    if (decision.addLabels.length > 0 || decision.removeLabels.length > 0) {
+      const labelUpdate = await issueManager.updateLabels(issue.number, {
+        add: decision.addLabels,
+        remove: decision.removeLabels,
+      });
+
+      if (!labelUpdate.ok) {
+        console.error(`Could not sync retry labels for issue #${issue.number}: ${labelUpdate.message}`);
+      } else if (labelUpdate.issue) {
+        nextIssue = labelUpdate.issue;
+      }
+    }
+
+    if (decision.eligible) {
+      eligible.push(nextIssue);
+    }
+  }
+
+  return eligible;
 }
 
 function formatDuration(durationMs: number | null): string {
@@ -320,7 +404,8 @@ export async function main(): Promise<void> {
         }
       }
 
-      const selectedIssue = selectIssueForWork(actionableIssues);
+      const retryEligibleIssues = await applyChallengeRetryGate(issueManager, actionableIssues, actionableIssues);
+      const selectedIssue = selectIssueForWork(retryEligibleIssues);
 
       if (!selectedIssue) {
         const isStartupBootstrap = cycle === 1 && openIssues.length === 0;
@@ -369,13 +454,13 @@ export async function main(): Promise<void> {
       });
 
       if (runError) {
-        await updateChallengeMetrics(selectedIssue, runError, runResult);
+        await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
         await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueFailureComment(selectedIssue, runError));
         continue;
       }
 
       if (runResult) {
-        await updateChallengeMetrics(selectedIssue, runError, runResult);
+        await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
         await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueExecutionComment(selectedIssue, runResult));
       }
 


### PR DESCRIPTION
## Summary\n- add challenge retry eligibility evaluator with gating on corrective issue completion, cooldown, and max attempts\n- persist retry state for challenge attempts and failure timestamps under .evolvo/challenge-retry-state.json\n- apply challenge labels (challenge:ready-to-retry, challenge:failed, challenge:blocked) from runtime decision flow\n- expose retry decisions in runtime logs and skip ineligible retries\n- add tests for each retry gate branch and label update behavior\n\n## Validation\n- pnpm validate\n\nCloses #47