### PR TITLE
fix(validation): add explicit exit code and duration fields

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -298,7 +298,19 @@ describe("main", () => {
 
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       13,
-      expect.stringContaining("`pnpm validate` (name=pnpm, status=1, elapsed=321ms)"),
+      expect.stringContaining("`pnpm validate` (name=pnpm, status=1, elapsed=321ms"),
+    );
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      13,
+      expect.stringContaining("exit_code=1"),
+    );
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      13,
+      expect.stringContaining("duration_ms=321ms"),
+    );
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      13,
+      expect.stringContaining("outcome=failed"),
     );
   });
 

--- a/src/runtime/issueLifecyclePresentation.ts
+++ b/src/runtime/issueLifecyclePresentation.ts
@@ -29,7 +29,9 @@ function formatValidationCommand(command: CommandExecutionSummary): string {
     ? command.commandName
     : getCommandName(command.command);
   const exitCode = command.exitCode === null ? "unknown" : String(command.exitCode);
-  return `- \`${command.command}\` (name=${commandName}, status=${exitCode}, elapsed=${formatDuration(command.durationMs)})`;
+  const duration = formatDuration(command.durationMs);
+  const outcome = command.exitCode === null ? "unknown" : command.exitCode === 0 ? "passed" : "failed";
+  return `- \`${command.command}\` (name=${commandName}, status=${exitCode}, elapsed=${duration}, exit_code=${exitCode}, duration_ms=${duration}, outcome=${outcome})`;
 }
 
 function summarizeRetryNotes(result: CodingAgentRunResult): string {


### PR DESCRIPTION
## Summary
- extend validation log formatting with explicit 'exit_code', 'duration_ms', and 'outcome'
- preserve existing fields ('name', 'status', 'elapsed') for continuity
- add assertions in main lifecycle tests for the new validation reporting fields

## Validation
- pnpm validate

Closes #106