### PR TITLE
refactor(prompt): strengthen Evolvo master prompt guardrails

### DIFF
--- a/src/agents/codingAgent.test.ts
+++ b/src/agents/codingAgent.test.ts
@@ -39,6 +39,32 @@ describe("buildCodingPrompt", () => {
     expect(prompt).toContain("explicitly confirm whether the external PR was merged");
   });
 
+  it("includes explicit runtime stability and high-risk surface guardrails", () => {
+    const prompt = buildCodingPrompt("Issue #95: Improve master prompt discipline");
+
+    expect(prompt).toContain("Protecting core runtime stability takes priority");
+    expect(prompt).toContain("main issue loop orchestration");
+    expect(prompt).toContain("restart and readiness flow");
+    expect(prompt).toContain("GitHub write-side mutation paths");
+  });
+
+  it("distinguishes canonical, derived, and presentation state", () => {
+    const prompt = buildCodingPrompt("Issue #90: Lifecycle state discipline");
+
+    expect(prompt).toContain("canonical state: authoritative, persisted, used for control flow");
+    expect(prompt).toContain("derived state: computed from canonical state and structured signals");
+    expect(prompt).toContain("presentation state: comments, logs, labels, narrative output for humans");
+    expect(prompt).toContain("Comments, labels, and logs are useful observability, but they are not automatically canonical truth.");
+  });
+
+  it("requires evidence-driven issue quality and structured facts over heuristics", () => {
+    const prompt = buildCodingPrompt("Issue quality discipline");
+
+    expect(prompt).toContain("prioritize issues backed by concrete evidence");
+    expect(prompt).toContain("Avoid low-value issue generation based only on superficial repository shape.");
+    expect(prompt).toContain("When heuristics and structured facts conflict, choose structured facts.");
+  });
+
   it("keeps Codex configured for workspace-write execution", () => {
     expect(CODING_AGENT_THREAD_OPTIONS.sandboxMode).toBe("workspace-write");
     expect(CODING_AGENT_THREAD_OPTIONS.approvalPolicy).toBe("never");

--- a/src/agents/codingAgent.ts
+++ b/src/agents/codingAgent.ts
@@ -71,6 +71,25 @@ Try to be correct.
 Do not seek the biggest change.
 Seek the best next change.
 
+## Runtime Stability Guardrails
+
+Protecting core runtime stability takes priority over all optimization or cleanup work.
+
+High-risk surfaces include:
+- main issue loop orchestration
+- restart and readiness flow
+- issue/challenge lifecycle state transitions
+- issue selection and queue management
+- GitHub write-side mutation paths (labels, comments, close/reopen, PR flow)
+
+When touching any high-risk surface:
+- reduce scope to the smallest workable patch
+- avoid combining unrelated refactors in the same change
+- prefer explicit invariants and transition checks over implicit behavior
+- require stronger validation and more skeptical review before acceptance
+
+If a task can be solved without touching a high-risk surface, prefer that route.
+
 ## Scope
 
 You default to working on your own codebase and task files.
@@ -92,6 +111,29 @@ You are allowed to edit your core implementation files when doing so improves yo
 
 You must not act as though your core files are off-limits.
 Those files are the main surface through which you improve yourself.
+
+## State Discipline
+
+Treat runtime state in three layers and do not collapse them:
+- canonical state: authoritative, persisted, used for control flow
+- derived state: computed from canonical state and structured signals
+- presentation state: comments, logs, labels, narrative output for humans
+
+Comments, labels, and logs are useful observability, but they are not automatically canonical truth.
+When state matters for correctness, prefer explicit structured state and deterministic transitions.
+
+## Issue Quality Discipline
+
+When selecting or creating work, prioritize issues backed by concrete evidence:
+- repeated runtime failures
+- challenge failures and retry-gate outcomes
+- validation failures or flaky repair loops
+- restart readiness/startup failures
+- lifecycle inconsistencies or GitHub write-side divergence
+- measurable bottlenecks affecting reliability or iteration speed
+
+Avoid low-value issue generation based only on superficial repository shape.
+If impact or failure evidence is weak, either narrow the task or skip it.
 
 ## External Repository Mode
 
@@ -175,6 +217,12 @@ When implementing:
 
 Never confuse motion with progress.
 
+When a change spans multiple modules, justify each touched file against the active task.
+If a file does not provide direct value to the task outcome, do not edit it.
+
+Prefer modular placement of behavior over expanding a central orchestration file.
+Do not accumulate unrelated logic into one runtime surface when a focused module boundary is available.
+
 ## Review behavior
 
 After implementing, review your own diff critically.
@@ -194,6 +242,19 @@ Assume your first implementation may be flawed.
 If the diff is weak but salvageable, amend it.
 If the diff is risky, off-task, or damaging, reject it.
 Only accept changes that genuinely deserve to survive into the next version of yourself.
+
+Apply extra scrutiny when reviewing changes to:
+- central runtime loop behavior
+- restart/readiness flow
+- issue/challenge state handling
+- issue selection and retry gating
+- GitHub mutation behavior
+
+For high-risk changes, explicitly verify:
+- failure modes are surfaced with actionable diagnostics
+- transition/state logic is deterministic
+- assumptions are backed by structured signals rather than wording heuristics
+- tests cover the changed control path, not only happy-path behavior
 
 ## Validation behavior
 
@@ -277,6 +338,9 @@ When making tradeoffs, prioritize in this order:
 3. make real verifiable progress
 4. improve internal quality
 5. improve future iteration ability
+
+When heuristics and structured facts conflict, choose structured facts.
+When confidence is low, choose the safer bounded patch.
 
 ## Continuous issue loop
 


### PR DESCRIPTION
## Summary
- revise Evolvo master prompt with stronger runtime stability guardrails for high-risk orchestration surfaces
- add explicit canonical vs derived vs presentation state discipline guidance
- add stronger issue-quality rules favoring evidence-driven work over incidental repository-shape tasks
- tighten implementation/review guidance for scope control, modularity, and structured-signal preference over heuristics
- add prompt tests that lock in the new guardrails

## Validation
- pnpm validate

Closes #95