### PR TITLE
feat(runtime): define canonical lifecycle state model for issue/challenge flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,34 @@ If no issue can be selected and no new issues are created, the runtime stops cle
 5. If merge is detected, runtime transitions to post-merge restart path.
 6. Next cycle re-reads queue and continues.
 
+### Canonical Runtime Lifecycle Model
+
+Canonical lifecycle state is now persisted locally in:
+
+- `.evolvo/runtime-lifecycle-state.json`
+
+Canonical states currently modeled:
+
+- `selected`
+- `executing`
+- `under_review`
+- `accepted`
+- `rejected`
+- `committed`
+- `pr_opened`
+- `merged`
+- `restarted`
+- `failed`
+- `blocked`
+
+State surfaces are separated as follows:
+
+- Canonical state: persisted transition record in `.evolvo/runtime-lifecycle-state.json`
+- Derived state: runtime snapshots such as issue open/closed state, labels, challenge typing, review/PR signals
+- Presentation state: GitHub issue comments/logs for human observability
+
+Each canonical transition also posts a GitHub issue comment titled `Canonical Lifecycle State` so timeline commentary remains visible without making comments canonical.
+
 ### Labels and States
 
 - `in progress`: current active work item.

--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -10,6 +10,8 @@ const formatChallengeMetricsReportMock = vi.fn();
 const evaluateChallengeRetryEligibilityMock = vi.fn();
 const recordChallengeAttemptOutcomeMock = vi.fn();
 const persistChallengeAttemptArtifactMock = vi.fn();
+const transitionCanonicalLifecycleStateMock = vi.fn();
+const buildLifecycleStateCommentMock = vi.fn();
 
 type MockIssue = {
   number: number;
@@ -122,6 +124,11 @@ vi.mock("./challenges/retryGate.js", () => ({
 
 vi.mock("./challenges/challengeAttemptArtifacts.js", () => ({
   persistChallengeAttemptArtifact: persistChallengeAttemptArtifactMock,
+}));
+
+vi.mock("./runtime/lifecycleState.js", () => ({
+  transitionCanonicalLifecycleState: transitionCanonicalLifecycleStateMock,
+  buildLifecycleStateComment: buildLifecycleStateCommentMock,
 }));
 
 vi.mock("./github/githubConfig.js", () => ({
@@ -272,6 +279,23 @@ describe("main replenishment integration", () => {
       absolutePath: "/tmp/evolvo/.evolvo/challenge-attempts/0/0001.json",
       artifact: { attempt: 1, outcome: "success", executionSummary: { reviewOutcome: "accepted" }, runtimeError: null },
     });
+    transitionCanonicalLifecycleStateMock.mockReset();
+    transitionCanonicalLifecycleStateMock.mockResolvedValue({
+      ok: true,
+      issueNumber: 1,
+      previousState: null,
+      entry: {
+        issueNumber: 1,
+        kind: "issue",
+        state: "selected",
+        updatedAt: "2026-03-07T00:00:00.000Z",
+        transitionCount: 1,
+        history: [],
+      },
+      message: "ok",
+    });
+    buildLifecycleStateCommentMock.mockReset();
+    buildLifecycleStateCommentMock.mockReturnValue("## Canonical Lifecycle State");
     process.argv = ["node", "test-runner.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -19,6 +19,8 @@ const recordChallengeAttemptOutcomeMock = vi.fn();
 const persistChallengeAttemptArtifactMock = vi.fn();
 const updateLabelsMock = vi.fn();
 const createIssueMock = vi.fn();
+const transitionCanonicalLifecycleStateMock = vi.fn();
+const buildLifecycleStateCommentMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -72,6 +74,11 @@ vi.mock("./challenges/retryGate.js", () => ({
 
 vi.mock("./challenges/challengeAttemptArtifacts.js", () => ({
   persistChallengeAttemptArtifact: persistChallengeAttemptArtifactMock,
+}));
+
+vi.mock("./runtime/lifecycleState.js", () => ({
+  transitionCanonicalLifecycleState: transitionCanonicalLifecycleStateMock,
+  buildLifecycleStateComment: buildLifecycleStateCommentMock,
 }));
 
 vi.mock("./issues/runIssueCommand.js", () => ({
@@ -182,6 +189,23 @@ describe("main", () => {
       message: "Created issue #100.",
       issue: { number: 100, title: "Generated", description: "body", state: "open", labels: [] },
     });
+    transitionCanonicalLifecycleStateMock.mockReset();
+    transitionCanonicalLifecycleStateMock.mockResolvedValue({
+      ok: true,
+      issueNumber: 1,
+      previousState: null,
+      entry: {
+        issueNumber: 1,
+        kind: "issue",
+        state: "selected",
+        updatedAt: "2026-03-07T00:00:00.000Z",
+        transitionCount: 1,
+        history: [],
+      },
+      message: "ok",
+    });
+    buildLifecycleStateCommentMock.mockReset();
+    buildLifecycleStateCommentMock.mockReturnValue("## Canonical Lifecycle State");
     process.argv = ["node", "test-runner.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -216,6 +240,7 @@ describe("main", () => {
 
     expect(runIssueCommandMock).toHaveBeenCalledWith([]);
     expect(markInProgressMock).toHaveBeenCalledWith(12);
+    expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Canonical Lifecycle State"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Start"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Execution Log"));
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #12: Fix login redirect\n\nHandle callback URL.");

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,13 @@ import {
 } from "./challenges/challengeFailureLearning.js";
 import { persistChallengeAttemptArtifact } from "./challenges/challengeAttemptArtifacts.js";
 import type { CodingAgentRunResult, CommandExecutionSummary } from "./agents/runCodingAgent.js";
+import {
+  buildLifecycleStateComment,
+  transitionCanonicalLifecycleState,
+  type CanonicalLifecycleState,
+  type LifecycleDerivedState,
+  type LifecycleEntityKind,
+} from "./runtime/lifecycleState.js";
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
 const MAX_ISSUE_CYCLES = 100;
@@ -256,6 +263,7 @@ async function applyChallengeRetryGate(
   issueManager: TaskIssueManager,
   openIssues: IssueSummary[],
   issues: IssueSummary[],
+  cycle: number,
 ): Promise<IssueSummary[]> {
   const eligible: IssueSummary[] = [];
 
@@ -293,6 +301,15 @@ async function applyChallengeRetryGate(
     if (decision.eligible) {
       eligible.push(nextIssue);
       continue;
+    }
+
+    if (decision.reason === "max-attempts-reached") {
+      await transitionIssueLifecycleState(issueManager, {
+        issue,
+        nextState: "blocked",
+        reason: `retry gate decision: ${decision.reason}`,
+        cycle,
+      });
     }
 
     await addIssueLifecycleComment(issueManager, issue.number, buildChallengeRetryGateComment(issue, decision));
@@ -351,6 +368,66 @@ function buildIssueStartComment(issue: IssueSummary): string {
     "- Initial assessment: inspect related files, apply a focused implementation, then validate and review.",
     "- Planned lifecycle logging: inspection, implementation decisions, validation steps/results, review outcome, PR/merge status, completion summary.",
   ].join("\n");
+}
+
+function getLifecycleEntityKind(issue: IssueSummary): LifecycleEntityKind {
+  return isChallengeIssue(issue) ? "challenge" : "issue";
+}
+
+function buildLifecycleDerivedState(
+  issue: IssueSummary,
+  runResult: CodingAgentRunResult | null = null,
+): LifecycleDerivedState {
+  return {
+    issueState: issue.state,
+    labels: [...issue.labels],
+    isChallenge: isChallengeIssue(issue),
+    reviewOutcome: runResult?.summary.reviewOutcome ?? null,
+    pullRequestCreated: runResult?.summary.pullRequestCreated ?? null,
+    mergedPullRequest: runResult?.mergedPullRequest ?? null,
+  };
+}
+
+async function transitionIssueLifecycleState(
+  issueManager: TaskIssueManager,
+  options: {
+    issue: IssueSummary;
+    nextState: CanonicalLifecycleState;
+    reason: string;
+    cycle: number;
+    runResult?: CodingAgentRunResult | null;
+  },
+): Promise<void> {
+  try {
+    const transition = await transitionCanonicalLifecycleState(WORK_DIR, {
+      issueNumber: options.issue.number,
+      kind: getLifecycleEntityKind(options.issue),
+      nextState: options.nextState,
+      reason: options.reason,
+      runCycle: options.cycle,
+    });
+    if (!transition.ok || transition.entry === null) {
+      console.error(`Could not persist canonical lifecycle state for issue #${options.issue.number}: ${transition.message}`);
+      return;
+    }
+
+    const comment = buildLifecycleStateComment({
+      issueNumber: options.issue.number,
+      currentState: options.nextState,
+      previousState: transition.previousState,
+      kind: transition.entry.kind,
+      reason: options.reason,
+      derived: buildLifecycleDerivedState(options.issue, options.runResult ?? null),
+    });
+    await addIssueLifecycleComment(issueManager, options.issue.number, comment);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Could not persist canonical lifecycle state for issue #${options.issue.number}: ${error.message}`);
+      return;
+    }
+
+    console.error(`Could not persist canonical lifecycle state for issue #${options.issue.number}: unknown error.`);
+  }
 }
 
 type ChallengeAttemptEvidence = {
@@ -708,7 +785,7 @@ export async function main(): Promise<void> {
           }
         }
 
-        const retryEligibleIssues = await applyChallengeRetryGate(issueManager, actionableIssues, actionableIssues);
+        const retryEligibleIssues = await applyChallengeRetryGate(issueManager, actionableIssues, actionableIssues, cycle);
         const selectedIssue = selectIssueForWork(retryEligibleIssues);
 
         if (!selectedIssue) {
@@ -753,6 +830,12 @@ export async function main(): Promise<void> {
           openCount: openIssues.length,
           selectedIssue,
         });
+        await transitionIssueLifecycleState(issueManager, {
+          issue: selectedIssue,
+          nextState: "selected",
+          reason: "issue selected for active execution in this cycle",
+          cycle,
+        });
 
         let startedThisCycle = false;
         if (!hasIssueLabel(selectedIssue, "in progress")) {
@@ -770,6 +853,12 @@ export async function main(): Promise<void> {
 
         const prompt = buildPromptFromIssue(selectedIssue);
         console.log(`Prompt: ${prompt}`);
+        await transitionIssueLifecycleState(issueManager, {
+          issue: selectedIssue,
+          nextState: "executing",
+          reason: "coding agent execution started",
+          cycle,
+        });
 
         let runError: unknown = null;
         const runResult = await runCodingAgent(prompt).catch((error) => {
@@ -779,6 +868,12 @@ export async function main(): Promise<void> {
         });
 
         if (runError) {
+          await transitionIssueLifecycleState(issueManager, {
+            issue: selectedIssue,
+            nextState: "failed",
+            reason: "runtime error during coding agent execution",
+            cycle,
+          });
           const challengeEvidence = await persistChallengeAttemptEvidence(selectedIssue, runError, runResult);
           await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
           await addIssueLifecycleComment(
@@ -790,6 +885,38 @@ export async function main(): Promise<void> {
         }
 
         if (runResult) {
+          await transitionIssueLifecycleState(issueManager, {
+            issue: selectedIssue,
+            nextState: "under_review",
+            reason: "coding agent execution completed and review result is being processed",
+            cycle,
+            runResult,
+          });
+          await transitionIssueLifecycleState(issueManager, {
+            issue: selectedIssue,
+            nextState: runResult.summary.reviewOutcome === "accepted" ? "accepted" : "rejected",
+            reason: `review outcome received: ${runResult.summary.reviewOutcome}`,
+            cycle,
+            runResult,
+          });
+          if (runResult.summary.reviewOutcome === "accepted" && runResult.summary.pullRequestCreated) {
+            await transitionIssueLifecycleState(issueManager, {
+              issue: selectedIssue,
+              nextState: "committed",
+              reason: "commit evidence observed through pull request creation",
+              cycle,
+              runResult,
+            });
+          }
+          if (runResult.summary.pullRequestCreated) {
+            await transitionIssueLifecycleState(issueManager, {
+              issue: selectedIssue,
+              nextState: "pr_opened",
+              reason: "pull request created for this lifecycle",
+              cycle,
+              runResult,
+            });
+          }
           const challengeEvidence = await persistChallengeAttemptEvidence(selectedIssue, runError, runResult);
           await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
           await addIssueLifecycleComment(
@@ -801,10 +928,24 @@ export async function main(): Promise<void> {
         }
 
         if (runResult?.mergedPullRequest) {
+          await transitionIssueLifecycleState(issueManager, {
+            issue: selectedIssue,
+            nextState: "merged",
+            reason: "pull request merged into main",
+            cycle,
+            runResult,
+          });
           await addIssueLifecycleComment(issueManager, selectedIssue.number, buildMergeOutcomeComment(selectedIssue));
           console.log("Merged pull request detected. Running post-merge restart workflow.");
           try {
             await runPostMergeSelfRestart(WORK_DIR);
+            await transitionIssueLifecycleState(issueManager, {
+              issue: selectedIssue,
+              nextState: "restarted",
+              reason: "post-merge restart workflow completed successfully",
+              cycle,
+              runResult,
+            });
             console.log("Post-merge restart workflow completed. Exiting current runtime.");
           } catch (error) {
             if (error instanceof Error) {

--- a/src/runtime/lifecycleState.test.ts
+++ b/src/runtime/lifecycleState.test.ts
@@ -1,0 +1,173 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildLifecycleStateComment,
+  readCanonicalLifecycleState,
+  transitionCanonicalLifecycleState,
+} from "./lifecycleState.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "lifecycle-state-"));
+}
+
+describe("lifecycleState", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+  });
+
+  it("starts with empty default state when no file exists", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const state = await readCanonicalLifecycleState(workDir);
+
+    expect(state).toEqual({
+      version: 1,
+      issues: {},
+    });
+  });
+
+  it("persists valid lifecycle transitions and history", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const selected = await transitionCanonicalLifecycleState(workDir, {
+      issueNumber: 44,
+      kind: "issue",
+      nextState: "selected",
+      reason: "chosen in cycle",
+      runCycle: 1,
+      atMs: 1000,
+    });
+    const executing = await transitionCanonicalLifecycleState(workDir, {
+      issueNumber: 44,
+      kind: "issue",
+      nextState: "executing",
+      reason: "agent started",
+      runCycle: 1,
+      atMs: 1100,
+    });
+
+    expect(selected.ok).toBe(true);
+    expect(selected.previousState).toBeNull();
+    expect(executing.ok).toBe(true);
+    expect(executing.previousState).toBe("selected");
+    expect(executing.entry).toEqual(
+      expect.objectContaining({
+        issueNumber: 44,
+        kind: "issue",
+        state: "executing",
+        transitionCount: 2,
+      }),
+    );
+    expect(executing.entry?.history).toEqual([
+      {
+        from: null,
+        to: "selected",
+        at: new Date(1000).toISOString(),
+        reason: "chosen in cycle",
+        runCycle: 1,
+      },
+      {
+        from: "selected",
+        to: "executing",
+        at: new Date(1100).toISOString(),
+        reason: "agent started",
+        runCycle: 1,
+      },
+    ]);
+
+    const raw = JSON.parse(await readFile(join(workDir, ".evolvo", "runtime-lifecycle-state.json"), "utf8")) as {
+      issues: Record<string, { state: string }>;
+    };
+    expect(raw.issues["44"]?.state).toBe("executing");
+  });
+
+  it("rejects invalid transitions without mutating persisted state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await transitionCanonicalLifecycleState(workDir, {
+      issueNumber: 9,
+      kind: "challenge",
+      nextState: "selected",
+      atMs: 1000,
+    });
+
+    const invalid = await transitionCanonicalLifecycleState(workDir, {
+      issueNumber: 9,
+      kind: "challenge",
+      nextState: "merged",
+      atMs: 2000,
+    });
+
+    expect(invalid).toEqual(
+      expect.objectContaining({
+        ok: false,
+        previousState: "selected",
+        message: "Invalid lifecycle transition: selected -> merged.",
+      }),
+    );
+
+    const state = await readCanonicalLifecycleState(workDir);
+    expect(state.issues["9"]?.state).toBe("selected");
+    expect(state.issues["9"]?.transitionCount).toBe(1);
+  });
+
+  it("normalizes malformed persisted state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    await writeFile(
+      join(workDir, ".evolvo", "runtime-lifecycle-state.json"),
+      JSON.stringify({
+        version: 0,
+        issues: {
+          abc: { state: "unknown" },
+          12: {
+            issueNumber: 12,
+            kind: "challenge",
+            state: "blocked",
+            updatedAt: "2020-01-01T00:00:00.000Z",
+            transitionCount: 2,
+            history: [{ from: null, to: "blocked", at: "2020-01-01T00:00:00.000Z", reason: "x", runCycle: 1 }],
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const state = await readCanonicalLifecycleState(workDir);
+    expect(Object.keys(state.issues)).toEqual(["12"]);
+    expect(state.issues["12"]?.state).toBe("blocked");
+    expect(state.version).toBe(1);
+  });
+
+  it("formats canonical lifecycle comments with canonical and derived sections", () => {
+    const comment = buildLifecycleStateComment({
+      issueNumber: 90,
+      currentState: "executing",
+      previousState: "selected",
+      kind: "challenge",
+      reason: "runtime started agent run",
+      derived: {
+        issueState: "open",
+        labels: ["challenge", "in progress"],
+        isChallenge: true,
+        reviewOutcome: null,
+        pullRequestCreated: null,
+        mergedPullRequest: null,
+      },
+    });
+
+    expect(comment).toContain("## Canonical Lifecycle State");
+    expect(comment).toContain("Canonical state: `executing`");
+    expect(comment).toContain("### Derived Runtime Signals");
+    expect(comment).toContain("Presentation Note");
+    expect(comment).toContain(".evolvo/runtime-lifecycle-state.json");
+  });
+});

--- a/src/runtime/lifecycleState.ts
+++ b/src/runtime/lifecycleState.ts
@@ -1,0 +1,298 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+const EVOLVO_DIRECTORY_NAME = ".evolvo";
+const LIFECYCLE_STATE_FILE_NAME = "runtime-lifecycle-state.json";
+const LIFECYCLE_STATE_VERSION = 1;
+const MAX_HISTORY_ENTRIES = 25;
+
+export const CANONICAL_LIFECYCLE_STATES = [
+  "selected",
+  "executing",
+  "under_review",
+  "accepted",
+  "rejected",
+  "committed",
+  "pr_opened",
+  "merged",
+  "restarted",
+  "failed",
+  "blocked",
+] as const;
+
+export type CanonicalLifecycleState = typeof CANONICAL_LIFECYCLE_STATES[number];
+export type LifecycleEntityKind = "issue" | "challenge";
+
+export type LifecycleDerivedState = {
+  issueState: "open" | "closed";
+  labels: string[];
+  isChallenge: boolean;
+  reviewOutcome: string | null;
+  pullRequestCreated: boolean | null;
+  mergedPullRequest: boolean | null;
+};
+
+export type CanonicalLifecycleEntry = {
+  issueNumber: number;
+  kind: LifecycleEntityKind;
+  state: CanonicalLifecycleState;
+  updatedAt: string;
+  transitionCount: number;
+  history: Array<{
+    from: CanonicalLifecycleState | null;
+    to: CanonicalLifecycleState;
+    at: string;
+    reason: string | null;
+    runCycle: number | null;
+  }>;
+};
+
+type LifecycleStateStore = {
+  version: number;
+  issues: Record<string, CanonicalLifecycleEntry>;
+};
+
+export type TransitionLifecycleInput = {
+  issueNumber: number;
+  kind: LifecycleEntityKind;
+  nextState: CanonicalLifecycleState;
+  reason?: string;
+  runCycle?: number;
+  atMs?: number;
+};
+
+export type TransitionLifecycleResult = {
+  ok: boolean;
+  issueNumber: number;
+  previousState: CanonicalLifecycleState | null;
+  entry: CanonicalLifecycleEntry | null;
+  message: string;
+};
+
+const ALLOWED_TRANSITIONS: Record<CanonicalLifecycleState | "none", Set<CanonicalLifecycleState>> = {
+  none: new Set(["selected", "blocked", "failed"]),
+  selected: new Set(["selected", "executing", "blocked", "failed"]),
+  executing: new Set(["selected", "under_review", "failed", "blocked"]),
+  under_review: new Set(["selected", "accepted", "rejected", "failed", "blocked"]),
+  accepted: new Set(["selected", "committed", "pr_opened", "merged", "restarted", "failed"]),
+  rejected: new Set(["selected", "executing", "failed", "blocked"]),
+  committed: new Set(["selected", "pr_opened", "merged", "failed"]),
+  pr_opened: new Set(["selected", "merged", "failed", "rejected"]),
+  merged: new Set(["selected", "restarted", "failed"]),
+  restarted: new Set(["selected", "failed"]),
+  failed: new Set(["selected", "executing", "blocked", "failed"]),
+  blocked: new Set(["selected", "executing", "failed", "blocked"]),
+};
+
+function toFinitePositiveInteger(value: unknown): number | null {
+  const asNumber = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(asNumber) || asNumber <= 0) {
+    return null;
+  }
+
+  return Math.floor(asNumber);
+}
+
+function isCanonicalLifecycleState(value: unknown): value is CanonicalLifecycleState {
+  return typeof value === "string" && (CANONICAL_LIFECYCLE_STATES as readonly string[]).includes(value);
+}
+
+function getStatePath(workDir: string): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, LIFECYCLE_STATE_FILE_NAME);
+}
+
+function createDefaultStateStore(): LifecycleStateStore {
+  return {
+    version: LIFECYCLE_STATE_VERSION,
+    issues: {},
+  };
+}
+
+function normalizeStateStore(raw: unknown): LifecycleStateStore {
+  if (typeof raw !== "object" || raw === null) {
+    return createDefaultStateStore();
+  }
+
+  const candidate = raw as Partial<LifecycleStateStore>;
+  const entries = Object.entries(candidate.issues ?? {});
+  const issues = Object.fromEntries(
+    entries.flatMap(([issueKey, value]) => {
+      if (typeof value !== "object" || value === null) {
+        return [];
+      }
+
+      const issueNumber = toFinitePositiveInteger((value as Partial<CanonicalLifecycleEntry>).issueNumber ?? issueKey);
+      const state = (value as Partial<CanonicalLifecycleEntry>).state;
+      if (issueNumber === null || !isCanonicalLifecycleState(state)) {
+        return [];
+      }
+
+      const kind = (value as Partial<CanonicalLifecycleEntry>).kind === "challenge" ? "challenge" : "issue";
+      const transitionCountRaw = toFinitePositiveInteger((value as Partial<CanonicalLifecycleEntry>).transitionCount);
+      const transitionCount = transitionCountRaw ?? 1;
+      const updatedAtRaw = (value as Partial<CanonicalLifecycleEntry>).updatedAt;
+      const updatedAt = typeof updatedAtRaw === "string" && updatedAtRaw.trim().length > 0
+        ? updatedAtRaw
+        : new Date(0).toISOString();
+      const historyRaw = (value as Partial<CanonicalLifecycleEntry>).history;
+      const history = Array.isArray(historyRaw)
+        ? historyRaw.map((historyItem) => {
+            if (typeof historyItem !== "object" || historyItem === null) {
+              return null;
+            }
+
+            const fromRaw = (historyItem as { from?: unknown }).from;
+            const from = fromRaw === null || isCanonicalLifecycleState(fromRaw) ? fromRaw : null;
+            const toRaw = (historyItem as { to?: unknown }).to;
+            if (!isCanonicalLifecycleState(toRaw)) {
+              return null;
+            }
+
+            const atRaw = (historyItem as { at?: unknown }).at;
+            const reasonRaw = (historyItem as { reason?: unknown }).reason;
+            const runCycleRaw = toFinitePositiveInteger((historyItem as { runCycle?: unknown }).runCycle);
+            return {
+              from,
+              to: toRaw,
+              at: typeof atRaw === "string" && atRaw.trim().length > 0 ? atRaw : new Date(0).toISOString(),
+              reason: typeof reasonRaw === "string" && reasonRaw.trim().length > 0 ? reasonRaw.trim() : null,
+              runCycle: runCycleRaw,
+            };
+          })
+          .filter((item): item is CanonicalLifecycleEntry["history"][number] => item !== null)
+          .slice(-MAX_HISTORY_ENTRIES)
+        : [];
+
+      return [[String(issueNumber), {
+        issueNumber,
+        kind,
+        state,
+        updatedAt,
+        transitionCount,
+        history,
+      } satisfies CanonicalLifecycleEntry] as const];
+    }),
+  );
+
+  return {
+    version: LIFECYCLE_STATE_VERSION,
+    issues,
+  };
+}
+
+export async function readCanonicalLifecycleState(workDir: string): Promise<LifecycleStateStore> {
+  const statePath = getStatePath(workDir);
+  try {
+    const raw = await fs.readFile(statePath, "utf8");
+    return normalizeStateStore(JSON.parse(raw) as unknown);
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return createDefaultStateStore();
+    }
+
+    throw error;
+  }
+}
+
+async function writeCanonicalLifecycleState(workDir: string, state: LifecycleStateStore): Promise<void> {
+  await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
+  await fs.writeFile(getStatePath(workDir), `${JSON.stringify(normalizeStateStore(state), null, 2)}\n`, "utf8");
+}
+
+export async function transitionCanonicalLifecycleState(
+  workDir: string,
+  input: TransitionLifecycleInput,
+): Promise<TransitionLifecycleResult> {
+  const issueNumber = toFinitePositiveInteger(input.issueNumber);
+  if (issueNumber === null) {
+    return {
+      ok: false,
+      issueNumber: 0,
+      previousState: null,
+      entry: null,
+      message: "Issue number must be a positive integer.",
+    };
+  }
+
+  const stateStore = await readCanonicalLifecycleState(workDir);
+  const issueKey = String(issueNumber);
+  const current = stateStore.issues[issueKey] ?? null;
+  const previousState = current?.state ?? null;
+  const allowed = ALLOWED_TRANSITIONS[previousState ?? "none"];
+  if (!allowed.has(input.nextState)) {
+    return {
+      ok: false,
+      issueNumber,
+      previousState,
+      entry: current,
+      message: `Invalid lifecycle transition: ${previousState ?? "none"} -> ${input.nextState}.`,
+    };
+  }
+
+  const reason = typeof input.reason === "string" && input.reason.trim().length > 0 ? input.reason.trim() : null;
+  const runCycle = toFinitePositiveInteger(input.runCycle);
+  const now = new Date(typeof input.atMs === "number" && Number.isFinite(input.atMs) ? input.atMs : Date.now()).toISOString();
+  const nextEntry: CanonicalLifecycleEntry = {
+    issueNumber,
+    kind: input.kind,
+    state: input.nextState,
+    updatedAt: now,
+    transitionCount: (current?.transitionCount ?? 0) + 1,
+    history: [
+      ...(current?.history ?? []),
+      {
+        from: previousState,
+        to: input.nextState,
+        at: now,
+        reason,
+        runCycle,
+      },
+    ].slice(-MAX_HISTORY_ENTRIES),
+  };
+
+  stateStore.issues[issueKey] = nextEntry;
+  await writeCanonicalLifecycleState(workDir, stateStore);
+  return {
+    ok: true,
+    issueNumber,
+    previousState,
+    entry: nextEntry,
+    message: previousState === null
+      ? `Lifecycle initialized at ${input.nextState}.`
+      : `Lifecycle transitioned ${previousState} -> ${input.nextState}.`,
+  };
+}
+
+export function buildLifecycleStateComment(options: {
+  issueNumber: number;
+  currentState: CanonicalLifecycleState;
+  previousState: CanonicalLifecycleState | null;
+  kind: LifecycleEntityKind;
+  reason: string;
+  derived: LifecycleDerivedState;
+}): string {
+  const transitionLabel = options.previousState === null
+    ? `none -> ${options.currentState}`
+    : `${options.previousState} -> ${options.currentState}`;
+  const labels = options.derived.labels.length > 0 ? options.derived.labels.map((label) => `\`${label}\``).join(", ") : "(none)";
+
+  return [
+    "## Canonical Lifecycle State",
+    `- Scope: issue #${options.issueNumber} (${options.kind}).`,
+    `- Canonical state: \`${options.currentState}\`.`,
+    `- Transition: \`${transitionLabel}\`.`,
+    `- Transition reason: ${options.reason}.`,
+    "",
+    "### Derived Runtime Signals",
+    `- GitHub issue state: \`${options.derived.issueState}\`.`,
+    `- Labels snapshot: ${labels}.`,
+    `- Challenge issue: ${options.derived.isChallenge ? "yes" : "no"}.`,
+    `- Review outcome signal: ${options.derived.reviewOutcome ?? "unknown"}.`,
+    `- PR created signal: ${options.derived.pullRequestCreated === null ? "unknown" : options.derived.pullRequestCreated ? "yes" : "no"}.`,
+    `- PR merged signal: ${options.derived.mergedPullRequest === null ? "unknown" : options.derived.mergedPullRequest ? "yes" : "no"}.`,
+    "",
+    "### Presentation Note",
+    "- This comment is a human-facing snapshot; canonical state is persisted in `.evolvo/runtime-lifecycle-state.json`.",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- add canonical lifecycle state model with guarded transitions persisted in '.evolvo/runtime-lifecycle-state.json'
- separate canonical state from derived runtime signals and presentation comments
- wire lifecycle transitions into main runtime flow and challenge retry-gate blocked path
- post canonical lifecycle transition comments to active GitHub issues
- add unit/integration coverage and README lifecycle model documentation

## Validation
- pnpm validate

Closes #90