### PR TITLE
feat(challenges): persist challenge attempt artifacts and evidence

### DIFF
--- a/src/challenges/challengeAttemptArtifacts.test.ts
+++ b/src/challenges/challengeAttemptArtifacts.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { persistChallengeAttemptArtifact } from "./challengeAttemptArtifacts.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "challenge-attempt-artifacts-"));
+}
+
+describe("challengeAttemptArtifacts", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it("writes a deterministic failure artifact with runtime error fields", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const persisted = await persistChallengeAttemptArtifact(workDir, {
+      challengeIssueNumber: 45,
+      runResult: null,
+      runError: new Error("execution exploded"),
+      nowMs: 1_700_000_000_000,
+    });
+
+    expect(persisted.relativePath).toBe(".evolvo/challenge-attempts/45/0001.json");
+    expect(persisted.artifact).toEqual({
+      schemaVersion: 1,
+      challengeIssueNumber: 45,
+      attempt: 1,
+      attemptedAtMs: 1_700_000_000_000,
+      attemptedAtIso: "2023-11-14T22:13:20.000Z",
+      outcome: "failure",
+      executionSummary: {
+        reviewOutcome: null,
+        pullRequestCreated: false,
+        mergedPullRequest: false,
+        inspectedAreas: [],
+        editedFiles: [],
+        validationCommands: [],
+        failedValidationCommands: [],
+        finalResponseExcerpt: null,
+      },
+      runtimeError: {
+        name: "Error",
+        message: "execution exploded",
+        stackPreview: expect.any(String),
+      },
+    });
+  });
+
+  it("writes a success artifact with execution summary fields and null runtime error", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const persisted = await persistChallengeAttemptArtifact(workDir, {
+      challengeIssueNumber: 45,
+      runResult: {
+        mergedPullRequest: true,
+        summary: {
+          inspectedAreas: ["src/main.ts"],
+          editedFiles: ["src/challenges/challengeAttemptArtifacts.ts"],
+          validationCommands: [{ command: "pnpm test", exitCode: 0, durationMs: 210 }],
+          failedValidationCommands: [],
+          reviewOutcome: "accepted",
+          pullRequestCreated: true,
+          externalRepositories: [],
+          externalPullRequests: [],
+          mergedExternalPullRequest: false,
+          finalResponse: "Implemented and validated.",
+        },
+      },
+      runError: null,
+      nowMs: 1_700_000_000_001,
+    });
+
+    expect(persisted.relativePath).toBe(".evolvo/challenge-attempts/45/0001.json");
+    expect(persisted.artifact.outcome).toBe("success");
+    expect(persisted.artifact.runtimeError).toBeNull();
+    expect(persisted.artifact.executionSummary).toEqual({
+      reviewOutcome: "accepted",
+      pullRequestCreated: true,
+      mergedPullRequest: true,
+      inspectedAreas: ["src/main.ts"],
+      editedFiles: ["src/challenges/challengeAttemptArtifacts.ts"],
+      validationCommands: [{ command: "pnpm test", exitCode: 0, durationMs: 210 }],
+      failedValidationCommands: [],
+      finalResponseExcerpt: "Implemented and validated.",
+    });
+  });
+
+  it("increments attempt numbering per challenge and preserves schema on disk", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await persistChallengeAttemptArtifact(workDir, {
+      challengeIssueNumber: 91,
+      runResult: null,
+      runError: new Error("first"),
+      nowMs: 100,
+    });
+    const second = await persistChallengeAttemptArtifact(workDir, {
+      challengeIssueNumber: 91,
+      runResult: null,
+      runError: new Error("second"),
+      nowMs: 101,
+    });
+
+    expect(second.relativePath).toBe(".evolvo/challenge-attempts/91/0002.json");
+
+    const raw = await readFile(join(workDir, second.relativePath), "utf8");
+    const parsed = JSON.parse(raw) as {
+      schemaVersion: number;
+      challengeIssueNumber: number;
+      attempt: number;
+      outcome: string;
+      runtimeError: { name: string; message: string; stackPreview: string | null } | null;
+    };
+
+    expect(parsed).toEqual(expect.objectContaining({
+      schemaVersion: 1,
+      challengeIssueNumber: 91,
+      attempt: 2,
+      outcome: "failure",
+    }));
+    expect(parsed.runtimeError).toEqual(expect.objectContaining({ message: "second" }));
+  });
+});

--- a/src/challenges/challengeAttemptArtifacts.ts
+++ b/src/challenges/challengeAttemptArtifacts.ts
@@ -1,0 +1,183 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import type { CodingAgentRunResult, CommandExecutionSummary } from "../agents/runCodingAgent.js";
+
+const EVOLVO_DIRECTORY_NAME = ".evolvo";
+const CHALLENGE_ATTEMPTS_DIRECTORY_NAME = "challenge-attempts";
+const ARTIFACT_SCHEMA_VERSION = 1;
+const MAX_FINAL_RESPONSE_EXCERPT_LENGTH = 280;
+
+export type ChallengeAttemptArtifact = {
+  schemaVersion: 1;
+  challengeIssueNumber: number;
+  attempt: number;
+  attemptedAtMs: number;
+  attemptedAtIso: string;
+  outcome: "success" | "failure";
+  executionSummary: {
+    reviewOutcome: string | null;
+    pullRequestCreated: boolean;
+    mergedPullRequest: boolean;
+    inspectedAreas: string[];
+    editedFiles: string[];
+    validationCommands: CommandExecutionSummary[];
+    failedValidationCommands: CommandExecutionSummary[];
+    finalResponseExcerpt: string | null;
+  };
+  runtimeError: {
+    name: string;
+    message: string;
+    stackPreview: string | null;
+  } | null;
+};
+
+export type PersistChallengeAttemptArtifactInput = {
+  challengeIssueNumber: number;
+  runResult: CodingAgentRunResult | null;
+  runError: unknown;
+  nowMs?: number;
+};
+
+export type PersistChallengeAttemptArtifactResult = {
+  artifact: ChallengeAttemptArtifact;
+  relativePath: string;
+  absolutePath: string;
+};
+
+function toFiniteNonNegativeInteger(value: unknown): number {
+  const numericValue = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numericValue) || numericValue < 0) {
+    return 0;
+  }
+
+  return Math.floor(numericValue);
+}
+
+function formatAttemptFileName(attempt: number): string {
+  return `${String(attempt).padStart(4, "0")}.json`;
+}
+
+function normalizeCommand(command: CommandExecutionSummary): CommandExecutionSummary {
+  return {
+    command: String(command.command),
+    exitCode: typeof command.exitCode === "number" ? Math.floor(command.exitCode) : null,
+    durationMs: typeof command.durationMs === "number" && Number.isFinite(command.durationMs)
+      ? Math.max(0, command.durationMs)
+      : null,
+  };
+}
+
+function summarizeRuntimeError(runError: unknown): ChallengeAttemptArtifact["runtimeError"] {
+  if (runError === null || runError === undefined) {
+    return null;
+  }
+
+  if (runError instanceof Error) {
+    const stackPreview = typeof runError.stack === "string" && runError.stack.trim().length > 0
+      ? runError.stack.split("\n").slice(0, 3).join("\n")
+      : null;
+    return {
+      name: runError.name || "Error",
+      message: runError.message || "Unknown error.",
+      stackPreview,
+    };
+  }
+
+  return {
+    name: "NonErrorThrownValue",
+    message: String(runError),
+    stackPreview: null,
+  };
+}
+
+function summarizeFinalResponse(response: string): string | null {
+  const normalized = response.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.length <= MAX_FINAL_RESPONSE_EXCERPT_LENGTH) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, MAX_FINAL_RESPONSE_EXCERPT_LENGTH - 3)}...`;
+}
+
+function buildExecutionSummary(runResult: CodingAgentRunResult | null): ChallengeAttemptArtifact["executionSummary"] {
+  if (!runResult) {
+    return {
+      reviewOutcome: null,
+      pullRequestCreated: false,
+      mergedPullRequest: false,
+      inspectedAreas: [],
+      editedFiles: [],
+      validationCommands: [],
+      failedValidationCommands: [],
+      finalResponseExcerpt: null,
+    };
+  }
+
+  return {
+    reviewOutcome: runResult.summary.reviewOutcome,
+    pullRequestCreated: runResult.summary.pullRequestCreated,
+    mergedPullRequest: runResult.mergedPullRequest,
+    inspectedAreas: [...runResult.summary.inspectedAreas],
+    editedFiles: [...runResult.summary.editedFiles],
+    validationCommands: runResult.summary.validationCommands.map(normalizeCommand),
+    failedValidationCommands: runResult.summary.failedValidationCommands.map(normalizeCommand),
+    finalResponseExcerpt: summarizeFinalResponse(runResult.summary.finalResponse),
+  };
+}
+
+function getChallengeAttemptDirectory(workDir: string, challengeIssueNumber: number): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, CHALLENGE_ATTEMPTS_DIRECTORY_NAME, String(challengeIssueNumber));
+}
+
+async function getNextAttemptNumber(attemptDirectoryPath: string): Promise<number> {
+  const entries = await fs.readdir(attemptDirectoryPath, { withFileTypes: true });
+  const attempts = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => {
+      const match = entry.name.match(/^(\d+)\.json$/);
+      if (!match?.[1]) {
+        return 0;
+      }
+
+      return toFiniteNonNegativeInteger(match[1]);
+    })
+    .filter((value) => value > 0);
+
+  if (attempts.length === 0) {
+    return 1;
+  }
+
+  return Math.max(...attempts) + 1;
+}
+
+export async function persistChallengeAttemptArtifact(
+  workDir: string,
+  input: PersistChallengeAttemptArtifactInput,
+): Promise<PersistChallengeAttemptArtifactResult> {
+  const challengeIssueNumber = Math.max(1, toFiniteNonNegativeInteger(input.challengeIssueNumber));
+  const nowMs = toFiniteNonNegativeInteger(input.nowMs ?? Date.now());
+  const attemptDirectoryPath = getChallengeAttemptDirectory(workDir, challengeIssueNumber);
+  await fs.mkdir(attemptDirectoryPath, { recursive: true });
+  const attempt = await getNextAttemptNumber(attemptDirectoryPath);
+  const artifactFileName = formatAttemptFileName(attempt);
+  const relativePath = `${EVOLVO_DIRECTORY_NAME}/${CHALLENGE_ATTEMPTS_DIRECTORY_NAME}/${challengeIssueNumber}/${artifactFileName}`;
+  const absolutePath = join(attemptDirectoryPath, artifactFileName);
+  const success = input.runError === null && input.runResult !== null && input.runResult.summary.reviewOutcome === "accepted";
+  const artifact: ChallengeAttemptArtifact = {
+    schemaVersion: ARTIFACT_SCHEMA_VERSION,
+    challengeIssueNumber,
+    attempt,
+    attemptedAtMs: nowMs,
+    attemptedAtIso: new Date(nowMs).toISOString(),
+    outcome: success ? "success" : "failure",
+    executionSummary: buildExecutionSummary(input.runResult),
+    runtimeError: summarizeRuntimeError(input.runError),
+  };
+
+  await fs.writeFile(absolutePath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  return { artifact, relativePath, absolutePath };
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -15,6 +15,7 @@ const recordChallengeAttemptMetricsMock = vi.fn();
 const formatChallengeMetricsReportMock = vi.fn();
 const evaluateChallengeRetryEligibilityMock = vi.fn();
 const recordChallengeAttemptOutcomeMock = vi.fn();
+const persistChallengeAttemptArtifactMock = vi.fn();
 const updateLabelsMock = vi.fn();
 const createIssueMock = vi.fn();
 
@@ -66,6 +67,10 @@ vi.mock("./challenges/retryGate.js", () => ({
   CHALLENGE_READY_TO_RETRY_LABEL: "challenge:ready-to-retry",
   evaluateChallengeRetryEligibility: evaluateChallengeRetryEligibilityMock,
   recordChallengeAttemptOutcome: recordChallengeAttemptOutcomeMock,
+}));
+
+vi.mock("./challenges/challengeAttemptArtifacts.js", () => ({
+  persistChallengeAttemptArtifact: persistChallengeAttemptArtifactMock,
 }));
 
 vi.mock("./issues/runIssueCommand.js", () => ({
@@ -152,6 +157,19 @@ describe("main", () => {
     });
     recordChallengeAttemptOutcomeMock.mockReset();
     recordChallengeAttemptOutcomeMock.mockResolvedValue({ failuresByChallenge: {} });
+    persistChallengeAttemptArtifactMock.mockReset();
+    persistChallengeAttemptArtifactMock.mockResolvedValue({
+      relativePath: ".evolvo/challenge-attempts/88/0001.json",
+      absolutePath: "/tmp/evolvo/.evolvo/challenge-attempts/88/0001.json",
+      artifact: {
+        attempt: 1,
+        outcome: "success",
+        executionSummary: {
+          reviewOutcome: "accepted",
+        },
+        runtimeError: null,
+      },
+    });
     updateLabelsMock.mockReset();
     updateLabelsMock.mockResolvedValue({ ok: true, message: "labels updated" });
     createIssueMock.mockReset();
@@ -198,6 +216,7 @@ describe("main", () => {
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Execution Log"));
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #12: Fix login redirect\n\nHandle callback URL.");
     expect(recordChallengeAttemptMetricsMock).not.toHaveBeenCalled();
+    expect(persistChallengeAttemptArtifactMock).not.toHaveBeenCalled();
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith(
       expect.objectContaining({ minimumIssueCount: 3, maximumOpenIssues: 5 }),
     );
@@ -455,6 +474,7 @@ describe("main", () => {
   });
 
   it("records challenge metrics for accepted challenge attempts", async () => {
+    process.argv = ["node", "test-runner.ts"];
     listOpenIssuesMock
       .mockResolvedValueOnce([
         { number: 88, title: "Challenge pass", description: "solve", state: "open", labels: ["challenge"] },
@@ -471,6 +491,13 @@ describe("main", () => {
 
     await main();
 
+    expect(persistChallengeAttemptArtifactMock).toHaveBeenCalledWith("/tmp/evolvo", {
+      challengeIssueNumber: 88,
+      runResult: expect.objectContaining({
+        summary: expect.objectContaining({ reviewOutcome: "accepted" }),
+      }),
+      runError: null,
+    });
     expect(recordChallengeAttemptMetricsMock).toHaveBeenCalledWith("/tmp/evolvo", {
       challengeIssueNumber: 88,
       success: true,
@@ -484,19 +511,44 @@ describe("main", () => {
       remove: ["challenge:failed", "challenge:ready-to-retry", "challenge:blocked", "learning-generated"],
     });
     expect(formatChallengeMetricsReportMock).toHaveBeenCalled();
+    expect(addProgressCommentMock).toHaveBeenCalledWith(88, expect.stringContaining("### Challenge Attempt Artifact"));
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      88,
+      expect.stringContaining("`.evolvo/challenge-attempts/88/0001.json`"),
+    );
   });
 
   it("records challenge metrics for challenge runtime failures", async () => {
+    process.argv = ["node", "test-runner.ts"];
     listOpenIssuesMock
       .mockResolvedValueOnce([
         { number: 89, title: "Challenge fail", description: "break", state: "open", labels: ["challenge"] },
       ])
       .mockResolvedValueOnce([]);
     runCodingAgentMock.mockRejectedValueOnce(new Error("run blew up"));
+    persistChallengeAttemptArtifactMock.mockResolvedValueOnce({
+      relativePath: ".evolvo/challenge-attempts/89/0002.json",
+      absolutePath: "/tmp/evolvo/.evolvo/challenge-attempts/89/0002.json",
+      artifact: {
+        attempt: 2,
+        outcome: "failure",
+        executionSummary: {
+          reviewOutcome: null,
+        },
+        runtimeError: {
+          message: "run blew up",
+        },
+      },
+    });
     const { main } = await import("./main.js");
 
     await main();
 
+    expect(persistChallengeAttemptArtifactMock).toHaveBeenCalledWith("/tmp/evolvo", {
+      challengeIssueNumber: 89,
+      runResult: null,
+      runError: expect.any(Error),
+    });
     expect(recordChallengeAttemptMetricsMock).toHaveBeenCalledWith("/tmp/evolvo", {
       challengeIssueNumber: 89,
       success: false,
@@ -513,6 +565,11 @@ describe("main", () => {
     );
     expect(addProgressCommentMock).toHaveBeenCalledWith(89, expect.stringContaining("## Challenge Failure Learning"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(89, expect.stringContaining("Failure classification: `execution_failure`"));
+    expect(addProgressCommentMock).toHaveBeenCalledWith(89, expect.stringContaining("### Challenge Attempt Artifact"));
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      89,
+      expect.stringContaining("`.evolvo/challenge-attempts/89/0002.json`"),
+    );
     expect(updateLabelsMock).toHaveBeenCalledWith(89, {
       add: ["learning-generated"],
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
   classifyChallengeFailure,
   createCorrectiveIssuesForChallengeFailure,
 } from "./challenges/challengeFailureLearning.js";
+import { persistChallengeAttemptArtifact } from "./challenges/challengeAttemptArtifacts.js";
 import type { CodingAgentRunResult, CommandExecutionSummary } from "./agents/runCodingAgent.js";
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
@@ -273,7 +274,79 @@ function buildIssueStartComment(issue: IssueSummary): string {
   ].join("\n");
 }
 
-function buildIssueExecutionComment(issue: IssueSummary, result: CodingAgentRunResult): string {
+type ChallengeAttemptEvidence = {
+  artifactPath: string;
+  attempt: number;
+  outcome: "success" | "failure";
+  reviewOutcome: string | null;
+  runtimeErrorMessage: string | null;
+};
+
+function buildChallengeEvidenceCommentLines(evidence: ChallengeAttemptEvidence | null): string[] {
+  if (!evidence) {
+    return [
+      "",
+      "### Challenge Attempt Artifact",
+      "- Artifact path: (capture failed)",
+      "- Attempt: unknown",
+    ];
+  }
+
+  return [
+    "",
+    "### Challenge Attempt Artifact",
+    `- Artifact path: \`${evidence.artifactPath}\``,
+    `- Attempt: ${evidence.attempt}`,
+    `- Outcome: ${evidence.outcome}`,
+    `- Review outcome: ${evidence.reviewOutcome ?? "unknown"}`,
+    `- Runtime error message: ${evidence.runtimeErrorMessage ?? "none"}`,
+  ];
+}
+
+async function persistChallengeAttemptEvidence(
+  issue: IssueSummary,
+  runError: unknown,
+  runResult: CodingAgentRunResult | null,
+): Promise<ChallengeAttemptEvidence | null> {
+  if (!isChallengeIssue(issue)) {
+    return null;
+  }
+
+  try {
+    const persisted = await persistChallengeAttemptArtifact(WORK_DIR, {
+      challengeIssueNumber: issue.number,
+      runResult,
+      runError,
+    });
+    const reviewOutcome = persisted.artifact.executionSummary &&
+      typeof persisted.artifact.executionSummary.reviewOutcome === "string"
+      ? persisted.artifact.executionSummary.reviewOutcome
+      : null;
+    const outcome = persisted.artifact.outcome === "success" ? "success" : "failure";
+    const attempt = Number.isFinite(persisted.artifact.attempt) ? Math.max(1, Math.floor(persisted.artifact.attempt)) : 1;
+    return {
+      artifactPath: persisted.relativePath,
+      attempt,
+      outcome,
+      reviewOutcome,
+      runtimeErrorMessage: persisted.artifact.runtimeError?.message ?? null,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Could not persist challenge attempt artifact for issue #${issue.number}: ${error.message}`);
+      return null;
+    }
+
+    console.error(`Could not persist challenge attempt artifact for issue #${issue.number}: unknown error.`);
+    return null;
+  }
+}
+
+function buildIssueExecutionComment(
+  issue: IssueSummary,
+  result: CodingAgentRunResult,
+  challengeEvidence: ChallengeAttemptEvidence | null,
+): string {
   const inspectedAreas = result.summary.inspectedAreas.length > 0
     ? result.summary.inspectedAreas.map((area) => `- \`${area}\``)
     : ["- No explicit file/area inspection commands were captured."];
@@ -294,6 +367,7 @@ function buildIssueExecutionComment(issue: IssueSummary, result: CodingAgentRunR
     ? result.summary.externalPullRequests.map((url) => `- ${url}`)
     : ["- No external pull request link captured."];
   const externalMergeLine = `- External pull request merged: ${result.summary.mergedExternalPullRequest ? "yes" : "no"}.`;
+  const challengeEvidenceLines = isChallengeIssue(issue) ? buildChallengeEvidenceCommentLines(challengeEvidence) : [];
 
   return [
     "## Task Execution Log",
@@ -320,6 +394,7 @@ function buildIssueExecutionComment(issue: IssueSummary, result: CodingAgentRunR
     "#### External Pull Request",
     ...externalPullRequestLines,
     externalMergeLine,
+    ...challengeEvidenceLines,
     "",
     "### Completion Summary",
     `- Issue #${issue.number} execution cycle finished with outcome: ${result.summary.reviewOutcome}.`,
@@ -327,12 +402,18 @@ function buildIssueExecutionComment(issue: IssueSummary, result: CodingAgentRunR
   ].join("\n");
 }
 
-function buildIssueFailureComment(issue: IssueSummary, error: unknown): string {
+function buildIssueFailureComment(
+  issue: IssueSummary,
+  error: unknown,
+  challengeEvidence: ChallengeAttemptEvidence | null,
+): string {
   const message = error instanceof Error ? error.message : "Unknown runtime error.";
+  const challengeEvidenceLines = isChallengeIssue(issue) ? buildChallengeEvidenceCommentLines(challengeEvidence) : [];
   return [
     "## Task Execution Problem",
     `- Issue #${issue.number} hit an execution error: ${message}`,
     "- Action: run interrupted; follow-up retry/amendment is required.",
+    ...challengeEvidenceLines,
   ].join("\n");
 }
 
@@ -493,14 +574,24 @@ export async function main(): Promise<void> {
       });
 
       if (runError) {
+        const challengeEvidence = await persistChallengeAttemptEvidence(selectedIssue, runError, runResult);
         await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
-        await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueFailureComment(selectedIssue, runError));
+        await addIssueLifecycleComment(
+          issueManager,
+          selectedIssue.number,
+          buildIssueFailureComment(selectedIssue, runError, challengeEvidence),
+        );
         continue;
       }
 
       if (runResult) {
+        const challengeEvidence = await persistChallengeAttemptEvidence(selectedIssue, runError, runResult);
         await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
-        await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueExecutionComment(selectedIssue, runResult));
+        await addIssueLifecycleComment(
+          issueManager,
+          selectedIssue.number,
+          buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence),
+        );
       }
 
       if (runResult?.mergedPullRequest) {


### PR DESCRIPTION
## Summary
- add challenge attempt artifact persistence under `.evolvo/challenge-attempts/<issue>/<attempt>.json`
- persist deterministic JSON schema with execution summary and runtime error fields
- include challenge artifact evidence in lifecycle comments for success and failure attempts
- add tests for schema shape, per-attempt persistence behavior, and lifecycle evidence wiring

## Validation
- pnpm test -- src/main.test.ts src/challenges/challengeAttemptArtifacts.test.ts
- pnpm typecheck

Closes #45
