### PR TITLE
feat(run-loop): analyze codebase for non-startup queue replenishment

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -733,7 +733,7 @@ describe("main", () => {
 
     await main();
 
-    expect(generateStartupIssueTemplatesMock).not.toHaveBeenCalled();
+    expect(generateStartupIssueTemplatesMock).toHaveBeenCalledWith("/tmp/evolvo", { targetCount: 3 });
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({ minimumIssueCount: 3, maximumOpenIssues: 5 });
     expect(console.log).toHaveBeenCalledWith(
       "Cycle 1 queue health: open=1 selected=none queueAction=replenish created=1 outcome=continue",
@@ -794,6 +794,43 @@ describe("main", () => {
     );
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #31: Initial\n\nfirst");
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #32: Replenished\n\nsecond");
+  });
+
+  it("uses codebase analysis templates when replenishing a non-startup empty queue", async () => {
+    process.argv = ["node", "test-runner.ts"];
+    generateStartupIssueTemplatesMock.mockResolvedValueOnce([
+      { title: "Analysis issue A", description: "from analysis" },
+      { title: "Analysis issue B", description: "from analysis" },
+      { title: "Analysis issue C", description: "from analysis" },
+    ]);
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 33, title: "Initial", description: "first", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { number: 34, title: "Analysis Replenished", description: "second", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    replenishSelfImprovementIssuesMock.mockResolvedValueOnce({
+      created: [{ number: 34, title: "Analysis Replenished", description: "second", state: "open", labels: [] }],
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(generateStartupIssueTemplatesMock).toHaveBeenCalledWith("/tmp/evolvo", { targetCount: 3 });
+    expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      templates: [
+        { title: "Analysis issue A", description: "from analysis" },
+        { title: "Analysis issue B", description: "from analysis" },
+        { title: "Analysis issue C", description: "from analysis" },
+      ],
+    });
+    expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #33: Initial\n\nfirst");
+    expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #34: Analysis Replenished\n\nsecond");
   });
 
   it("replenishes an empty queue mid-run and keeps processing without hitting exit paths", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import {
 import { runIssueCommand } from "./issues/runIssueCommand.js";
 import { hasIssueLabel, isChallengeIssue } from "./issues/challengeIssue.js";
 import { TaskIssueManager, type IssueSummary } from "./issues/taskIssueManager.js";
+import { generateStartupIssueTemplates } from "./issues/startupIssueBootstrap.js";
 
 const MAX_ISSUE_CYCLES = 100;
 const MIN_REPLENISH_ISSUES = 3;
@@ -181,12 +182,30 @@ export async function main(): Promise<void> {
 
         if (!selectedIssue) {
           const isStartupBootstrap = cycle === 1 && openIssues.length === 0;
+          let analysisTemplates:
+            | Array<{
+              title: string;
+              description: string;
+            }>
+            | undefined;
+          if (!isStartupBootstrap && openIssues.length === 0) {
+            try {
+              analysisTemplates = await generateStartupIssueTemplates(WORK_DIR, { targetCount: MIN_REPLENISH_ISSUES });
+            } catch (error) {
+              if (error instanceof Error) {
+                console.error(`Queue analysis for replenishment templates failed: ${error.message}`);
+              } else {
+                console.error("Queue analysis for replenishment templates failed with an unknown error.");
+              }
+            }
+          }
           const createdIssues = isStartupBootstrap
             ? await bootstrapStartupIssues(issueManager, WORK_DIR)
             : (
                 await issueManager.replenishSelfImprovementIssues({
                   minimumIssueCount: MIN_REPLENISH_ISSUES,
                   maximumOpenIssues: MAX_OPEN_ISSUES,
+                  ...(analysisTemplates && analysisTemplates.length > 0 ? { templates: analysisTemplates } : {}),
                 })
               ).created;
           logCycleQueueHealth({


### PR DESCRIPTION
## Summary
- switch non-startup empty-queue replenishment to use codebase analysis templates
- pass analyzed templates into replenishment creation instead of relying directly on hard-coded fallback templates
- add regression coverage for analysis-driven non-startup replenishment behavior

## Validation
- pnpm vitest src/main.test.ts src/main.replenishment.integration.test.ts

Closes #131