### PR TITLE
fix(issue-logs): prevent duplicate task start lifecycle comments

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -260,6 +260,8 @@ describe("main", () => {
     await main();
 
     expect(markInProgressMock).not.toHaveBeenCalled();
+    expect(addProgressCommentMock).not.toHaveBeenCalledWith(9, expect.stringContaining("## Task Start"));
+    expect(addProgressCommentMock).toHaveBeenCalledWith(9, expect.stringContaining("## Task Execution Log"));
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #9: B\n\nB");
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -680,14 +680,19 @@ export async function main(): Promise<void> {
           selectedIssue,
         });
 
+        let startedThisCycle = false;
         if (!hasIssueLabel(selectedIssue, "in progress")) {
           const result = await issueManager.markInProgress(selectedIssue.number);
           if (!result.ok) {
             console.error(`Could not mark issue #${selectedIssue.number} as in progress: ${result.message}`);
+          } else {
+            startedThisCycle = true;
           }
         }
 
-        await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue));
+        if (startedThisCycle) {
+          await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue));
+        }
 
         const prompt = buildPromptFromIssue(selectedIssue);
         console.log(`Prompt: ${prompt}`);


### PR DESCRIPTION
## Summary
- only add the `Task Start` lifecycle comment when an issue is newly transitioned to `in progress` in the current cycle
- keep execution logging unchanged for already in-progress issues
- add regression coverage for the already in-progress selection path

## Validation
- pnpm vitest src/main.test.ts

Closes #72