### PR TITLE
feat(restart): add explicit readiness verification to post-merge restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,14 @@ Post-merge workflow runs:
 2. `git pull --ff-only`
 3. `pnpm i`
 4. `pnpm build`
-5. detached `pnpm start`
+5. `pnpm start` (with readiness-token handshake)
 
-If any step fails, runtime logs the failing command and exits current cycle. Fix the reported failure, then restart manually with `pnpm dev`.
+Restart success requires an explicit readiness signal:
+
+- restarted runtime writes `.evolvo/runtime-readiness.json` with the restart token from `EVOLVO_RESTART_TOKEN`
+- parent process waits for matching token readiness before declaring restart success
+
+If any step fails, or readiness is not observed in time, runtime logs diagnostics and exits current cycle. Fix the reported failure, then restart manually with `pnpm dev`.
 
 ## Manual Issue Commands
 

--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -12,6 +12,7 @@ const recordChallengeAttemptOutcomeMock = vi.fn();
 const persistChallengeAttemptArtifactMock = vi.fn();
 const transitionCanonicalLifecycleStateMock = vi.fn();
 const buildLifecycleStateCommentMock = vi.fn();
+const writeRuntimeReadinessSignalMock = vi.fn();
 
 type MockIssue = {
   number: number;
@@ -129,6 +130,10 @@ vi.mock("./challenges/challengeAttemptArtifacts.js", () => ({
 vi.mock("./runtime/lifecycleState.js", () => ({
   transitionCanonicalLifecycleState: transitionCanonicalLifecycleStateMock,
   buildLifecycleStateComment: buildLifecycleStateCommentMock,
+}));
+
+vi.mock("./runtime/runtimeReadiness.js", () => ({
+  writeRuntimeReadinessSignal: writeRuntimeReadinessSignalMock,
 }));
 
 vi.mock("./github/githubConfig.js", () => ({
@@ -296,6 +301,8 @@ describe("main replenishment integration", () => {
     });
     buildLifecycleStateCommentMock.mockReset();
     buildLifecycleStateCommentMock.mockReturnValue("## Canonical Lifecycle State");
+    writeRuntimeReadinessSignalMock.mockReset();
+    writeRuntimeReadinessSignalMock.mockResolvedValue("/tmp/evolvo/.evolvo/runtime-readiness.json");
     process.argv = ["node", "test-runner.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -21,6 +21,7 @@ const updateLabelsMock = vi.fn();
 const createIssueMock = vi.fn();
 const transitionCanonicalLifecycleStateMock = vi.fn();
 const buildLifecycleStateCommentMock = vi.fn();
+const writeRuntimeReadinessSignalMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -81,6 +82,10 @@ vi.mock("./runtime/lifecycleState.js", () => ({
   buildLifecycleStateComment: buildLifecycleStateCommentMock,
 }));
 
+vi.mock("./runtime/runtimeReadiness.js", () => ({
+  writeRuntimeReadinessSignal: writeRuntimeReadinessSignalMock,
+}));
+
 vi.mock("./issues/runIssueCommand.js", () => ({
   runIssueCommand: runIssueCommandMock,
 }));
@@ -118,6 +123,8 @@ describe("main", () => {
 
   beforeEach(() => {
     vi.resetModules();
+    delete process.env.EVOLVO_RESTART_TOKEN;
+    delete process.env.EVOLVO_READINESS_FILE;
     runCodingAgentMock.mockReset();
     runCodingAgentMock.mockResolvedValue(DEFAULT_RUN_RESULT);
     runPostMergeSelfRestartMock.mockReset();
@@ -206,6 +213,8 @@ describe("main", () => {
     });
     buildLifecycleStateCommentMock.mockReset();
     buildLifecycleStateCommentMock.mockReturnValue("## Canonical Lifecycle State");
+    writeRuntimeReadinessSignalMock.mockReset();
+    writeRuntimeReadinessSignalMock.mockResolvedValue("/tmp/evolvo/.evolvo/runtime-readiness.json");
     process.argv = ["node", "test-runner.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -226,6 +235,22 @@ describe("main", () => {
     expect(runIssueCommandMock).toHaveBeenCalledWith(["issues", "list"]);
     expect(runCodingAgentMock).not.toHaveBeenCalled();
     expect(listOpenIssuesMock).not.toHaveBeenCalled();
+  });
+
+  it("writes startup readiness signal when restart token is present", async () => {
+    process.env.EVOLVO_RESTART_TOKEN = "restart-token";
+    process.env.EVOLVO_READINESS_FILE = "/tmp/evolvo/.evolvo/runtime-readiness.json";
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(writeRuntimeReadinessSignalMock).toHaveBeenCalledWith({
+      workDir: "/tmp/evolvo",
+      token: "restart-token",
+      signalPath: "/tmp/evolvo/.evolvo/runtime-readiness.json",
+    });
+    delete process.env.EVOLVO_RESTART_TOKEN;
+    delete process.env.EVOLVO_READINESS_FILE;
   });
 
   it("selects an open issue and uses it as the prompt", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import {
   type LifecycleDerivedState,
   type LifecycleEntityKind,
 } from "./runtime/lifecycleState.js";
+import { writeRuntimeReadinessSignal } from "./runtime/runtimeReadiness.js";
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
 const MAX_ISSUE_CYCLES = 100;
@@ -751,6 +752,21 @@ async function waitForRunLoopRetry(delayMs: number): Promise<void> {
   });
 }
 
+async function signalRestartReadinessIfRequested(workDir: string): Promise<void> {
+  const token = process.env.EVOLVO_RESTART_TOKEN?.trim();
+  if (!token) {
+    return;
+  }
+
+  const signalPathOverride = process.env.EVOLVO_READINESS_FILE?.trim();
+  const signalPath = await writeRuntimeReadinessSignal({
+    workDir,
+    token,
+    signalPath: signalPathOverride || undefined,
+  });
+  console.log(`[startup] Runtime readiness signal written: ${signalPath}`);
+}
+
 export async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const issueCommandHandled = await runIssueCommand(args);
@@ -763,6 +779,7 @@ export async function main(): Promise<void> {
 
   console.log(`Hello from ${GITHUB_OWNER}/${GITHUB_REPO}!`);
   console.log(`Working directory: ${WORK_DIR}`);
+  await signalRestartReadinessIfRequested(WORK_DIR);
 
   issueCycleLoop: for (let cycle = 1; cycle <= MAX_ISSUE_CYCLES; cycle += 1) {
     let retryAttempt = 0;

--- a/src/runtime/runtimeReadiness.test.ts
+++ b/src/runtime/runtimeReadiness.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getRuntimeReadinessSignalPath,
+  waitForRuntimeReadinessSignal,
+  writeRuntimeReadinessSignal,
+} from "./runtimeReadiness.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "runtime-readiness-"));
+}
+
+describe("runtimeReadiness", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+  });
+
+  it("writes readiness signal with runtime metadata", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const path = await writeRuntimeReadinessSignal({
+      workDir,
+      token: "abc-123",
+    });
+
+    expect(path).toBe(join(workDir, ".evolvo", "runtime-readiness.json"));
+    const raw = JSON.parse(await readFile(path, "utf8")) as {
+      token: string;
+      status: string;
+      pid: number;
+      startedAt: string;
+    };
+    expect(raw.token).toBe("abc-123");
+    expect(raw.status).toBe("ready");
+    expect(raw.pid).toBe(process.pid);
+    expect(typeof raw.startedAt).toBe("string");
+  });
+
+  it("waits until matching readiness token appears", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const signalPath = getRuntimeReadinessSignalPath(workDir);
+
+    const waitPromise = waitForRuntimeReadinessSignal({
+      workDir,
+      token: "restart-token",
+      timeoutMs: 400,
+      pollIntervalMs: 20,
+      signalPath,
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 60);
+    });
+    await writeRuntimeReadinessSignal({
+      workDir,
+      token: "restart-token",
+      signalPath,
+    });
+
+    await expect(waitPromise).resolves.toEqual(
+      expect.objectContaining({
+        token: "restart-token",
+        status: "ready",
+      }),
+    );
+  });
+
+  it("fails with token mismatch diagnostics when readiness token is wrong", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await writeRuntimeReadinessSignal({
+      workDir,
+      token: "other-token",
+    });
+
+    await expect(
+      waitForRuntimeReadinessSignal({
+        workDir,
+        token: "expected-token",
+        timeoutMs: 80,
+        pollIntervalMs: 10,
+      }),
+    ).rejects.toThrow("Last observed token=other-token");
+  });
+
+  it("fails when readiness file payload is malformed", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const signalPath = getRuntimeReadinessSignalPath(workDir);
+    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    await writeFile(signalPath, "{not-json", "utf8");
+
+    await expect(
+      waitForRuntimeReadinessSignal({
+        workDir,
+        token: "expected-token",
+        timeoutMs: 80,
+        pollIntervalMs: 10,
+        signalPath,
+      }),
+    ).rejects.toThrow(`Could not read runtime readiness signal at ${signalPath}`);
+  });
+});

--- a/src/runtime/runtimeReadiness.ts
+++ b/src/runtime/runtimeReadiness.ts
@@ -1,0 +1,144 @@
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+
+const EVOLVO_DIRECTORY_NAME = ".evolvo";
+const RUNTIME_READINESS_FILE_NAME = "runtime-readiness.json";
+const DEFAULT_POLL_INTERVAL_MS = 100;
+
+export type RuntimeReadinessSignal = {
+  token: string;
+  status: "ready";
+  pid: number;
+  startedAt: string;
+};
+
+function toFinitePositiveInteger(value: unknown): number | null {
+  const asNumber = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(asNumber) || asNumber <= 0) {
+    return null;
+  }
+
+  return Math.floor(asNumber);
+}
+
+function isRuntimeReadinessSignal(value: unknown): value is RuntimeReadinessSignal {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<RuntimeReadinessSignal>;
+  const pid = toFinitePositiveInteger(candidate.pid);
+  return typeof candidate.token === "string" &&
+    candidate.token.trim().length > 0 &&
+    candidate.status === "ready" &&
+    pid !== null &&
+    typeof candidate.startedAt === "string" &&
+    candidate.startedAt.trim().length > 0;
+}
+
+export function getRuntimeReadinessSignalPath(workDir: string): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, RUNTIME_READINESS_FILE_NAME);
+}
+
+async function readRuntimeReadinessSignal(signalPath: string): Promise<RuntimeReadinessSignal | null> {
+  try {
+    const raw = await fs.readFile(signalPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRuntimeReadinessSignal(parsed)) {
+      return null;
+    }
+
+    return {
+      ...parsed,
+      pid: Math.floor(parsed.pid),
+      token: parsed.token.trim(),
+    };
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+export async function writeRuntimeReadinessSignal(options: {
+  workDir: string;
+  token: string;
+  signalPath?: string;
+}): Promise<string> {
+  const signalPath = options.signalPath ?? getRuntimeReadinessSignalPath(options.workDir);
+  const token = options.token.trim();
+  if (!token) {
+    throw new Error("Runtime readiness token cannot be empty.");
+  }
+
+  const signal: RuntimeReadinessSignal = {
+    token,
+    status: "ready",
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  };
+  await fs.mkdir(dirname(signalPath), { recursive: true });
+  await fs.writeFile(signalPath, `${JSON.stringify(signal, null, 2)}\n`, "utf8");
+  return signalPath;
+}
+
+async function wait(delayMs: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+export async function waitForRuntimeReadinessSignal(options: {
+  workDir: string;
+  token: string;
+  timeoutMs: number;
+  pollIntervalMs?: number;
+  signalPath?: string;
+}): Promise<RuntimeReadinessSignal> {
+  const token = options.token.trim();
+  if (!token) {
+    throw new Error("Runtime readiness token cannot be empty.");
+  }
+
+  const timeoutMs = Math.max(1, Math.floor(options.timeoutMs));
+  const pollIntervalMs = Math.max(1, Math.floor(options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS));
+  const signalPath = options.signalPath ?? getRuntimeReadinessSignalPath(options.workDir);
+  const deadline = Date.now() + timeoutMs;
+  let lastObservedToken: string | null = null;
+  let sawMalformedPayload = false;
+
+  while (Date.now() <= deadline) {
+    try {
+      const signal = await readRuntimeReadinessSignal(signalPath);
+      if (signal) {
+        if (signal.token === token) {
+          return signal;
+        }
+
+        lastObservedToken = signal.token;
+      } else {
+        const raw = await fs.readFile(signalPath, "utf8").catch(() => null);
+        if (raw !== null) {
+          sawMalformedPayload = true;
+        }
+      }
+    } catch (error) {
+      throw new Error(
+        `Could not read runtime readiness signal at ${signalPath}: ${
+          error instanceof Error ? error.message : "unknown error"
+        }`,
+      );
+    }
+
+    await wait(pollIntervalMs);
+  }
+
+  const tokenHint = lastObservedToken ? ` Last observed token=${lastObservedToken}.` : "";
+  const malformedHint = sawMalformedPayload ? " Last observed payload was malformed." : "";
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for runtime readiness token ${token} at ${signalPath}.${tokenHint}${malformedHint}`,
+  );
+}

--- a/src/runtime/selfRestart.test.ts
+++ b/src/runtime/selfRestart.test.ts
@@ -2,10 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.fn();
 const spawnMock = vi.fn();
+const getRuntimeReadinessSignalPathMock = vi.fn();
+const waitForRuntimeReadinessSignalMock = vi.fn();
 
 vi.mock("node:child_process", () => ({
   execFile: execFileMock,
   spawn: spawnMock,
+}));
+
+vi.mock("./runtimeReadiness.js", () => ({
+  getRuntimeReadinessSignalPath: getRuntimeReadinessSignalPathMock,
+  waitForRuntimeReadinessSignal: waitForRuntimeReadinessSignalMock,
 }));
 
 function createChildProcessStub(overrides: {
@@ -26,6 +33,15 @@ describe("runPostMergeSelfRestart", () => {
     vi.useFakeTimers();
     execFileMock.mockReset();
     spawnMock.mockReset();
+    getRuntimeReadinessSignalPathMock.mockReset();
+    getRuntimeReadinessSignalPathMock.mockReturnValue("/tmp/evolvo/.evolvo/runtime-readiness.json");
+    waitForRuntimeReadinessSignalMock.mockReset();
+    waitForRuntimeReadinessSignalMock.mockResolvedValue({
+      token: "token",
+      status: "ready",
+      pid: 1234,
+      startedAt: "2026-01-01T00:00:00.000Z",
+    });
     vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
@@ -47,18 +63,32 @@ describe("runPostMergeSelfRestart", () => {
     spawnMock.mockReturnValue(child);
 
     const { runPostMergeSelfRestart } = await import("./selfRestart.js");
-    const restartPromise = runPostMergeSelfRestart("/tmp/evolvo");
-    await vi.advanceTimersByTimeAsync(3000);
-    await expect(restartPromise).resolves.toBeUndefined();
+    await expect(runPostMergeSelfRestart("/tmp/evolvo")).resolves.toBeUndefined();
 
     expect(execFileMock).toHaveBeenNthCalledWith(1, "git", ["checkout", "main"], { cwd: "/tmp/evolvo" }, expect.any(Function));
     expect(execFileMock).toHaveBeenNthCalledWith(2, "git", ["pull", "--ff-only"], { cwd: "/tmp/evolvo" }, expect.any(Function));
     expect(execFileMock).toHaveBeenNthCalledWith(3, "pnpm", ["i"], { cwd: "/tmp/evolvo" }, expect.any(Function));
     expect(execFileMock).toHaveBeenNthCalledWith(4, "pnpm", ["build"], { cwd: "/tmp/evolvo" }, expect.any(Function));
-    expect(spawnMock).toHaveBeenCalledWith("pnpm", ["start"], {
+    const spawnCall = spawnMock.mock.calls[0];
+    expect(spawnCall?.[0]).toBe("pnpm");
+    expect(spawnCall?.[1]).toEqual(["start"]);
+    expect(spawnCall?.[2]).toEqual(expect.objectContaining({
       cwd: "/tmp/evolvo",
       detached: false,
       stdio: "inherit",
+      env: expect.objectContaining({
+        EVOLVO_READINESS_FILE: "/tmp/evolvo/.evolvo/runtime-readiness.json",
+        EVOLVO_RESTART_TOKEN: expect.any(String),
+      }),
+    }));
+    const restartToken = (spawnCall?.[2] as { env?: { EVOLVO_RESTART_TOKEN?: string } })?.env?.EVOLVO_RESTART_TOKEN;
+    expect(typeof restartToken).toBe("string");
+    expect(restartToken?.length).toBeGreaterThan(0);
+    expect(waitForRuntimeReadinessSignalMock).toHaveBeenCalledWith({
+      workDir: "/tmp/evolvo",
+      token: restartToken,
+      timeoutMs: 15000,
+      signalPath: "/tmp/evolvo/.evolvo/runtime-readiness.json",
     });
     expect(onceHandlers.error).toBeTypeOf("function");
     expect(onceHandlers.exit).toBeTypeOf("function");
@@ -95,6 +125,20 @@ describe("runPostMergeSelfRestart", () => {
     const { runPostMergeSelfRestart } = await import("./selfRestart.js");
     await expect(runPostMergeSelfRestart("/tmp/evolvo")).rejects.toThrow(
       "Post-merge restart failed: pnpm start exited early with code 1.",
+    );
+  });
+
+  it("fails when readiness signal is not observed", async () => {
+    execFileMock.mockImplementation((_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+      callback(null, "", "");
+    });
+    const child = createChildProcessStub();
+    spawnMock.mockReturnValue(child);
+    waitForRuntimeReadinessSignalMock.mockRejectedValueOnce(new Error("Timed out waiting for readiness token"));
+
+    const { runPostMergeSelfRestart } = await import("./selfRestart.js");
+    await expect(runPostMergeSelfRestart("/tmp/evolvo")).rejects.toThrow(
+      "Post-merge restart readiness check failed: Timed out waiting for readiness token",
     );
   });
 });

--- a/src/runtime/selfRestart.ts
+++ b/src/runtime/selfRestart.ts
@@ -1,8 +1,11 @@
 import { execFile, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
+import { getRuntimeReadinessSignalPath, waitForRuntimeReadinessSignal } from "./runtimeReadiness.js";
 
 const execFileAsync = promisify(execFile);
-const STARTUP_TIMEOUT_MS = 3000;
+const STARTUP_READINESS_TIMEOUT_MS = 15_000;
 
 type ExecFailure = Error & { stdout?: string | Buffer; stderr?: string | Buffer };
 
@@ -31,18 +34,31 @@ async function runStep(command: string, args: string[], workingDirectory: string
 
 async function startUpdatedRuntime(workingDirectory: string): Promise<void> {
   console.log("[restart] Running: pnpm start");
+  const readinessToken = randomUUID();
+  const readinessSignalPath = getRuntimeReadinessSignalPath(workingDirectory);
+  await fs.rm(readinessSignalPath, { force: true });
 
   const child = spawn("pnpm", ["start"], {
     cwd: workingDirectory,
     detached: false,
     stdio: "inherit",
+    env: {
+      ...process.env,
+      EVOLVO_RESTART_TOKEN: readinessToken,
+      EVOLVO_READINESS_FILE: readinessSignalPath,
+    },
   });
 
+  let readySignalPid: number | null = null;
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
       cleanup();
-      resolve();
-    }, STARTUP_TIMEOUT_MS);
+      reject(
+        new Error(
+          `Post-merge restart readiness check failed: timed out after ${STARTUP_READINESS_TIMEOUT_MS}ms waiting for token ${readinessToken} at ${readinessSignalPath}.`,
+        ),
+      );
+    }, STARTUP_READINESS_TIMEOUT_MS);
 
     function cleanup(): void {
       clearTimeout(timeout);
@@ -63,9 +79,28 @@ async function startUpdatedRuntime(workingDirectory: string): Promise<void> {
 
     child.once("error", onError);
     child.once("exit", onExit);
+    waitForRuntimeReadinessSignal({
+      workDir: workingDirectory,
+      token: readinessToken,
+      timeoutMs: STARTUP_READINESS_TIMEOUT_MS,
+      signalPath: readinessSignalPath,
+    }).then((signal) => {
+      readySignalPid = signal.pid;
+      cleanup();
+      resolve();
+    }).catch((error) => {
+      cleanup();
+      reject(new Error(
+        `Post-merge restart readiness check failed: ${
+          error instanceof Error ? error.message : "unknown error"
+        }`,
+      ));
+    });
   });
 
-  console.log(`[restart] Started updated runtime process (pid ${child.pid ?? "unknown"}).`);
+  console.log(
+    `[restart] Started updated runtime process (pid ${child.pid ?? "unknown"}) with readiness signal pid ${readySignalPid ?? "unknown"}.`,
+  );
 }
 
 export async function runPostMergeSelfRestart(workingDirectory: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add explicit runtime readiness signal module ('.evolvo/runtime-readiness.json' + token handshake)
- make post-merge restart wait for matching readiness signal instead of short alive-time heuristic
- pass restart token/file path into restarted runtime and fail with clear readiness diagnostics
- wire main startup to publish readiness when 'EVOLVO_RESTART_TOKEN' is set
- extend restart/main tests and document readiness behavior

## Validation
- pnpm validate

Closes #89