### PR TITLE
fix(validation): emit numeric duration_ms in lifecycle logs

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -306,7 +306,7 @@ describe("main", () => {
     );
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       13,
-      expect.stringContaining("duration_ms=321ms"),
+      expect.stringContaining("duration_ms=321"),
     );
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       13,
@@ -335,6 +335,31 @@ describe("main", () => {
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       18,
       expect.stringContaining("`CI=1 pnpm test` (name=pnpm, status=0, elapsed=155ms"),
+    );
+  });
+
+  it("logs unknown validation status and duration fields when command metadata is missing", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 20, title: "Validation unknown fields", description: "unknown status", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    runCodingAgentMock.mockResolvedValueOnce({
+      ...DEFAULT_RUN_RESULT,
+      summary: {
+        ...DEFAULT_RUN_RESULT.summary,
+        validationCommands: [{ command: "pnpm test", commandName: "", exitCode: null, durationMs: null }],
+        failedValidationCommands: [{ command: "pnpm test", commandName: "", exitCode: null, durationMs: null }],
+        reviewOutcome: "amended",
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      20,
+      expect.stringContaining("`pnpm test` (name=pnpm, status=unknown, elapsed=unknown, exit_code=unknown, duration_ms=unknown, outcome=unknown)"),
     );
   });
 

--- a/src/runtime/issueLifecyclePresentation.ts
+++ b/src/runtime/issueLifecyclePresentation.ts
@@ -19,6 +19,14 @@ function formatDuration(durationMs: number | null): string {
   return `${Math.round(durationMs)}ms`;
 }
 
+function formatDurationMsValue(durationMs: number | null): string {
+  if (durationMs === null || !Number.isFinite(durationMs) || durationMs < 0) {
+    return "unknown";
+  }
+
+  return String(Math.round(durationMs));
+}
+
 function getCommandName(command: string): string {
   const tokens = command.trim().split(/\s+/).filter(Boolean);
   let cursor = 0;
@@ -40,12 +48,13 @@ function getCommandName(command: string): string {
 
 function formatValidationCommand(command: CommandExecutionSummary): string {
   const commandName = typeof command.commandName === "string" && command.commandName.trim().length > 0
-    ? command.commandName
+    ? command.commandName.trim()
     : getCommandName(command.command);
   const exitCode = command.exitCode === null ? "unknown" : String(command.exitCode);
   const duration = formatDuration(command.durationMs);
+  const durationMsValue = formatDurationMsValue(command.durationMs);
   const outcome = command.exitCode === null ? "unknown" : command.exitCode === 0 ? "passed" : "failed";
-  return `- \`${command.command}\` (name=${commandName}, status=${exitCode}, elapsed=${duration}, exit_code=${exitCode}, duration_ms=${duration}, outcome=${outcome})`;
+  return `- \`${command.command}\` (name=${commandName}, status=${exitCode}, elapsed=${duration}, exit_code=${exitCode}, duration_ms=${durationMsValue}, outcome=${outcome})`;
 }
 
 function summarizeRetryNotes(result: CodingAgentRunResult): string {


### PR DESCRIPTION
## Summary
- emit `duration_ms` as a numeric milliseconds value in lifecycle validation logs while keeping human-readable `elapsed`
- normalize provided command names by trimming whitespace before formatting
- add regression coverage for unknown/null validation metadata fields

## Validation
- pnpm vitest src/main.test.ts
- pnpm vitest src/main.test.ts src/runtime/loopUtils.test.ts

Closes #121