### PR TITLE
feat(run-loop): include per-cycle queue action outcomes

### DIFF
--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -288,7 +288,9 @@ describe("main replenishment integration", () => {
     await main();
 
     expect(mockApiState.createdIssueTitles).toHaveLength(3);
-    expect(console.log).toHaveBeenCalledWith("Cycle 2 queue health: open=0 selected=none queueAction=replenish:3");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 2 queue health: open=0 selected=none queueAction=replenish created=3 outcome=continue",
+    );
     expect(runCodingAgentMock).toHaveBeenCalledTimes(2);
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #10: Initial work item\n\nfirst pass");
     const secondPrompt = runCodingAgentMock.mock.calls[1]?.[0];
@@ -322,7 +324,9 @@ describe("main replenishment integration", () => {
 
     await main();
 
-    expect(console.log).toHaveBeenCalledWith("Cycle 2 queue health: open=0 selected=none queueAction=replenish:3");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 2 queue health: open=0 selected=none queueAction=replenish created=3 outcome=continue",
+    );
     expect(runCodingAgentMock).toHaveBeenCalledTimes(2);
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #10: Initial work item\n\nfirst pass");
     const secondPrompt = runCodingAgentMock.mock.calls[1]?.[0];
@@ -358,7 +362,9 @@ describe("main replenishment integration", () => {
       "Bootstrap issue B",
       "Bootstrap issue C",
     ]);
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:3");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=3 outcome=continue",
+    );
     expect(console.log).toHaveBeenCalledWith(
       "No open issues found on startup. Bootstrapped issue queue from repository analysis.",
     );
@@ -388,7 +394,9 @@ describe("main replenishment integration", () => {
       "Bootstrap issue B",
       "Bootstrap issue C",
     ]);
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:3");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=3 outcome=continue",
+    );
     expect(console.log).toHaveBeenCalledWith("Cycle 2 queue health: open=3 selected=#100");
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(
       1,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -406,7 +406,9 @@ describe("main", () => {
       ],
     });
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #19: Generated\n\ngenerated");
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:1");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=1 outcome=continue",
+    );
     expect(console.log).toHaveBeenCalledWith(
       "No open issues found on startup. Bootstrapped issue queue from repository analysis.",
     );
@@ -440,7 +442,9 @@ describe("main", () => {
     expect(console.error).toHaveBeenCalledWith(
       "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
     );
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=0 outcome=stop",
+    );
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
   });
 
@@ -486,7 +490,9 @@ describe("main", () => {
     expect(console.error).toHaveBeenCalledWith(
       "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
     );
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=0 outcome=stop",
+    );
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
     expect(runCodingAgentMock).not.toHaveBeenCalled();
   });
@@ -509,7 +515,9 @@ describe("main", () => {
     expect(console.error).toHaveBeenCalledWith(
       "Recovery: verify GitHub token permissions and repository issue settings, then run `pnpm dev -- issues list` and create an issue manually if needed.",
     );
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=0 selected=none queueAction=bootstrap:0");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=0 outcome=stop",
+    );
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
     expect(runCodingAgentMock).not.toHaveBeenCalled();
   });
@@ -541,7 +549,9 @@ describe("main", () => {
     expect(runCodingAgentMock).not.toHaveBeenCalled();
     expect(markInProgressMock).not.toHaveBeenCalled();
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=1 selected=none queueAction=replenish:0");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=1 selected=none queueAction=replenish created=0 outcome=stop",
+    );
   });
 
   it("replenishes completed-only queues and processes created issue on the next cycle", async () => {
@@ -563,7 +573,9 @@ describe("main", () => {
 
     expect(generateStartupIssueTemplatesMock).not.toHaveBeenCalled();
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
-    expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=1 selected=none queueAction=replenish:1");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 1 queue health: open=1 selected=none queueAction=replenish created=1 outcome=continue",
+    );
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #24: Generated\n\ngenerated");
   });
 
@@ -586,7 +598,9 @@ describe("main", () => {
     await main();
 
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
-    expect(console.log).toHaveBeenCalledWith("Cycle 2 queue health: open=0 selected=none queueAction=replenish:1");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 2 queue health: open=0 selected=none queueAction=replenish created=1 outcome=continue",
+    );
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #31: Initial\n\nfirst");
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #32: Replenished\n\nsecond");
   });
@@ -618,7 +632,9 @@ describe("main", () => {
     expect(markInProgressMock).toHaveBeenNthCalledWith(2, 42);
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #41: First\n\none");
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #42: Second\n\ntwo");
-    expect(console.log).toHaveBeenCalledWith("Cycle 2 queue health: open=0 selected=none queueAction=replenish:1");
+    expect(console.log).toHaveBeenCalledWith(
+      "Cycle 2 queue health: open=0 selected=none queueAction=replenish created=1 outcome=continue",
+    );
     expect(console.log).not.toHaveBeenCalledWith(DEFAULT_PROMPT);
     const cycleThreeLogIndex = (console.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.findIndex(
       (call) => call[0] === "Cycle 3 queue health: open=1 selected=#42",

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,10 +90,16 @@ function logCycleQueueHealth(options: {
   cycle: number;
   openCount: number;
   selectedIssue: IssueSummary | null;
-  queueActionOutcome?: string;
+  queueAction?: {
+    type: "bootstrap" | "replenish";
+    createdCount: number;
+    outcome: "continue" | "stop";
+  };
 }): void {
   const selectedIssueLog = options.selectedIssue ? `#${options.selectedIssue.number}` : "none";
-  const queueActionSuffix = options.queueActionOutcome ? ` queueAction=${options.queueActionOutcome}` : "";
+  const queueActionSuffix = options.queueAction
+    ? ` queueAction=${options.queueAction.type} created=${options.queueAction.createdCount} outcome=${options.queueAction.outcome}`
+    : "";
   console.log(
     `Cycle ${options.cycle} queue health: open=${options.openCount} selected=${selectedIssueLog}${queueActionSuffix}`,
   );
@@ -678,12 +684,15 @@ export async function main(): Promise<void> {
                   maximumOpenIssues: MAX_OPEN_ISSUES,
                 })
               ).created;
-          const queueActionOutcome = `${isStartupBootstrap ? "bootstrap" : "replenish"}:${createdIssues.length}`;
           logCycleQueueHealth({
             cycle,
             openCount: openIssues.length,
             selectedIssue: null,
-            queueActionOutcome,
+            queueAction: {
+              type: isStartupBootstrap ? "bootstrap" : "replenish",
+              createdCount: createdIssues.length,
+              outcome: createdIssues.length > 0 ? "continue" : "stop",
+            },
           });
 
           if (createdIssues.length > 0) {


### PR DESCRIPTION
## Summary
- make per-cycle queue health logs include explicit queue action fields for bootstrap/replenish paths
- include created issue count and action outcome (`continue` or `stop`) in the same log line
- update unit and replenishment integration tests to assert the new concise format

## Validation
- pnpm vitest run src/main.test.ts src/main.replenishment.integration.test.ts

Closes #76