### PR TITLE
fix(challenges): add terminal completion for successful challenges (#84)

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -6,6 +6,7 @@ const runIssueCommandMock = vi.fn();
 const getGitHubConfigMock = vi.fn();
 const listOpenIssuesMock = vi.fn();
 const markInProgressMock = vi.fn();
+const markCompletedMock = vi.fn();
 const addProgressCommentMock = vi.fn();
 const closeIssueMock = vi.fn();
 const replenishSelfImprovementIssuesMock = vi.fn();
@@ -96,6 +97,7 @@ vi.mock("./issues/taskIssueManager.js", () => ({
   TaskIssueManager: class {
     listOpenIssues = listOpenIssuesMock;
     markInProgress = markInProgressMock;
+    markCompleted = markCompletedMock;
     addProgressComment = addProgressCommentMock;
     closeIssue = closeIssueMock;
     replenishSelfImprovementIssues = replenishSelfImprovementIssuesMock;
@@ -126,6 +128,8 @@ describe("main", () => {
     listOpenIssuesMock.mockResolvedValue([]);
     markInProgressMock.mockReset();
     markInProgressMock.mockResolvedValue({ ok: true, message: "ok" });
+    markCompletedMock.mockReset();
+    markCompletedMock.mockResolvedValue({ ok: true, message: "completed" });
     addProgressCommentMock.mockReset();
     addProgressCommentMock.mockResolvedValue({ ok: true, message: "commented" });
     closeIssueMock.mockReset();
@@ -178,7 +182,7 @@ describe("main", () => {
       message: "Created issue #100.",
       issue: { number: 100, title: "Generated", description: "body", state: "open", labels: [] },
     });
-    process.argv = ["node", "src/main.ts"];
+    process.argv = ["node", "test-runner.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -850,6 +854,36 @@ describe("main", () => {
       88,
       expect.stringContaining("`.evolvo/challenge-attempts/88/0001.json`"),
     );
+    expect(markCompletedMock).toHaveBeenCalledWith(
+      88,
+      expect.stringContaining("## Challenge Completion"),
+    );
+    expect(markCompletedMock).toHaveBeenCalledWith(
+      88,
+      expect.stringContaining("Lifecycle state: terminal success (`completed`)"),
+    );
+  });
+
+  it("does not mark challenge as completed when review outcome is amended", async () => {
+    process.argv = ["node", "test-runner.ts"];
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 92, title: "Challenge amended", description: "needs fixes", state: "open", labels: ["challenge"] },
+      ])
+      .mockResolvedValueOnce([]);
+    runCodingAgentMock.mockResolvedValueOnce({
+      ...DEFAULT_RUN_RESULT,
+      summary: {
+        ...DEFAULT_RUN_RESULT.summary,
+        reviewOutcome: "amended",
+        failedValidationCommands: [{ command: "pnpm validate", commandName: "pnpm", exitCode: 1, durationMs: 120 }],
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(markCompletedMock).not.toHaveBeenCalled();
   });
 
   it("records challenge metrics for challenge runtime failures", async () => {
@@ -968,5 +1002,17 @@ describe("main", () => {
     await main();
 
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #91: Retry allowed\n\nallowed");
+  });
+
+  it("does not evaluate retry gate for completed challenge issues", async () => {
+    listOpenIssuesMock.mockResolvedValue([
+      { number: 93, title: "Done challenge", description: "already done", state: "open", labels: ["challenge", "completed"] },
+    ]);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(evaluateChallengeRetryEligibilityMock).not.toHaveBeenCalled();
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,6 +220,38 @@ function buildChallengeRetryGateComment(issue: IssueSummary, decision: Challenge
   ].join("\n");
 }
 
+function buildChallengeCompletionSummary(issue: IssueSummary, result: CodingAgentRunResult): string {
+  const reviewOutcome = result.summary.reviewOutcome;
+  const validationStatus = result.summary.failedValidationCommands.length === 0 ? "all passed" : "had failures";
+  const mergeStatus = result.mergedPullRequest ? "merged into main" : "not merged in this run";
+  return [
+    "## Challenge Completion",
+    `- Challenge issue #${issue.number} succeeded.`,
+    `- Acceptance criteria status: met (review outcome: \`${reviewOutcome}\`, validation: ${validationStatus}).`,
+    `- Pull request status: ${mergeStatus}.`,
+    "- Lifecycle state: terminal success (`completed`).",
+    "- Further attempts are blocked unless this challenge is explicitly reopened or re-issued.",
+  ].join("\n");
+}
+
+async function finalizeChallengeSuccess(
+  issueManager: TaskIssueManager,
+  issue: IssueSummary,
+  runResult: CodingAgentRunResult,
+): Promise<void> {
+  if (!isChallengeIssue(issue) || runResult.summary.reviewOutcome !== "accepted") {
+    return;
+  }
+
+  const completionResult = await issueManager.markCompleted(issue.number, buildChallengeCompletionSummary(issue, runResult));
+  const alreadyTerminal =
+    /already marked as completed/i.test(completionResult.message) ||
+    /is closed and cannot be completed/i.test(completionResult.message);
+  if (!completionResult.ok && !alreadyTerminal) {
+    console.error(`Could not finalize challenge issue #${issue.number}: ${completionResult.message}`);
+  }
+}
+
 async function applyChallengeRetryGate(
   issueManager: TaskIssueManager,
   openIssues: IssueSummary[],
@@ -229,6 +261,11 @@ async function applyChallengeRetryGate(
 
   for (const issue of issues) {
     if (!isChallengeIssue(issue)) {
+      eligible.push(issue);
+      continue;
+    }
+
+    if (hasIssueLabel(issue, "completed")) {
       eligible.push(issue);
       continue;
     }
@@ -760,6 +797,7 @@ export async function main(): Promise<void> {
             selectedIssue.number,
             buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence),
           );
+          await finalizeChallengeSuccess(issueManager, selectedIssue, runResult);
         }
 
         if (runResult?.mergedPullRequest) {


### PR DESCRIPTION
## Summary
- mark accepted challenge runs as terminal by calling issue completion in the main loop
- record explicit challenge completion commentary that states acceptance criteria were met and retries should stop
- skip retry-gate evaluation for already completed challenge issues
- add regression coverage for completion-on-success, non-completion-on-amended, and completed-challenge retry-gate bypass

## Validation
- pnpm vitest src/main.test.ts src/main.replenishment.integration.test.ts

Closes #84