### PR TITLE
fix: harden startup diagnostics for bootstrap creation failures

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -433,6 +433,9 @@ describe("main", () => {
     expect(console.error).toHaveBeenCalledWith("Startup bootstrap created 0 issues from 3 repository-derived template(s).");
     expect(console.error).toHaveBeenCalledWith("Startup repository-derived bootstrap created 0 issues. Issue queue remains empty.");
     expect(console.error).toHaveBeenCalledWith(
+      "Startup bootstrap diagnostics: context=repository-derived bootstrap targetCount=3 templateCount=3 createdCount=0.",
+    );
+    expect(console.error).toHaveBeenCalledWith(
       "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
     );
     expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
@@ -455,7 +458,9 @@ describe("main", () => {
     await main();
 
     expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
-    expect(console.error).toHaveBeenCalledWith("Startup issue bootstrap is falling back to default issue templates.");
+    expect(console.error).toHaveBeenCalledWith(
+      "Startup issue bootstrap is falling back to default issue templates (targetCount=3).",
+    );
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #30: Fallback issue\n\nfallback");
   });
@@ -468,9 +473,14 @@ describe("main", () => {
     await main();
 
     expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
-    expect(console.error).toHaveBeenCalledWith("Startup issue bootstrap is falling back to default issue templates.");
+    expect(console.error).toHaveBeenCalledWith(
+      "Startup issue bootstrap is falling back to default issue templates (targetCount=3).",
+    );
     expect(console.error).toHaveBeenCalledWith("Startup fallback issue creation failed: issue create denied");
     expect(console.error).toHaveBeenCalledWith("Startup fallback bootstrap created 0 issues. Issue queue remains empty.");
+    expect(console.error).toHaveBeenCalledWith(
+      "Startup bootstrap diagnostics: context=fallback bootstrap targetCount=3 templateCount=default createdCount=0.",
+    );
     expect(console.error).toHaveBeenCalledWith(
       "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
     );
@@ -487,8 +497,13 @@ describe("main", () => {
     await main();
 
     expect(console.error).toHaveBeenCalledWith("Startup repository analysis failed: analysis boom");
-    expect(console.error).toHaveBeenCalledWith("Startup issue bootstrap is falling back to default issue templates.");
+    expect(console.error).toHaveBeenCalledWith(
+      "Startup issue bootstrap is falling back to default issue templates (targetCount=3).",
+    );
     expect(console.error).toHaveBeenCalledWith("Startup fallback bootstrap created 0 issues. Issue queue remains empty.");
+    expect(console.error).toHaveBeenCalledWith(
+      "Startup bootstrap diagnostics: context=fallback bootstrap targetCount=3 templateCount=default createdCount=0.",
+    );
     expect(console.error).toHaveBeenCalledWith(
       "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -482,8 +482,18 @@ function logCreatedIssues(issues: IssueSummary[]): void {
   console.log(`Created ${issues.length} self-improvement issue(s): ${issueList}.`);
 }
 
-function logStartupBootstrapRecoveryGuidance(context: "repository-derived bootstrap" | "fallback bootstrap"): void {
-  console.error(`Startup ${context} created 0 issues. Issue queue remains empty.`);
+type StartupBootstrapRecoveryContext = {
+  context: "repository-derived bootstrap" | "fallback bootstrap";
+  targetCount: number;
+  templateCount: number | "default";
+  createdCount: number;
+};
+
+function logStartupBootstrapRecoveryGuidance(context: StartupBootstrapRecoveryContext): void {
+  console.error(`Startup ${context.context} created 0 issues. Issue queue remains empty.`);
+  console.error(
+    `Startup bootstrap diagnostics: context=${context.context} targetCount=${context.targetCount} templateCount=${context.templateCount} createdCount=${context.createdCount}.`,
+  );
   console.error(
     "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
   );
@@ -503,7 +513,12 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
       console.error(
         `Startup bootstrap created 0 issues from ${templates.length} repository-derived template(s).`,
       );
-      logStartupBootstrapRecoveryGuidance("repository-derived bootstrap");
+      logStartupBootstrapRecoveryGuidance({
+        context: "repository-derived bootstrap",
+        targetCount,
+        templateCount: templates.length,
+        createdCount: replenishment.created.length,
+      });
     }
 
     return replenishment.created;
@@ -514,7 +529,7 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
       console.error("Startup repository analysis failed with an unknown error.");
     }
 
-    console.error("Startup issue bootstrap is falling back to default issue templates.");
+    console.error(`Startup issue bootstrap is falling back to default issue templates (targetCount=${targetCount}).`);
 
     try {
       const replenishment = await issueManager.replenishSelfImprovementIssues({
@@ -523,7 +538,12 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
       });
 
       if (replenishment.created.length === 0) {
-        logStartupBootstrapRecoveryGuidance("fallback bootstrap");
+        logStartupBootstrapRecoveryGuidance({
+          context: "fallback bootstrap",
+          targetCount,
+          templateCount: "default",
+          createdCount: replenishment.created.length,
+        });
       }
 
       return replenishment.created;
@@ -534,7 +554,12 @@ async function bootstrapStartupIssues(issueManager: TaskIssueManager): Promise<I
         console.error("Startup fallback issue creation failed with an unknown error.");
       }
 
-      logStartupBootstrapRecoveryGuidance("fallback bootstrap");
+      logStartupBootstrapRecoveryGuidance({
+        context: "fallback bootstrap",
+        targetCount,
+        templateCount: "default",
+        createdCount: 0,
+      });
       return [];
     }
   }


### PR DESCRIPTION
## Summary
- add structured startup bootstrap diagnostics when queue creation yields zero issues
- include target count in fallback notice so recovery context is explicit
- extend startup bootstrap tests to assert the new diagnostic signals

## Validation
- pnpm vitest run src/main.test.ts
- pnpm vitest run src/main.replenishment.integration.test.ts

Closes #56