### PR TITLE
fix(validation): include command name in lifecycle validation logs

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -298,11 +298,15 @@ describe("main", () => {
 
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       13,
-      expect.stringContaining("`pnpm validate` (name=pnpm, status=1, elapsed=321ms"),
+      expect.stringContaining("`pnpm validate` (name=pnpm, command_name=pnpm, status=1, elapsed=321ms"),
     );
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       13,
       expect.stringContaining("exit_code=1"),
+    );
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      13,
+      expect.stringContaining("command_name=pnpm"),
     );
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       13,
@@ -334,7 +338,7 @@ describe("main", () => {
 
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       18,
-      expect.stringContaining("`CI=1 pnpm test` (name=pnpm, status=0, elapsed=155ms"),
+      expect.stringContaining("`CI=1 pnpm test` (name=pnpm, command_name=pnpm, status=0, elapsed=155ms"),
     );
   });
 
@@ -359,7 +363,7 @@ describe("main", () => {
 
     expect(addProgressCommentMock).toHaveBeenCalledWith(
       20,
-      expect.stringContaining("`pnpm test` (name=pnpm, status=unknown, elapsed=unknown, exit_code=unknown, duration_ms=unknown, outcome=unknown)"),
+      expect.stringContaining("`pnpm test` (name=pnpm, command_name=pnpm, status=unknown, elapsed=unknown, exit_code=unknown, duration_ms=unknown, outcome=unknown)"),
     );
   });
 

--- a/src/runtime/issueLifecyclePresentation.ts
+++ b/src/runtime/issueLifecyclePresentation.ts
@@ -54,7 +54,7 @@ function formatValidationCommand(command: CommandExecutionSummary): string {
   const duration = formatDuration(command.durationMs);
   const durationMsValue = formatDurationMsValue(command.durationMs);
   const outcome = command.exitCode === null ? "unknown" : command.exitCode === 0 ? "passed" : "failed";
-  return `- \`${command.command}\` (name=${commandName}, status=${exitCode}, elapsed=${duration}, exit_code=${exitCode}, duration_ms=${durationMsValue}, outcome=${outcome})`;
+  return `- \`${command.command}\` (name=${commandName}, command_name=${commandName}, status=${exitCode}, elapsed=${duration}, exit_code=${exitCode}, duration_ms=${durationMsValue}, outcome=${outcome})`;
 }
 
 function summarizeRetryNotes(result: CodingAgentRunResult): string {


### PR DESCRIPTION
## Summary
- add explicit command_name field to lifecycle validation command lines
- update runtime integration tests to assert the new field in failure/recovery paths

## Validation
- pnpm vitest src/main.test.ts src/runtime/loopUtils.test.ts

Closes #118