### PR TITLE
fix(validation): normalize env-prefixed command names in reports

### DIFF
--- a/src/agents/runCodingAgent.test.ts
+++ b/src/agents/runCodingAgent.test.ts
@@ -221,6 +221,60 @@ describe("runCodingAgent", () => {
     );
   });
 
+  it("derives validation command name from env-prefixed commands", async () => {
+    startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
+    runStreamedMock.mockResolvedValue(createEventStream([
+      {
+        type: "item.started",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "CI=1 pnpm test",
+          aggregated_output: "",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "CI=1 pnpm test",
+          exit_code: 0,
+          aggregated_output: "ok",
+          status: "completed",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "2",
+          type: "agent_message",
+          text: "done",
+        },
+      },
+    ]));
+
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(2000)
+      .mockReturnValue(2400);
+
+    const { runCodingAgent } = await import("./runCodingAgent.js");
+    const result = await runCodingAgent("Run validation");
+
+    expect(result.summary.validationCommands).toEqual([
+      expect.objectContaining({
+        command: "CI=1 pnpm test",
+        commandName: "pnpm",
+        exitCode: 0,
+        durationMs: 400,
+      }),
+    ]);
+    expect(console.log).toHaveBeenCalledWith(
+      "[command completed] command=\"CI=1 pnpm test\" name=pnpm exit=0 duration=400ms",
+    );
+  });
+
   it("does not infer pull request merges from agent messages alone", async () => {
     startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
     runStreamedMock.mockResolvedValue(createEventStream([

--- a/src/agents/runCodingAgent.ts
+++ b/src/agents/runCodingAgent.ts
@@ -81,8 +81,7 @@ function formatFileChanges(item: Extract<ThreadItem, { type: "file_change" }>): 
 }
 
 function getCommandName(command: string): string {
-  const [commandName] = splitCommandTokens(command);
-  return commandName || "unknown";
+  return parseCommand(command).commandName || "unknown";
 }
 
 function splitCommandTokens(command: string): string[] {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -314,6 +314,30 @@ describe("main", () => {
     );
   });
 
+  it("derives lifecycle validation command name from env-prefixed command text", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 18, title: "Validation name fallback", description: "Check env command names", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    runCodingAgentMock.mockResolvedValueOnce({
+      ...DEFAULT_RUN_RESULT,
+      summary: {
+        ...DEFAULT_RUN_RESULT.summary,
+        validationCommands: [{ command: "CI=1 pnpm test", commandName: "", exitCode: 0, durationMs: 155 }],
+        failedValidationCommands: [],
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      18,
+      expect.stringContaining("`CI=1 pnpm test` (name=pnpm, status=0, elapsed=155ms"),
+    );
+  });
+
   it("prefers an issue already in progress", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([

--- a/src/runtime/issueLifecyclePresentation.ts
+++ b/src/runtime/issueLifecyclePresentation.ts
@@ -20,8 +20,22 @@ function formatDuration(durationMs: number | null): string {
 }
 
 function getCommandName(command: string): string {
-  const [commandName] = command.trim().split(/\s+/, 1);
-  return commandName || "unknown";
+  const tokens = command.trim().split(/\s+/).filter(Boolean);
+  let cursor = 0;
+
+  if (tokens[cursor] === "env") {
+    cursor += 1;
+    while (tokens[cursor]?.startsWith("-")) {
+      cursor += 1;
+    }
+  }
+
+  while (tokens[cursor]?.includes("=")) {
+    cursor += 1;
+  }
+
+  const commandName = tokens[cursor];
+  return commandName ? commandName.toLowerCase() : "unknown";
 }
 
 function formatValidationCommand(command: CommandExecutionSummary): string {


### PR DESCRIPTION
## Summary
- normalize command-name extraction for validation reporting when commands include env prefixes (for example 
> evolvo-ts@1.0.0 test /home/paddy/evolvo-ts
> vitest run src


 RUN  v4.0.18 /home/paddy/evolvo-ts

 ✓ src/environment.test.ts (2 tests) 20ms
 ✓ src/constants/workDir.test.ts (2 tests) 21ms
 ✓ src/github/githubConfig.test.ts (5 tests) 23ms
 ✓ src/runtime/selfRestart.test.ts (4 tests) 52ms
 ✓ src/runtime/lifecycleState.test.ts (5 tests) 24ms
 ✓ src/challenges/challengeMetrics.test.ts (6 tests) 30ms
 ✓ src/github/githubClient.test.ts (10 tests) 33ms
 ✓ src/challenges/challengeAttemptArtifacts.test.ts (3 tests) 32ms
 ✓ src/issues/startupIssueBootstrap.test.ts (5 tests) 45ms
 ✓ src/agents/runCodingAgent.test.ts (12 tests) 69ms
 ✓ src/issues/runIssueCommand.test.ts (17 tests) 59ms
 ✓ src/challenges/retryGate.test.ts (9 tests) 50ms
 ✓ src/main.replenishment.integration.test.ts (4 tests) 133ms
 ✓ src/challenges/challengeFailureLearning.test.ts (5 tests) 3ms
 ✓ src/agents/codingAgent.test.ts (8 tests) 2ms
 ✓ src/issues/challengeIssue.test.ts (5 tests) 2ms
 ✓ src/utils/string/stringifyOutput.test.ts (3 tests) 1ms
 ✓ src/issues/taskIssueManager.test.ts (26 tests) 12ms
 ✓ src/runtime/runtimeReadiness.test.ts (4 tests) 170ms
 ✓ src/main.test.ts (36 tests) 378ms

 Test Files  20 passed (20)
      Tests  171 passed (171)
   Start at  17:39:12
   Duration  637ms (transform 1.56s, setup 0ms, import 1.67s, tests 1.16s, environment 2ms))
- apply the same normalization in lifecycle comment formatting fallback logic
- add regression coverage for run summary and lifecycle comment rendering

## Validation
- pnpm vitest src/agents/runCodingAgent.test.ts src/main.test.ts

Closes #109