### PR TITLE
fix(run-loop): harden transient GitHub retry handling (follow-up 2)

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -687,6 +687,48 @@ describe("main", () => {
     expect(runCodingAgentMock).not.toHaveBeenCalled();
   });
 
+  it("retries transient GitHub rate-limit failures and recovers", async () => {
+    process.argv = ["node", "test-runner.ts"];
+    listOpenIssuesMock
+      .mockRejectedValueOnce(
+        new GitHubApiError(
+          "GitHub API request failed (403): API rate limit exceeded for user",
+          403,
+          { message: "API rate limit exceeded for user." },
+        ),
+      )
+      .mockResolvedValueOnce([
+        { number: 59, title: "Rate limit recovery", description: "retry 403", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(listOpenIssuesMock).toHaveBeenCalledTimes(3);
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #59: Rate limit recovery\n\nretry 403");
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Transient GitHub issue sync failure on cycle 1 (attempt 1/2). Retrying in 50ms."),
+    );
+  });
+
+  it("does not retry non-transient GitHub 403 failures", async () => {
+    process.argv = ["node", "test-runner.ts"];
+    listOpenIssuesMock.mockRejectedValue(
+      new GitHubApiError("GitHub API request failed (403): Resource not accessible by integration", 403, null),
+    );
+    const { DEFAULT_PROMPT, main } = await import("./main.js");
+
+    await main();
+
+    expect(listOpenIssuesMock).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      "GitHub issue sync unavailable: GitHub API request failed (403): Resource not accessible by integration",
+    );
+    expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+  });
+
   it("adds a lifecycle issue comment when agent execution fails", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ const CHALLENGE_MAX_ATTEMPTS = 3;
 const CHALLENGE_RETRY_COOLDOWN_MS = 60 * 60 * 1000;
 const RUN_LOOP_GITHUB_MAX_RETRIES = 2;
 const RUN_LOOP_GITHUB_RETRY_BASE_DELAY_MS = 50;
+const RUN_LOOP_GITHUB_RETRY_MAX_DELAY_MS = 1_000;
 const RUN_LOOP_TRANSIENT_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
 
 function selectIssueForWork(issues: IssueSummary[]): IssueSummary | null {
@@ -586,6 +587,10 @@ function logGitHubFallback(error: unknown): void {
 
 function isTransientGitHubError(error: unknown): boolean {
   if (error instanceof GitHubApiError) {
+    if (isGitHubRateLimitError(error)) {
+      return true;
+    }
+
     return RUN_LOOP_TRANSIENT_STATUS_CODES.has(error.status);
   }
 
@@ -598,6 +603,26 @@ function isTransientGitHubError(error: unknown): boolean {
   }
 
   return false;
+}
+
+function isGitHubRateLimitError(error: GitHubApiError): boolean {
+  if (error.status !== 403) {
+    return false;
+  }
+
+  if (typeof error.responseBody === "object" && error.responseBody !== null && "message" in error.responseBody) {
+    const message = (error.responseBody as { message?: unknown }).message;
+    if (typeof message === "string" && /rate limit/i.test(message)) {
+      return true;
+    }
+  }
+
+  return /rate limit/i.test(error.message);
+}
+
+function getRunLoopRetryDelayMs(retryAttempt: number): number {
+  const exponentialDelay = RUN_LOOP_GITHUB_RETRY_BASE_DELAY_MS * (2 ** Math.max(0, retryAttempt - 1));
+  return Math.min(exponentialDelay, RUN_LOOP_GITHUB_RETRY_MAX_DELAY_MS);
 }
 
 async function waitForRunLoopRetry(delayMs: number): Promise<void> {
@@ -749,7 +774,7 @@ export async function main(): Promise<void> {
       } catch (error) {
         if (isTransientGitHubError(error) && retryAttempt < RUN_LOOP_GITHUB_MAX_RETRIES) {
           retryAttempt += 1;
-          const delayMs = RUN_LOOP_GITHUB_RETRY_BASE_DELAY_MS * retryAttempt;
+          const delayMs = getRunLoopRetryDelayMs(retryAttempt);
           const message = error instanceof Error ? error.message : "unknown error";
           console.error(
             `Transient GitHub issue sync failure on cycle ${cycle} (attempt ${retryAttempt}/${RUN_LOOP_GITHUB_MAX_RETRIES}). Retrying in ${delayMs}ms. Error: ${message}`,


### PR DESCRIPTION
## Summary
- treat GitHub 403 rate-limit responses as transient in the run-loop retry classifier
- keep retry/backoff bounded with a capped delay helper
- add tests for 403 rate-limit recovery and non-transient 403 fallback behavior

## Validation
- pnpm test -- src/main.test.ts

Closes #77