### PR TITLE
fix(run-loop): normalize invalid retry attempt inputs

### DIFF
--- a/src/runtime/loopUtils.test.ts
+++ b/src/runtime/loopUtils.test.ts
@@ -17,6 +17,13 @@ describe("loopUtils retry handling", () => {
     expect(getRunLoopRetryDelayMs(9)).toBe(1000);
   });
 
+  it("falls back to base delay when retry attempt input is invalid", () => {
+    expect(getRunLoopRetryDelayMs(0)).toBe(50);
+    expect(getRunLoopRetryDelayMs(-3)).toBe(50);
+    expect(getRunLoopRetryDelayMs(Number.NaN)).toBe(50);
+    expect(getRunLoopRetryDelayMs(Number.POSITIVE_INFINITY)).toBe(50);
+  });
+
   it("classifies transient GitHub API status errors correctly", () => {
     expect(isTransientGitHubError(new GitHubApiError("rate", 429, null))).toBe(true);
     expect(isTransientGitHubError(new GitHubApiError("server", 500, null))).toBe(true);

--- a/src/runtime/loopUtils.ts
+++ b/src/runtime/loopUtils.ts
@@ -249,7 +249,11 @@ export function isTransientGitHubError(error: unknown): boolean {
 }
 
 export function getRunLoopRetryDelayMs(retryAttempt: number): number {
-  const exponentialDelay = RUN_LOOP_GITHUB_RETRY_BASE_DELAY_MS * (2 ** Math.max(0, retryAttempt - 1));
+  const normalizedAttempt =
+    Number.isFinite(retryAttempt) && retryAttempt > 0
+      ? Math.floor(retryAttempt)
+      : 1;
+  const exponentialDelay = RUN_LOOP_GITHUB_RETRY_BASE_DELAY_MS * (2 ** Math.max(0, normalizedAttempt - 1));
   return Math.min(exponentialDelay, RUN_LOOP_GITHUB_RETRY_MAX_DELAY_MS);
 }
 


### PR DESCRIPTION
## Summary
- harden retry delay calculation against invalid retry-attempt inputs
- treat non-positive/non-finite attempts as base attempt for deterministic backoff
- add direct unit coverage for invalid retry-attempt values

## Validation
- pnpm vitest src/runtime/loopUtils.test.ts src/main.test.ts

Closes #120