### PR TITLE
fix(validation): persist command metadata in validation summaries

### DIFF
--- a/src/agents/runCodingAgent.ts
+++ b/src/agents/runCodingAgent.ts
@@ -25,6 +25,7 @@ type CommandExecutionLogDetails = {
 
 export type CommandExecutionSummary = {
   command: string;
+  commandName: string;
   exitCode: number | null;
   durationMs: number | null;
 };
@@ -318,6 +319,7 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
       if (event.item.type === "command_execution" && VALIDATION_COMMAND_PATTERN.test(event.item.command)) {
         const commandSummary: CommandExecutionSummary = {
           command: event.item.command,
+          commandName: getCommandName(event.item.command),
           exitCode: event.item.exit_code ?? null,
           durationMs: getCommandDurationMs(event.item.id, commandStartTimes),
         };

--- a/src/challenges/challengeAttemptArtifacts.test.ts
+++ b/src/challenges/challengeAttemptArtifacts.test.ts
@@ -64,7 +64,7 @@ describe("challengeAttemptArtifacts", () => {
         summary: {
           inspectedAreas: ["src/main.ts"],
           editedFiles: ["src/challenges/challengeAttemptArtifacts.ts"],
-          validationCommands: [{ command: "pnpm test", exitCode: 0, durationMs: 210 }],
+          validationCommands: [{ command: "pnpm test", commandName: "pnpm", exitCode: 0, durationMs: 210 }],
           failedValidationCommands: [],
           reviewOutcome: "accepted",
           pullRequestCreated: true,
@@ -87,7 +87,7 @@ describe("challengeAttemptArtifacts", () => {
       mergedPullRequest: true,
       inspectedAreas: ["src/main.ts"],
       editedFiles: ["src/challenges/challengeAttemptArtifacts.ts"],
-      validationCommands: [{ command: "pnpm test", exitCode: 0, durationMs: 210 }],
+      validationCommands: [{ command: "pnpm test", commandName: "pnpm", exitCode: 0, durationMs: 210 }],
       failedValidationCommands: [],
       finalResponseExcerpt: "Implemented and validated.",
     });

--- a/src/challenges/challengeAttemptArtifacts.ts
+++ b/src/challenges/challengeAttemptArtifacts.ts
@@ -58,8 +58,12 @@ function formatAttemptFileName(attempt: number): string {
 }
 
 function normalizeCommand(command: CommandExecutionSummary): CommandExecutionSummary {
+  const commandName = typeof command.commandName === "string" && command.commandName.trim().length > 0
+    ? command.commandName
+    : String(command.command).trim().split(/\s+/, 1)[0] || "unknown";
   return {
     command: String(command.command),
+    commandName,
     exitCode: typeof command.exitCode === "number" ? Math.floor(command.exitCode) : null,
     durationMs: typeof command.durationMs === "number" && Number.isFinite(command.durationMs)
       ? Math.max(0, command.durationMs)

--- a/src/challenges/challengeFailureLearning.test.ts
+++ b/src/challenges/challengeFailureLearning.test.ts
@@ -30,7 +30,7 @@ describe("challengeFailureLearning", () => {
     const category = classifyChallengeFailure(
       null,
       createRunResult({
-        failedValidationCommands: [{ command: "pnpm test", exitCode: 1, durationMs: 100 }],
+        failedValidationCommands: [{ command: "pnpm test", commandName: "pnpm", exitCode: 1, durationMs: 100 }],
         reviewOutcome: "amended",
       }),
     );

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -233,8 +233,8 @@ describe("main", () => {
       ...DEFAULT_RUN_RESULT,
       summary: {
         ...DEFAULT_RUN_RESULT.summary,
-        validationCommands: [{ command: "pnpm validate", exitCode: 1, durationMs: 321 }],
-        failedValidationCommands: [{ command: "pnpm validate", exitCode: 1, durationMs: 321 }],
+        validationCommands: [{ command: "pnpm validate", commandName: "pnpm", exitCode: 1, durationMs: 321 }],
+        failedValidationCommands: [{ command: "pnpm validate", commandName: "pnpm", exitCode: 1, durationMs: 321 }],
         reviewOutcome: "amended",
       },
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -271,8 +271,11 @@ function getCommandName(command: string): string {
 }
 
 function formatValidationCommand(command: CommandExecutionSummary): string {
+  const commandName = typeof command.commandName === "string" && command.commandName.trim().length > 0
+    ? command.commandName
+    : getCommandName(command.command);
   const exitCode = command.exitCode === null ? "unknown" : String(command.exitCode);
-  return `- \`${command.command}\` (name=${getCommandName(command.command)}, status=${exitCode}, elapsed=${formatDuration(command.durationMs)})`;
+  return `- \`${command.command}\` (name=${commandName}, status=${exitCode}, elapsed=${formatDuration(command.durationMs)})`;
 }
 
 function summarizeRetryNotes(result: CodingAgentRunResult): string {


### PR DESCRIPTION
## Summary
- capture and persist explicit validation command names alongside command, exit status, and duration
- use stored command name in lifecycle validation formatting with fallback for backward compatibility
- update artifact and lifecycle tests to cover the structured command metadata path

## Validation
- pnpm -s validate

Closes #79