### PR TITLE
feat(run-loop): emit per-cycle queue health logs

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -215,6 +215,7 @@ describe("main", () => {
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Start"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Execution Log"));
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #12: Fix login redirect\n\nHandle callback URL.");
+    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=1 selected=#12");
     expect(recordChallengeAttemptMetricsMock).not.toHaveBeenCalled();
     expect(persistChallengeAttemptArtifactMock).not.toHaveBeenCalled();
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith(
@@ -378,6 +379,7 @@ describe("main", () => {
       ],
     });
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #19: Generated\n\ngenerated");
+    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:1");
     expect(console.log).toHaveBeenCalledWith(
       "No open issues found on startup. Bootstrapped issue queue from repository analysis.",
     );
@@ -403,6 +405,7 @@ describe("main", () => {
         { title: "Startup issue 3", description: "from repo analysis" },
       ],
     });
+    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
   });
 
@@ -453,6 +456,7 @@ describe("main", () => {
     expect(runCodingAgentMock).not.toHaveBeenCalled();
     expect(markInProgressMock).not.toHaveBeenCalled();
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
+    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=1 selected=none queueAction=replenish:0");
   });
 
   it("falls back cleanly when GitHub credentials are invalid", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,19 @@ function formatIssueForLog(issue: IssueSummary): string {
   return `#${issue.number} ${issue.title}`;
 }
 
+function logCycleQueueHealth(options: {
+  cycle: number;
+  openCount: number;
+  selectedIssue: IssueSummary | null;
+  queueActionOutcome?: string;
+}): void {
+  const selectedIssueLog = options.selectedIssue ? `#${options.selectedIssue.number}` : "none";
+  const queueActionSuffix = options.queueActionOutcome ? ` queueAction=${options.queueActionOutcome}` : "";
+  console.log(
+    `Cycle ${options.cycle} queue health: open=${options.openCount} selected=${selectedIssueLog}${queueActionSuffix}`,
+  );
+}
+
 async function updateChallengeMetrics(
   issueManager: TaskIssueManager,
   issue: IssueSummary,
@@ -548,6 +561,13 @@ export async function main(): Promise<void> {
                 maximumOpenIssues: MAX_OPEN_ISSUES,
               })
             ).created;
+        const queueActionOutcome = `${isStartupBootstrap ? "bootstrap" : "replenish"}:${createdIssues.length}`;
+        logCycleQueueHealth({
+          cycle,
+          openCount: openIssues.length,
+          selectedIssue: null,
+          queueActionOutcome,
+        });
 
         if (createdIssues.length > 0) {
           if (isStartupBootstrap) {
@@ -564,6 +584,12 @@ export async function main(): Promise<void> {
         }
         return;
       }
+
+      logCycleQueueHealth({
+        cycle,
+        openCount: openIssues.length,
+        selectedIssue,
+      });
 
       if (!hasIssueLabel(selectedIssue, "in progress")) {
         const result = await issueManager.markInProgress(selectedIssue.number);


### PR DESCRIPTION
## Summary
- add a per-cycle queue health summary log in the main issue loop
- include open issue count and selected issue in the summary
- include bootstrap/replenishment outcomes when no issue is selected
- add regression assertions in main loop tests for queue health log output

## Validation
- pnpm vitest run src/main.test.ts
- pnpm test
- pnpm typecheck

Closes #58