### PR TITLE
feat(issues): introduce challenge typing and runtime priority selection

### DIFF
--- a/src/challenges/retryGate.test.ts
+++ b/src/challenges/retryGate.test.ts
@@ -79,6 +79,24 @@ describe("retryGate", () => {
     });
   });
 
+  it("treats metadata-marked issues as challenge issues", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const issue = createIssue({
+      labels: ["bug"],
+      description: "<!-- evolvo:challenge\nid: challenge-101\n-->",
+    });
+
+    const decision = await evaluateChallengeRetryEligibility(workDir, issue, [issue], {
+      maxAttempts: 3,
+      cooldownMs: 60_000,
+      nowMs: 1_000,
+    });
+
+    expect(decision.reason).toBe("first-attempt");
+    expect(decision.eligible).toBe(true);
+  });
+
   it("rejects retry when corrective issues are still open", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);

--- a/src/challenges/retryGate.ts
+++ b/src/challenges/retryGate.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
+import { hasIssueLabel, isChallengeIssue } from "../issues/challengeIssue.js";
 import type { IssueSummary } from "../issues/taskIssueManager.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
@@ -80,14 +81,6 @@ function normalizeRetryState(state: unknown): ChallengeRetryState {
   return { failuresByChallenge };
 }
 
-function hasLabel(issue: IssueSummary, label: string): boolean {
-  return issue.labels.some((existing) => existing.toLowerCase() === label.toLowerCase());
-}
-
-function isChallengeIssue(issue: IssueSummary): boolean {
-  return hasLabel(issue, "challenge");
-}
-
 function getRetryStatePath(workDir: string): string {
   return join(workDir, EVOLVO_DIRECTORY_NAME, CHALLENGE_RETRY_STATE_FILE_NAME);
 }
@@ -105,7 +98,7 @@ function parseCorrectiveChallengeLink(description: string): number | null {
 function getManagedLabelChanges(issue: IssueSummary, addLabels: string[]): { addLabels: string[]; removeLabels: string[] } {
   const addSet = new Set(addLabels.map((label) => label.toLowerCase()));
   const removeLabels = MANAGED_CHALLENGE_RETRY_LABELS
-    .filter((label) => !addSet.has(label.toLowerCase()) && hasLabel(issue, label));
+    .filter((label) => !addSet.has(label.toLowerCase()) && hasIssueLabel(issue, label));
   const existingLowerCase = new Set(issue.labels.map((label) => label.toLowerCase()));
   const dedupedAddLabels = addLabels.filter((label) => !existingLowerCase.has(label.toLowerCase()));
 
@@ -187,7 +180,7 @@ export async function evaluateChallengeRetryEligibility(
   const state = await readChallengeRetryState(workDir);
   const retryEntry = state.failuresByChallenge[String(issue.number)];
   const attemptCount = toFiniteNonNegativeInteger(retryEntry?.attempts);
-  const blockedLabelPresent = hasLabel(issue, CHALLENGE_BLOCKED_LABEL);
+  const blockedLabelPresent = hasIssueLabel(issue, CHALLENGE_BLOCKED_LABEL);
 
   if (blockedLabelPresent) {
     return {
@@ -200,7 +193,7 @@ export async function evaluateChallengeRetryEligibility(
     };
   }
 
-  const failedLabelPresent = hasLabel(issue, CHALLENGE_FAILED_LABEL) || attemptCount > 0;
+  const failedLabelPresent = hasIssueLabel(issue, CHALLENGE_FAILED_LABEL) || attemptCount > 0;
   if (!failedLabelPresent) {
     return {
       eligible: true,

--- a/src/issues/challengeIssue.test.ts
+++ b/src/issues/challengeIssue.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { IssueSummary } from "./taskIssueManager.js";
+import {
+  hasIssueLabel,
+  isChallengeInProgressIssue,
+  isChallengeIssue,
+  isChallengeRetryReadyIssue,
+  parseChallengeIssueMetadata,
+} from "./challengeIssue.js";
+
+function createIssue(overrides: Partial<IssueSummary> = {}): IssueSummary {
+  return {
+    number: 1,
+    title: "Issue",
+    description: "Description",
+    state: "open",
+    labels: [],
+    ...overrides,
+  };
+}
+
+describe("challengeIssue", () => {
+  it("matches labels case-insensitively", () => {
+    const issue = createIssue({ labels: ["Challenge:Ready-To-Retry"] });
+    expect(hasIssueLabel(issue, "challenge:ready-to-retry")).toBe(true);
+  });
+
+  it("parses challenge metadata block from issue description", () => {
+    const metadata = parseChallengeIssueMetadata([
+      "Some text",
+      "<!-- evolvo:challenge",
+      "id: challenge-44",
+      "source_issue: #44",
+      "retry_policy: gated",
+      "-->",
+      "More text",
+    ].join("\n"));
+
+    expect(metadata).toEqual({
+      id: "challenge-44",
+      source_issue: "#44",
+      retry_policy: "gated",
+    });
+  });
+
+  it("recognizes challenge issues by metadata when challenge label is missing", () => {
+    const issue = createIssue({
+      labels: ["bug"],
+      description: [
+        "<!-- evolvo:challenge",
+        "id: challenge-44",
+        "-->",
+      ].join("\n"),
+    });
+
+    expect(isChallengeIssue(issue)).toBe(true);
+  });
+
+  it("recognizes retry-ready and in-progress challenge predicates", () => {
+    const issue = createIssue({
+      labels: ["challenge:ready-to-retry", "in progress"],
+      description: "<!-- evolvo:challenge -->",
+    });
+
+    expect(isChallengeRetryReadyIssue(issue)).toBe(true);
+    expect(isChallengeInProgressIssue(issue)).toBe(true);
+  });
+
+  it("returns false for non-challenge issues", () => {
+    const issue = createIssue({ labels: ["enhancement"] });
+    expect(isChallengeIssue(issue)).toBe(false);
+    expect(isChallengeRetryReadyIssue(issue)).toBe(false);
+    expect(isChallengeInProgressIssue(issue)).toBe(false);
+  });
+});

--- a/src/issues/challengeIssue.ts
+++ b/src/issues/challengeIssue.ts
@@ -1,0 +1,64 @@
+import type { IssueSummary } from "./taskIssueManager.js";
+
+export const IN_PROGRESS_LABEL = "in progress";
+export const CHALLENGE_LABEL = "challenge";
+export const CHALLENGE_FAILED_LABEL = "challenge:failed";
+export const CHALLENGE_READY_TO_RETRY_LABEL = "challenge:ready-to-retry";
+export const CHALLENGE_BLOCKED_LABEL = "challenge:blocked";
+
+export type ChallengeIssueMetadata = {
+  id?: string;
+  source_issue?: string;
+  retry_policy?: string;
+  [key: string]: string | undefined;
+};
+
+export function hasIssueLabel(issue: IssueSummary, label: string): boolean {
+  return issue.labels.some((currentLabel) => currentLabel.toLowerCase() === label.toLowerCase());
+}
+
+export function parseChallengeIssueMetadata(description: string): ChallengeIssueMetadata | null {
+  const match = description.match(/<!--\s*evolvo:challenge([\s\S]*?)-->/i);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const metadata: ChallengeIssueMetadata = {};
+  const lines = match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex < 1 || separatorIndex >= line.length - 1) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim().toLowerCase();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (!key || !value) {
+      continue;
+    }
+
+    metadata[key] = value;
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : {};
+}
+
+export function isChallengeIssue(issue: IssueSummary): boolean {
+  if (hasIssueLabel(issue, CHALLENGE_LABEL)) {
+    return true;
+  }
+
+  return parseChallengeIssueMetadata(issue.description) !== null;
+}
+
+export function isChallengeRetryReadyIssue(issue: IssueSummary): boolean {
+  return isChallengeIssue(issue) && hasIssueLabel(issue, CHALLENGE_READY_TO_RETRY_LABEL);
+}
+
+export function isChallengeInProgressIssue(issue: IssueSummary): boolean {
+  return isChallengeIssue(issue) && hasIssueLabel(issue, IN_PROGRESS_LABEL);
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -237,6 +237,65 @@ describe("main", () => {
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #9: B\n\nB");
   });
 
+  it("prioritizes challenge first-attempt issues over self-improvement issues", async () => {
+    process.argv = ["node", "test-runner.ts"];
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 14, title: "Self task", description: "normal", state: "open", labels: ["in progress"] },
+        { number: 15, title: "Challenge task", description: "challenge", state: "open", labels: ["challenge"] },
+      ])
+      .mockResolvedValueOnce([]);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #15: Challenge task\n\nchallenge");
+  });
+
+  it("prioritizes retry-ready challenge issues over other challenge issues", async () => {
+    process.argv = ["node", "test-runner.ts"];
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 16, title: "Challenge first", description: "first", state: "open", labels: ["challenge"] },
+        {
+          number: 17,
+          title: "Challenge retry",
+          description: "retry",
+          state: "open",
+          labels: ["challenge", "challenge:ready-to-retry"],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #17: Challenge retry\n\nretry");
+  });
+
+  it("detects challenge issues from metadata and prioritizes them", async () => {
+    process.argv = ["node", "test-runner.ts"];
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 18, title: "Self task", description: "normal", state: "open", labels: ["in progress"] },
+        {
+          number: 19,
+          title: "Metadata challenge",
+          description: "<!-- evolvo:challenge\nid: challenge-19\n-->",
+          state: "open",
+          labels: [],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).toHaveBeenCalledWith(
+      "Issue #19: Metadata challenge\n\n<!-- evolvo:challenge\nid: challenge-19\n-->",
+    );
+  });
+
   it("continues to the next issue after a run completes", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,12 @@ import { runIssueCommand } from "./issues/runIssueCommand.js";
 import { getGitHubConfig } from "./github/githubConfig.js";
 import { GitHubApiError, GitHubClient } from "./github/githubClient.js";
 import { TaskIssueManager, type IssueSummary } from "./issues/taskIssueManager.js";
+import {
+  hasIssueLabel,
+  isChallengeInProgressIssue,
+  isChallengeIssue,
+  isChallengeRetryReadyIssue,
+} from "./issues/challengeIssue.js";
 import { generateStartupIssueTemplates } from "./issues/startupIssueBootstrap.js";
 import {
   formatChallengeMetricsReport,
@@ -38,20 +44,29 @@ const MAX_OPEN_ISSUES = 5;
 const CHALLENGE_MAX_ATTEMPTS = 3;
 const CHALLENGE_RETRY_COOLDOWN_MS = 60 * 60 * 1000;
 
-function hasLabel(issue: IssueSummary, label: string): boolean {
-  return issue.labels.some((currentLabel) => currentLabel.toLowerCase() === label.toLowerCase());
-}
-
 function selectIssueForWork(issues: IssueSummary[]): IssueSummary | null {
-  const notCompleted = issues.filter((issue) => !hasLabel(issue, "completed"));
+  const notCompleted = issues.filter((issue) => !hasIssueLabel(issue, "completed"));
   if (notCompleted.length === 0) {
     return null;
   }
 
-  const candidates = notCompleted;
-  const inProgress = candidates.find((issue) => hasLabel(issue, "in progress"));
+  const challengeCandidates = notCompleted.filter((issue) => isChallengeIssue(issue));
+  if (challengeCandidates.length > 0) {
+    const inProgressChallenge = challengeCandidates.find((issue) => isChallengeInProgressIssue(issue));
+    if (inProgressChallenge) {
+      return inProgressChallenge;
+    }
 
-  return inProgress ?? candidates[0] ?? null;
+    const retryReadyChallenge = challengeCandidates.find((issue) => isChallengeRetryReadyIssue(issue));
+    if (retryReadyChallenge) {
+      return retryReadyChallenge;
+    }
+
+    return challengeCandidates[0] ?? null;
+  }
+
+  const inProgress = notCompleted.find((issue) => hasIssueLabel(issue, "in progress"));
+  return inProgress ?? notCompleted[0] ?? null;
 }
 
 function isOutdatedIssue(issue: IssueSummary): boolean {
@@ -65,10 +80,6 @@ function buildPromptFromIssue(issue: IssueSummary): string {
 
 function formatIssueForLog(issue: IssueSummary): string {
   return `#${issue.number} ${issue.title}`;
-}
-
-function isChallengeIssue(issue: IssueSummary): boolean {
-  return hasLabel(issue, "challenge");
 }
 
 async function updateChallengeMetrics(
@@ -554,7 +565,7 @@ export async function main(): Promise<void> {
         return;
       }
 
-      if (!hasLabel(selectedIssue, "in progress")) {
+      if (!hasIssueLabel(selectedIssue, "in progress")) {
         const result = await issueManager.markInProgress(selectedIssue.number);
         if (!result.ok) {
           console.error(`Could not mark issue #${selectedIssue.number} as in progress: ${result.message}`);


### PR DESCRIPTION
## Summary
- add issue-model challenge helpers for labels and body metadata parsing
- classify issues as challenge or self-improvement via shared predicates
- update runtime selection order to prioritize: challenge in-progress, challenge retry-ready, then first-attempt challenge
- preserve prior self-improvement selection behavior when no challenge issues exist
- wire retry gate challenge detection to shared issue-model helpers

## Validation
- pnpm test -- src/issues/challengeIssue.test.ts src/challenges/retryGate.test.ts src/main.test.ts
- pnpm typecheck

Closes #44
