### PR TITLE
fix: harden startup bootstrap empty-queue diagnostics

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -431,6 +431,10 @@ describe("main", () => {
       ],
     });
     expect(console.error).toHaveBeenCalledWith("Startup bootstrap created 0 issues from 3 repository-derived template(s).");
+    expect(console.error).toHaveBeenCalledWith("Startup repository-derived bootstrap created 0 issues. Issue queue remains empty.");
+    expect(console.error).toHaveBeenCalledWith(
+      "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
+    );
     expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
   });
@@ -466,8 +470,27 @@ describe("main", () => {
     expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
     expect(console.error).toHaveBeenCalledWith("Startup issue bootstrap is falling back to default issue templates.");
     expect(console.error).toHaveBeenCalledWith("Startup fallback issue creation failed: issue create denied");
+    expect(console.error).toHaveBeenCalledWith("Startup fallback bootstrap created 0 issues. Issue queue remains empty.");
     expect(console.error).toHaveBeenCalledWith(
-      "Startup issue queue remains empty. Recovery: verify GitHub token permissions and repository issue settings, then rerun.",
+      "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
+    );
+    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
+    expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("logs actionable startup diagnostics when fallback issue creation returns no issues", async () => {
+    generateStartupIssueTemplatesMock.mockRejectedValueOnce(new Error("analysis boom"));
+    replenishSelfImprovementIssuesMock.mockResolvedValueOnce({ created: [] });
+    const { DEFAULT_PROMPT, main } = await import("./main.js");
+
+    await main();
+
+    expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
+    expect(console.error).toHaveBeenCalledWith("Startup issue bootstrap is falling back to default issue templates.");
+    expect(console.error).toHaveBeenCalledWith("Startup fallback bootstrap created 0 issues. Issue queue remains empty.");
+    expect(console.error).toHaveBeenCalledWith(
+      "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
     );
     expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);

--- a/src/main.ts
+++ b/src/main.ts
@@ -482,6 +482,13 @@ function logCreatedIssues(issues: IssueSummary[]): void {
   console.log(`Created ${issues.length} self-improvement issue(s): ${issueList}.`);
 }
 
+function logStartupBootstrapRecoveryGuidance(context: "repository-derived bootstrap" | "fallback bootstrap"): void {
+  console.error(`Startup ${context} created 0 issues. Issue queue remains empty.`);
+  console.error(
+    "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
+  );
+}
+
 async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<IssueSummary[]> {
   const targetCount = MIN_REPLENISH_ISSUES;
   try {
@@ -496,6 +503,7 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
       console.error(
         `Startup bootstrap created 0 issues from ${templates.length} repository-derived template(s).`,
       );
+      logStartupBootstrapRecoveryGuidance("repository-derived bootstrap");
     }
 
     return replenishment.created;
@@ -515,9 +523,7 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
       });
 
       if (replenishment.created.length === 0) {
-        console.error(
-          "Startup fallback issue creation created 0 issues. Recovery: verify issue creation permissions and rerun.",
-        );
+        logStartupBootstrapRecoveryGuidance("fallback bootstrap");
       }
 
       return replenishment.created;
@@ -528,9 +534,7 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
         console.error("Startup fallback issue creation failed with an unknown error.");
       }
 
-      console.error(
-        "Startup issue queue remains empty. Recovery: verify GitHub token permissions and repository issue settings, then rerun.",
-      );
+      logStartupBootstrapRecoveryGuidance("fallback bootstrap");
       return [];
     }
   }


### PR DESCRIPTION
## Summary\n- add shared startup bootstrap recovery diagnostics with explicit empty-queue messaging\n- emit recovery guidance for repository-derived bootstrap zero-create path and fallback zero-create path\n- add regression coverage for fallback returning zero created issues without throwing\n\n## Validation\n- pnpm validate\n\nRefs #56