### PR TITLE
fix(startup): harden bootstrap failure diagnostics

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -430,6 +430,7 @@ describe("main", () => {
         { title: "Startup issue 3", description: "from repo analysis" },
       ],
     });
+    expect(console.error).toHaveBeenCalledWith("Startup bootstrap created 0 issues from 3 repository-derived template(s).");
     expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
   });
@@ -450,8 +451,27 @@ describe("main", () => {
     await main();
 
     expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
+    expect(console.error).toHaveBeenCalledWith("Startup issue bootstrap is falling back to default issue templates.");
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #30: Fallback issue\n\nfallback");
+  });
+
+  it("logs actionable startup diagnostics when fallback issue creation also fails", async () => {
+    generateStartupIssueTemplatesMock.mockRejectedValueOnce(new Error("analysis boom"));
+    replenishSelfImprovementIssuesMock.mockRejectedValueOnce(new Error("issue create denied"));
+    const { DEFAULT_PROMPT, main } = await import("./main.js");
+
+    await main();
+
+    expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
+    expect(console.error).toHaveBeenCalledWith("Startup issue bootstrap is falling back to default issue templates.");
+    expect(console.error).toHaveBeenCalledWith("Startup fallback issue creation failed: issue create denied");
+    expect(console.error).toHaveBeenCalledWith(
+      "Startup issue queue remains empty. Recovery: verify GitHub token permissions and repository issue settings, then rerun.",
+    );
+    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
+    expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
   });
 
   it("closes outdated issues before selecting work", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -483,13 +483,20 @@ function logCreatedIssues(issues: IssueSummary[]): void {
 }
 
 async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<IssueSummary[]> {
+  const targetCount = MIN_REPLENISH_ISSUES;
   try {
-    const templates = await generateStartupIssueTemplates(WORK_DIR, { targetCount: MIN_REPLENISH_ISSUES });
+    const templates = await generateStartupIssueTemplates(WORK_DIR, { targetCount });
     const replenishment = await issueManager.replenishSelfImprovementIssues({
-      minimumIssueCount: MIN_REPLENISH_ISSUES,
+      minimumIssueCount: targetCount,
       maximumOpenIssues: MAX_OPEN_ISSUES,
       templates,
     });
+
+    if (replenishment.created.length === 0) {
+      console.error(
+        `Startup bootstrap created 0 issues from ${templates.length} repository-derived template(s).`,
+      );
+    }
 
     return replenishment.created;
   } catch (error) {
@@ -499,12 +506,33 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
       console.error("Startup repository analysis failed with an unknown error.");
     }
 
-    const replenishment = await issueManager.replenishSelfImprovementIssues({
-      minimumIssueCount: MIN_REPLENISH_ISSUES,
-      maximumOpenIssues: MAX_OPEN_ISSUES,
-    });
+    console.error("Startup issue bootstrap is falling back to default issue templates.");
 
-    return replenishment.created;
+    try {
+      const replenishment = await issueManager.replenishSelfImprovementIssues({
+        minimumIssueCount: targetCount,
+        maximumOpenIssues: MAX_OPEN_ISSUES,
+      });
+
+      if (replenishment.created.length === 0) {
+        console.error(
+          "Startup fallback issue creation created 0 issues. Recovery: verify issue creation permissions and rerun.",
+        );
+      }
+
+      return replenishment.created;
+    } catch (fallbackError) {
+      if (fallbackError instanceof Error) {
+        console.error(`Startup fallback issue creation failed: ${fallbackError.message}`);
+      } else {
+        console.error("Startup fallback issue creation failed with an unknown error.");
+      }
+
+      console.error(
+        "Startup issue queue remains empty. Recovery: verify GitHub token permissions and repository issue settings, then rerun.",
+      );
+      return [];
+    }
   }
 }
 


### PR DESCRIPTION
## Summary\n- add explicit startup bootstrap diagnostics when repository-derived templates produce zero created issues\n- add fallback-path diagnostics when repository analysis fails and default template creation is attempted\n- add recovery guidance when fallback creation fails so empty-queue startup is easier to debug\n- add/adjust unit coverage for zero-created and fallback-failure startup paths\n\n## Validation\n- pnpm vitest run src/main.test.ts\n- pnpm vitest run src/main.replenishment.integration.test.ts\n\nCloses #56