### PR TITLE
fix(validation-reporting): include command name in validation lifecycle logs

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -223,6 +223,31 @@ describe("main", () => {
     );
   });
 
+  it("logs validation command name, status, and elapsed time in lifecycle comments", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 13, title: "Validation detail", description: "Check logs", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    runCodingAgentMock.mockResolvedValueOnce({
+      ...DEFAULT_RUN_RESULT,
+      summary: {
+        ...DEFAULT_RUN_RESULT.summary,
+        validationCommands: [{ command: "pnpm validate", exitCode: 1, durationMs: 321 }],
+        failedValidationCommands: [{ command: "pnpm validate", exitCode: 1, durationMs: 321 }],
+        reviewOutcome: "amended",
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      13,
+      expect.stringContaining("`pnpm validate` (name=pnpm, status=1, elapsed=321ms)"),
+    );
+  });
+
   it("prefers an issue already in progress", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,9 +262,14 @@ function formatDuration(durationMs: number | null): string {
   return `${Math.round(durationMs)}ms`;
 }
 
+function getCommandName(command: string): string {
+  const [commandName] = command.trim().split(/\s+/, 1);
+  return commandName || "unknown";
+}
+
 function formatValidationCommand(command: CommandExecutionSummary): string {
   const exitCode = command.exitCode === null ? "unknown" : String(command.exitCode);
-  return `- \`${command.command}\` (exit=${exitCode}, duration=${formatDuration(command.durationMs)})`;
+  return `- \`${command.command}\` (name=${getCommandName(command.command)}, status=${exitCode}, elapsed=${formatDuration(command.durationMs)})`;
 }
 
 function summarizeRetryNotes(result: CodingAgentRunResult): string {


### PR DESCRIPTION
## Summary
- include command name in validation lines emitted to lifecycle comments
- keep exit status and elapsed time in the same line for failed-run triage
- add regression test for the lifecycle validation format

## Validation
- pnpm validate

Closes #61