### PR TITLE
fix(challenges): enforce blocked retry gating and lifecycle gate comments

### DIFF
--- a/src/challenges/retryGate.test.ts
+++ b/src/challenges/retryGate.test.ts
@@ -57,6 +57,28 @@ describe("retryGate", () => {
     });
   });
 
+  it("bypasses retry gating for non-challenge issues", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const issue = createIssue({ labels: ["bug"] });
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, issue, [issue], {
+      maxAttempts: 3,
+      cooldownMs: 60_000,
+      nowMs: 1_000,
+    });
+
+    expect(decision).toEqual({
+      eligible: true,
+      reason: "not-challenge",
+      attemptCount: 0,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      addLabels: [],
+      removeLabels: [],
+    });
+  });
+
   it("rejects retry when corrective issues are still open", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
@@ -170,6 +192,27 @@ describe("retryGate", () => {
     expect(decision.removeLabels).toEqual([]);
   });
 
+  it("keeps challenge blocked when blocked label is present without retry state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const challenge = createIssue({
+      number: 14,
+      labels: ["challenge", CHALLENGE_FAILED_LABEL, CHALLENGE_BLOCKED_LABEL, CHALLENGE_READY_TO_RETRY_LABEL],
+    });
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, challenge, [challenge], {
+      maxAttempts: 3,
+      cooldownMs: 0,
+      nowMs: 4_000,
+    });
+
+    expect(decision.eligible).toBe(false);
+    expect(decision.reason).toBe("max-attempts-reached");
+    expect(decision.addLabels).toEqual([]);
+    expect(decision.removeLabels).toEqual([CHALLENGE_READY_TO_RETRY_LABEL]);
+  });
+
   it("clears retry state after success", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
@@ -191,4 +234,3 @@ describe("retryGate", () => {
     expect(stateAfterSuccess.failuresByChallenge).toEqual({});
   });
 });
-

--- a/src/challenges/retryGate.ts
+++ b/src/challenges/retryGate.ts
@@ -187,6 +187,18 @@ export async function evaluateChallengeRetryEligibility(
   const state = await readChallengeRetryState(workDir);
   const retryEntry = state.failuresByChallenge[String(issue.number)];
   const attemptCount = toFiniteNonNegativeInteger(retryEntry?.attempts);
+  const blockedLabelPresent = hasLabel(issue, CHALLENGE_BLOCKED_LABEL);
+
+  if (blockedLabelPresent) {
+    return {
+      eligible: false,
+      reason: "max-attempts-reached",
+      attemptCount,
+      cooldownRemainingMs: 0,
+      openCorrectiveIssueNumbers: [],
+      ...getManagedLabelChanges(issue, [CHALLENGE_FAILED_LABEL, CHALLENGE_BLOCKED_LABEL]),
+    };
+  }
 
   const failedLabelPresent = hasLabel(issue, CHALLENGE_FAILED_LABEL) || attemptCount > 0;
   if (!failedLabelPresent) {
@@ -250,4 +262,3 @@ export async function evaluateChallengeRetryEligibility(
     ...getManagedLabelChanges(issue, [CHALLENGE_FAILED_LABEL, CHALLENGE_READY_TO_RETRY_LABEL]),
   };
 }
-

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -518,6 +518,8 @@ describe("main", () => {
     await main();
 
     expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(addProgressCommentMock).toHaveBeenCalledWith(90, expect.stringContaining("## Challenge Retry Gate"));
+    expect(addProgressCommentMock).toHaveBeenCalledWith(90, expect.stringContaining("Decision: `cooldown-active`"));
   });
 
   it("allows challenge retry when retry gate is eligible", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,6 +149,28 @@ function formatRetryDecisionLog(issue: IssueSummary, decision: ChallengeRetryDec
   return `Challenge retry decision for issue #${issue.number}: eligible=${decision.eligible} reason=${decision.reason} attempts=${decision.attemptCount}/${CHALLENGE_MAX_ATTEMPTS}${cooldownSuffix}${corrective}`;
 }
 
+function buildChallengeRetryGateComment(issue: IssueSummary, decision: ChallengeRetryDecision): string {
+  const details = [
+    `- Decision: \`${decision.reason}\``,
+    `- Eligible to run this cycle: ${decision.eligible ? "yes" : "no"}`,
+    `- Attempts recorded: ${decision.attemptCount}/${CHALLENGE_MAX_ATTEMPTS}`,
+  ];
+
+  if (decision.cooldownRemainingMs > 0) {
+    details.push(`- Cooldown remaining: ${decision.cooldownRemainingMs}ms`);
+  }
+
+  if (decision.openCorrectiveIssueNumbers.length > 0) {
+    details.push(`- Open corrective issues: ${decision.openCorrectiveIssueNumbers.map((number) => `#${number}`).join(", ")}`);
+  }
+
+  return [
+    "## Challenge Retry Gate",
+    `- Issue #${issue.number} was evaluated by retry gating.`,
+    ...details,
+  ].join("\n");
+}
+
 async function applyChallengeRetryGate(
   issueManager: TaskIssueManager,
   openIssues: IssueSummary[],
@@ -184,7 +206,10 @@ async function applyChallengeRetryGate(
 
     if (decision.eligible) {
       eligible.push(nextIssue);
+      continue;
     }
+
+    await addIssueLifecycleComment(issueManager, issue.number, buildChallengeRetryGateComment(issue, decision));
   }
 
   return eligible;


### PR DESCRIPTION
## Summary
- enforce retry ineligibility when `challenge:blocked` is present even if retry state is missing
- add lifecycle comment output when challenge retry gating skips execution
- extend tests for non-challenge bypass, blocked-label branch, and retry-gate lifecycle comment emission

## Validation
- pnpm vitest run src/challenges/retryGate.test.ts src/main.test.ts

Closes #47
