### PR TITLE
feat(planner): use dedicated planner agent for empty queue issue generation

### DIFF
--- a/src/agents/plannerAgent.test.ts
+++ b/src/agents/plannerAgent.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bootstrapStartupIssuesMock = vi.fn();
+const generateStartupIssueTemplatesMock = vi.fn();
+
+vi.mock("../runtime/loopUtils.js", () => ({
+  bootstrapStartupIssues: bootstrapStartupIssuesMock,
+}));
+
+vi.mock("../issues/startupIssueBootstrap.js", () => ({
+  generateStartupIssueTemplates: generateStartupIssueTemplatesMock,
+}));
+
+describe("plannerAgent", () => {
+  beforeEach(() => {
+    bootstrapStartupIssuesMock.mockReset();
+    generateStartupIssueTemplatesMock.mockReset();
+  });
+
+  it("uses startup bootstrap planner path for cycle 1 empty queue", async () => {
+    bootstrapStartupIssuesMock.mockResolvedValueOnce([{ number: 11, title: "A", description: "a", state: "open", labels: [] }]);
+    const issueManager = {
+      replenishSelfImprovementIssues: vi.fn(),
+    } as unknown as import("../issues/taskIssueManager.js").TaskIssueManager;
+    const { runPlannerAgent } = await import("./plannerAgent.js");
+
+    const result = await runPlannerAgent({
+      cycle: 1,
+      openIssueCount: 0,
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issueManager,
+      workDir: "/tmp/evolvo",
+    });
+
+    expect(result.startupBootstrap).toBe(true);
+    expect(result.created).toEqual([{ number: 11, title: "A", description: "a", state: "open", labels: [] }]);
+    expect(bootstrapStartupIssuesMock).toHaveBeenCalledWith(issueManager, "/tmp/evolvo");
+    expect(generateStartupIssueTemplatesMock).not.toHaveBeenCalled();
+  });
+
+  it("uses repository analysis templates for non-startup planner replenishment", async () => {
+    generateStartupIssueTemplatesMock.mockResolvedValueOnce([
+      { title: "Planned A", description: "A" },
+      { title: "Planned B", description: "B" },
+    ]);
+    const replenishMock = vi.fn().mockResolvedValueOnce({
+      created: [{ number: 21, title: "Planned A", description: "A", state: "open", labels: [] }],
+    });
+    const issueManager = {
+      replenishSelfImprovementIssues: replenishMock,
+    } as unknown as import("../issues/taskIssueManager.js").TaskIssueManager;
+    const { runPlannerAgent } = await import("./plannerAgent.js");
+
+    const result = await runPlannerAgent({
+      cycle: 2,
+      openIssueCount: 0,
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issueManager,
+      workDir: "/tmp/evolvo",
+    });
+
+    expect(result.startupBootstrap).toBe(false);
+    expect(generateStartupIssueTemplatesMock).toHaveBeenCalledWith("/tmp/evolvo", { targetCount: 3 });
+    expect(replenishMock).toHaveBeenCalledWith({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      templates: [
+        { title: "Planned A", description: "A" },
+        { title: "Planned B", description: "B" },
+      ],
+    });
+    expect(result.created).toEqual([{ number: 21, title: "Planned A", description: "A", state: "open", labels: [] }]);
+  });
+
+  it("falls back to default replenishment when repository analysis fails", async () => {
+    generateStartupIssueTemplatesMock.mockRejectedValueOnce(new Error("analysis failed"));
+    const replenishMock = vi.fn().mockResolvedValueOnce({
+      created: [{ number: 22, title: "Fallback", description: "B", state: "open", labels: [] }],
+    });
+    const issueManager = {
+      replenishSelfImprovementIssues: replenishMock,
+    } as unknown as import("../issues/taskIssueManager.js").TaskIssueManager;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { runPlannerAgent } = await import("./plannerAgent.js");
+
+    const result = await runPlannerAgent({
+      cycle: 2,
+      openIssueCount: 1,
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issueManager,
+      workDir: "/tmp/evolvo",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith("Queue analysis for replenishment templates failed: analysis failed");
+    expect(replenishMock).toHaveBeenCalledWith({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+    });
+    expect(result.created).toEqual([{ number: 22, title: "Fallback", description: "B", state: "open", labels: [] }]);
+  });
+});

--- a/src/agents/plannerAgent.ts
+++ b/src/agents/plannerAgent.ts
@@ -1,0 +1,58 @@
+import type { IssueSummary, TaskIssueManager } from "../issues/taskIssueManager.js";
+import { generateStartupIssueTemplates } from "../issues/startupIssueBootstrap.js";
+import { bootstrapStartupIssues } from "../runtime/loopUtils.js";
+
+export type PlannerAgentInput = {
+  cycle: number;
+  openIssueCount: number;
+  minimumIssueCount: number;
+  maximumOpenIssues: number;
+  issueManager: TaskIssueManager;
+  workDir: string;
+};
+
+export type PlannerAgentResult = {
+  created: IssueSummary[];
+  startupBootstrap: boolean;
+};
+
+export async function runPlannerAgent(input: PlannerAgentInput): Promise<PlannerAgentResult> {
+  const startupBootstrap = input.cycle === 1 && input.openIssueCount === 0;
+  if (startupBootstrap) {
+    return {
+      created: await bootstrapStartupIssues(input.issueManager, input.workDir),
+      startupBootstrap: true,
+    };
+  }
+
+  let plannerTemplates:
+    | Array<{
+      title: string;
+      description: string;
+    }>
+    | undefined;
+  try {
+    plannerTemplates = await generateStartupIssueTemplates(input.workDir, {
+      targetCount: input.minimumIssueCount,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Queue analysis for replenishment templates failed: ${error.message}`);
+    } else {
+      console.error("Queue analysis for replenishment templates failed with an unknown error.");
+    }
+  }
+
+  const created = (
+    await input.issueManager.replenishSelfImprovementIssues({
+      minimumIssueCount: input.minimumIssueCount,
+      maximumOpenIssues: input.maximumOpenIssues,
+      ...(plannerTemplates && plannerTemplates.length > 0 ? { templates: plannerTemplates } : {}),
+    })
+  ).created;
+
+  return {
+    created,
+    startupBootstrap: false,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import { pathToFileURL } from "node:url";
 import type { CodingAgentRunResult } from "./agents/runCodingAgent.js";
 import { runCodingAgent } from "./agents/runCodingAgent.js";
+import { runPlannerAgent } from "./agents/plannerAgent.js";
 import { WORK_DIR } from "./constants/workDir.js";
 import { GitHubClient } from "./github/githubClient.js";
 import { getGitHubConfig } from "./github/githubConfig.js";
@@ -14,7 +15,6 @@ import { writeRuntimeReadinessSignal } from "./runtime/runtimeReadiness.js";
 import { runPostMergeSelfRestart } from "./runtime/selfRestart.js";
 import {
   DEFAULT_PROMPT as LOOP_DEFAULT_PROMPT,
-  bootstrapStartupIssues,
   buildPromptFromIssue,
   formatIssueForLog,
   getRunLoopRetryDelayMs,
@@ -43,7 +43,6 @@ import {
 import { runIssueCommand } from "./issues/runIssueCommand.js";
 import { hasIssueLabel, isChallengeIssue } from "./issues/challengeIssue.js";
 import { TaskIssueManager, type IssueSummary } from "./issues/taskIssueManager.js";
-import { generateStartupIssueTemplates } from "./issues/startupIssueBootstrap.js";
 
 const MAX_ISSUE_CYCLES = 100;
 const MIN_REPLENISH_ISSUES = 3;
@@ -199,46 +198,28 @@ export async function main(): Promise<void> {
         const selectedIssue = selectIssueForWork(retryEligibleIssues);
 
         if (!selectedIssue) {
-          const isStartupBootstrap = cycle === 1 && openIssues.length === 0;
-          let analysisTemplates:
-            | Array<{
-              title: string;
-              description: string;
-            }>
-            | undefined;
-          if (!isStartupBootstrap && openIssues.length === 0) {
-            try {
-              analysisTemplates = await generateStartupIssueTemplates(WORK_DIR, { targetCount: MIN_REPLENISH_ISSUES });
-            } catch (error) {
-              if (error instanceof Error) {
-                console.error(`Queue analysis for replenishment templates failed: ${error.message}`);
-              } else {
-                console.error("Queue analysis for replenishment templates failed with an unknown error.");
-              }
-            }
-          }
-          const createdIssues = isStartupBootstrap
-            ? await bootstrapStartupIssues(issueManager, WORK_DIR)
-            : (
-                await issueManager.replenishSelfImprovementIssues({
-                  minimumIssueCount: MIN_REPLENISH_ISSUES,
-                  maximumOpenIssues: MAX_OPEN_ISSUES,
-                  ...(analysisTemplates && analysisTemplates.length > 0 ? { templates: analysisTemplates } : {}),
-                })
-              ).created;
+          const plannerResult = await runPlannerAgent({
+            cycle,
+            openIssueCount: openIssues.length,
+            minimumIssueCount: MIN_REPLENISH_ISSUES,
+            maximumOpenIssues: MAX_OPEN_ISSUES,
+            issueManager,
+            workDir: WORK_DIR,
+          });
+          const createdIssues = plannerResult.created;
           logCycleQueueHealth({
             cycle,
             openCount: openIssues.length,
             selectedIssue: null,
             queueAction: {
-              type: isStartupBootstrap ? "bootstrap" : "replenish",
+              type: plannerResult.startupBootstrap ? "bootstrap" : "replenish",
               createdCount: createdIssues.length,
               outcome: createdIssues.length > 0 ? "continue" : "stop",
             },
           });
 
           if (createdIssues.length > 0) {
-            if (isStartupBootstrap) {
+            if (plannerResult.startupBootstrap) {
               console.log("No open issues found on startup. Bootstrapped issue queue from repository analysis.");
             }
             logCreatedIssues(createdIssues);


### PR DESCRIPTION
## Summary
- add a dedicated planner agent that owns issue generation when no actionable work exists
- route queue-empty/no-actionable flow in main runtime through the planner agent
- keep startup bootstrap and replenishment behavior, but with planning responsibility separated from main loop orchestration

## Validation
- pnpm vitest src/agents/plannerAgent.test.ts src/main.test.ts src/main.replenishment.integration.test.ts
- pnpm typecheck
- pnpm test

Closes #145