### PR TITLE
feat(challenges): classify challenge failures and auto-generate corrective issues

### DIFF
--- a/src/challenges/challengeFailureLearning.test.ts
+++ b/src/challenges/challengeFailureLearning.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CodingAgentRunResult } from "../agents/runCodingAgent.js";
+import {
+  buildChallengeFailureLearningComment,
+  classifyChallengeFailure,
+  createCorrectiveIssuesForChallengeFailure,
+} from "./challengeFailureLearning.js";
+
+function createRunResult(overrides: Partial<CodingAgentRunResult["summary"]>): CodingAgentRunResult {
+  return {
+    mergedPullRequest: false,
+    summary: {
+      inspectedAreas: [],
+      editedFiles: ["src/main.ts"],
+      validationCommands: [],
+      failedValidationCommands: [],
+      reviewOutcome: "accepted",
+      pullRequestCreated: false,
+      externalRepositories: [],
+      externalPullRequests: [],
+      mergedExternalPullRequest: false,
+      finalResponse: "",
+      ...overrides,
+    },
+  };
+}
+
+describe("challengeFailureLearning", () => {
+  it("classifies validation failures from run result", () => {
+    const category = classifyChallengeFailure(
+      null,
+      createRunResult({
+        failedValidationCommands: [{ command: "pnpm test", exitCode: 1, durationMs: 100 }],
+        reviewOutcome: "amended",
+      }),
+    );
+
+    expect(category).toBe("validation_failure");
+  });
+
+  it("classifies workflow failures from runtime error message", () => {
+    const category = classifyChallengeFailure(new Error("Could not merge pull request"), null);
+    expect(category).toBe("workflow_failure");
+  });
+
+  it("classifies scope-control failures when no files were edited", () => {
+    const category = classifyChallengeFailure(
+      null,
+      createRunResult({ editedFiles: [], reviewOutcome: "amended" }),
+    );
+
+    expect(category).toBe("scope_control_failure");
+  });
+
+  it("creates corrective issues with challenge linkage in body", async () => {
+    const createIssue = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        message: "Created issue #201.",
+        issue: { number: 201, title: "A", description: "", state: "open", labels: [] },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        message: "Created issue #202.",
+        issue: { number: 202, title: "B", description: "", state: "open", labels: [] },
+      });
+
+    const created = await createCorrectiveIssuesForChallengeFailure(
+      { createIssue } as never,
+      46,
+      "validation_failure",
+    );
+
+    expect(created.map((issue) => issue.number)).toEqual([201, 202]);
+    expect(createIssue).toHaveBeenCalledTimes(2);
+    expect(createIssue).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.stringContaining("Relates-to-Challenge: #46"),
+    );
+    expect(createIssue).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.stringContaining("Challenge-Failure-Category: validation_failure"),
+    );
+  });
+
+  it("formats a learning comment with generated issue links", () => {
+    const comment = buildChallengeFailureLearningComment({
+      challengeIssueNumber: 46,
+      category: "execution_failure",
+      correctiveIssues: [
+        { number: 301, title: "Fix A", description: "", state: "open", labels: [] },
+      ],
+    });
+
+    expect(comment).toContain("Failure classification: `execution_failure`");
+    expect(comment).toContain("#301 Fix A");
+  });
+});

--- a/src/challenges/challengeFailureLearning.ts
+++ b/src/challenges/challengeFailureLearning.ts
@@ -1,0 +1,188 @@
+import type { CodingAgentRunResult } from "../agents/runCodingAgent.js";
+import type { IssueSummary, TaskIssueManager } from "../issues/taskIssueManager.js";
+
+export const CHALLENGE_LEARNING_GENERATED_LABEL = "learning-generated";
+
+const FAILURE_CATEGORIES = [
+  "validation_failure",
+  "workflow_failure",
+  "execution_failure",
+  "scope_control_failure",
+  "unknown",
+] as const;
+
+export type ChallengeFailureCategory = (typeof FAILURE_CATEGORIES)[number];
+
+type CorrectiveIssueTemplate = {
+  title: string;
+  description: string;
+};
+
+function getErrorMessage(runError: unknown): string {
+  if (runError instanceof Error) {
+    return runError.message.toLowerCase();
+  }
+
+  if (typeof runError === "string") {
+    return runError.toLowerCase();
+  }
+
+  return "";
+}
+
+function classifyFromErrorMessage(errorMessage: string): ChallengeFailureCategory {
+  if (!errorMessage) {
+    return "execution_failure";
+  }
+
+  if (/(\bpr\b|pull request|branch|commit|push|merge|workflow|github api)/i.test(errorMessage)) {
+    return "workflow_failure";
+  }
+
+  return "execution_failure";
+}
+
+export function classifyChallengeFailure(
+  runError: unknown,
+  runResult: CodingAgentRunResult | null,
+): ChallengeFailureCategory {
+  if (runResult?.summary.failedValidationCommands.length) {
+    return "validation_failure";
+  }
+
+  if (runError !== null && runError !== undefined) {
+    return classifyFromErrorMessage(getErrorMessage(runError));
+  }
+
+  if (runResult && runResult.summary.reviewOutcome === "amended") {
+    if (runResult.summary.editedFiles.length === 0) {
+      return "scope_control_failure";
+    }
+
+    return "unknown";
+  }
+
+  return "unknown";
+}
+
+function buildCommonChallengeReference(challengeIssueNumber: number, category: ChallengeFailureCategory): string {
+  return [
+    `Relates-to-Challenge: #${challengeIssueNumber}`,
+    `Challenge-Failure-Category: ${category}`,
+  ].join("\n");
+}
+
+function buildTemplatesForCategory(category: ChallengeFailureCategory): CorrectiveIssueTemplate[] {
+  switch (category) {
+    case "validation_failure":
+      return [
+        {
+          title: "Harden challenge validation repair loop for failing checks",
+          description:
+            "Improve amendment/retry handling after failed validation commands, including clearer failure triage and deterministic repair steps.",
+        },
+        {
+          title: "Add regression tests for challenge validation failure recovery",
+          description:
+            "Cover validation-failure challenge attempts with tests to ensure retries, diagnostics, and outcomes stay reliable.",
+        },
+      ];
+    case "workflow_failure":
+      return [
+        {
+          title: "Harden GitHub workflow failure recovery in challenge runs",
+          description:
+            "Improve resilience and diagnostics for branch/commit/push/PR/merge failures that interrupt challenge execution.",
+        },
+        {
+          title: "Add tests for challenge workflow failure classification and handling",
+          description:
+            "Add focused tests that verify workflow-related errors are classified correctly and trigger bounded corrective actions.",
+        },
+      ];
+    case "execution_failure":
+      return [
+        {
+          title: "Improve runtime exception handling for challenge execution failures",
+          description:
+            "Strengthen error handling paths so runtime failures produce actionable diagnostics and predictable follow-up behavior.",
+        },
+      ];
+    case "scope_control_failure":
+      return [
+        {
+          title: "Tighten challenge scope control when execution yields no bounded diff",
+          description:
+            "Improve checks and remediation for challenge attempts that fail to produce focused, relevant repository changes.",
+        },
+        {
+          title: "Add scope-control regression coverage for challenge attempt outcomes",
+          description:
+            "Add tests for boundedness checks and off-task handling so challenge retries remain focused and reviewable.",
+        },
+      ];
+    default:
+      return [
+        {
+          title: "Improve challenge failure diagnostics for unclassified outcomes",
+          description:
+            "Add structured logging and tighter failure evidence capture to reduce unknown challenge failure classifications.",
+        },
+      ];
+  }
+}
+
+function withChallengeContext(
+  templates: CorrectiveIssueTemplate[],
+  challengeIssueNumber: number,
+  category: ChallengeFailureCategory,
+): CorrectiveIssueTemplate[] {
+  const challengeReference = buildCommonChallengeReference(challengeIssueNumber, category);
+
+  return templates.slice(0, 3).map((template) => ({
+    title: template.title,
+    description: `${template.description}\n\n${challengeReference}`,
+  }));
+}
+
+export async function createCorrectiveIssuesForChallengeFailure(
+  issueManager: TaskIssueManager,
+  challengeIssueNumber: number,
+  category: ChallengeFailureCategory,
+): Promise<IssueSummary[]> {
+  const created: IssueSummary[] = [];
+  const templates = withChallengeContext(buildTemplatesForCategory(category), challengeIssueNumber, category);
+
+  for (const template of templates) {
+    const result = await issueManager.createIssue(template.title, template.description);
+    if (result.ok && result.issue) {
+      created.push(result.issue);
+    }
+  }
+
+  return created;
+}
+
+export function buildChallengeFailureLearningComment(options: {
+  challengeIssueNumber: number;
+  category: ChallengeFailureCategory;
+  correctiveIssues: IssueSummary[];
+}): string {
+  const lines = [
+    "## Challenge Failure Learning",
+    `- Challenge issue: #${options.challengeIssueNumber}`,
+    `- Failure classification: \`${options.category}\``,
+  ];
+
+  if (options.correctiveIssues.length === 0) {
+    lines.push("- Corrective issues generated: none");
+    return lines.join("\n");
+  }
+
+  lines.push(`- Corrective issues generated: ${options.correctiveIssues.length}`);
+  for (const issue of options.correctiveIssues) {
+    lines.push(`- #${issue.number} ${issue.title}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -16,6 +16,7 @@ const formatChallengeMetricsReportMock = vi.fn();
 const evaluateChallengeRetryEligibilityMock = vi.fn();
 const recordChallengeAttemptOutcomeMock = vi.fn();
 const updateLabelsMock = vi.fn();
+const createIssueMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -94,6 +95,7 @@ vi.mock("./issues/taskIssueManager.js", () => ({
     closeIssue = closeIssueMock;
     replenishSelfImprovementIssues = replenishSelfImprovementIssuesMock;
     updateLabels = updateLabelsMock;
+    createIssue = createIssueMock;
   },
 }));
 
@@ -152,6 +154,12 @@ describe("main", () => {
     recordChallengeAttemptOutcomeMock.mockResolvedValue({ failuresByChallenge: {} });
     updateLabelsMock.mockReset();
     updateLabelsMock.mockResolvedValue({ ok: true, message: "labels updated" });
+    createIssueMock.mockReset();
+    createIssueMock.mockResolvedValue({
+      ok: true,
+      message: "Created issue #100.",
+      issue: { number: 100, title: "Generated", description: "body", state: "open", labels: [] },
+    });
     process.argv = ["node", "src/main.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -473,7 +481,7 @@ describe("main", () => {
       success: true,
     });
     expect(updateLabelsMock).toHaveBeenCalledWith(88, {
-      remove: ["challenge:failed", "challenge:ready-to-retry", "challenge:blocked"],
+      remove: ["challenge:failed", "challenge:ready-to-retry", "challenge:blocked", "learning-generated"],
     });
     expect(formatChallengeMetricsReportMock).toHaveBeenCalled();
   });
@@ -492,11 +500,21 @@ describe("main", () => {
     expect(recordChallengeAttemptMetricsMock).toHaveBeenCalledWith("/tmp/evolvo", {
       challengeIssueNumber: 89,
       success: false,
-      failureCategory: "execution_error",
+      failureCategory: "execution_failure",
     });
     expect(updateLabelsMock).toHaveBeenCalledWith(89, {
       add: ["challenge:failed"],
       remove: ["challenge:ready-to-retry", "challenge:blocked"],
+    });
+    expect(createIssueMock).toHaveBeenCalled();
+    expect(createIssueMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("Relates-to-Challenge: #89"),
+    );
+    expect(addProgressCommentMock).toHaveBeenCalledWith(89, expect.stringContaining("## Challenge Failure Learning"));
+    expect(addProgressCommentMock).toHaveBeenCalledWith(89, expect.stringContaining("Failure classification: `execution_failure`"));
+    expect(updateLabelsMock).toHaveBeenCalledWith(89, {
+      add: ["learning-generated"],
     });
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,12 @@ import {
   recordChallengeAttemptOutcome,
   type ChallengeRetryDecision,
 } from "./challenges/retryGate.js";
+import {
+  buildChallengeFailureLearningComment,
+  CHALLENGE_LEARNING_GENERATED_LABEL,
+  classifyChallengeFailure,
+  createCorrectiveIssuesForChallengeFailure,
+} from "./challenges/challengeFailureLearning.js";
 import type { CodingAgentRunResult, CommandExecutionSummary } from "./agents/runCodingAgent.js";
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
@@ -64,29 +70,6 @@ function isChallengeIssue(issue: IssueSummary): boolean {
   return hasLabel(issue, "challenge");
 }
 
-function classifyChallengeFailure(
-  runError: unknown,
-  runResult: CodingAgentRunResult | null,
-): string {
-  if (runError) {
-    return "execution_error";
-  }
-
-  if (!runResult) {
-    return "unknown";
-  }
-
-  if (runResult.summary.failedValidationCommands.length > 0) {
-    return "validation_failure";
-  }
-
-  if (runResult.summary.reviewOutcome === "amended") {
-    return "review_rejection";
-  }
-
-  return "unknown";
-}
-
 async function updateChallengeMetrics(
   issueManager: TaskIssueManager,
   issue: IssueSummary,
@@ -114,7 +97,12 @@ async function updateChallengeMetrics(
     const failureAttempts = retryState.failuresByChallenge[String(issue.number)]?.attempts ?? 0;
     const labelUpdate = success
       ? await issueManager.updateLabels(issue.number, {
-          remove: [CHALLENGE_FAILED_LABEL, CHALLENGE_READY_TO_RETRY_LABEL, CHALLENGE_BLOCKED_LABEL],
+          remove: [
+            CHALLENGE_FAILED_LABEL,
+            CHALLENGE_READY_TO_RETRY_LABEL,
+            CHALLENGE_BLOCKED_LABEL,
+            CHALLENGE_LEARNING_GENERATED_LABEL,
+          ],
         })
       : await issueManager.updateLabels(issue.number, {
           add: failureAttempts >= CHALLENGE_MAX_ATTEMPTS
@@ -126,6 +114,32 @@ async function updateChallengeMetrics(
         });
     if (!labelUpdate.ok) {
       console.error(`Could not update challenge retry labels for issue #${issue.number}: ${labelUpdate.message}`);
+    }
+
+    if (!success && failureCategory) {
+      const correctiveIssues = await createCorrectiveIssuesForChallengeFailure(
+        issueManager,
+        issue.number,
+        failureCategory,
+      );
+      const learningComment = buildChallengeFailureLearningComment({
+        challengeIssueNumber: issue.number,
+        category: failureCategory,
+        correctiveIssues,
+      });
+      const commentResult = await issueManager.addProgressComment(issue.number, learningComment);
+      if (!commentResult.ok) {
+        console.error(`Could not add challenge learning comment for issue #${issue.number}: ${commentResult.message}`);
+      }
+
+      if (correctiveIssues.length > 0) {
+        const learningLabelUpdate = await issueManager.updateLabels(issue.number, {
+          add: [CHALLENGE_LEARNING_GENERATED_LABEL],
+        });
+        if (!learningLabelUpdate.ok) {
+          console.error(`Could not set learning label for issue #${issue.number}: ${learningLabelUpdate.message}`);
+        }
+      }
     }
 
     console.log(formatChallengeMetricsReport(metrics));


### PR DESCRIPTION
## Summary
- add a challenge failure taxonomy and classifier module
- map failure categories to bounded corrective issue templates
- on challenge failure, create corrective issues linked via `Relates-to-Challenge`, comment classification + generated links on challenge issue, and apply `learning-generated` when creation succeeds
- add tests for classification mapping and issue-generation linkage behavior

## Validation
- pnpm validate

Closes #46