### PR TITLE
fix: validate planner drafts before dedupe (#291)

### DIFF
--- a/src/agents/plannerAgent.test.ts
+++ b/src/agents/plannerAgent.test.ts
@@ -102,6 +102,52 @@ describe("plannerAgent", () => {
     });
   });
 
+  it("skips malformed planner issue drafts and logs diagnostics", async () => {
+    threadRunMock.mockResolvedValueOnce({
+      finalResponse: JSON.stringify({
+        issues: [
+          null,
+          { title: 42, description: "Not valid title type." },
+          { title: "   ", description: "Missing title text." },
+          { title: "Valid planner draft", description: "  Keep this one after trimming. " },
+          { title: "Valid planner draft", description: "Duplicate title should be ignored." },
+          { title: "Second valid planner draft", description: "Also valid." },
+        ],
+      }),
+    });
+    const createPlannedIssuesMock = vi.fn().mockResolvedValueOnce({ created: [] });
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValueOnce([]),
+      listRecentClosedIssues: vi.fn().mockResolvedValueOnce([]),
+      createPlannedIssues: createPlannedIssuesMock,
+    } as unknown as import("../issues/taskIssueManager.js").TaskIssueManager;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { runPlannerAgent } = await import("./plannerAgent.js");
+
+    await runPlannerAgent({
+      cycle: 2,
+      openIssueCount: 0,
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issueManager,
+      workDir: "/tmp/evolvo",
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    expect(warnSpy).toHaveBeenNthCalledWith(1, "Planner returned invalid issue draft at index 0: expected an object.");
+    expect(warnSpy).toHaveBeenNthCalledWith(2, "Planner returned invalid issue draft at index 1: title and description must be strings.");
+    expect(warnSpy).toHaveBeenNthCalledWith(3, "Planner returned invalid issue draft at index 2: title and description cannot be empty.");
+    expect(createPlannedIssuesMock).toHaveBeenCalledWith({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issues: [
+        { title: "Valid planner draft", description: "Keep this one after trimming." },
+        { title: "Second valid planner draft", description: "Also valid." },
+      ],
+    });
+    warnSpy.mockRestore();
+  });
+
   it("returns no created issues when planner analysis fails", async () => {
     threadRunMock.mockRejectedValueOnce(new Error("planner failed"));
     const createPlannedIssuesMock = vi.fn();

--- a/src/agents/plannerAgent.ts
+++ b/src/agents/plannerAgent.ts
@@ -45,11 +45,33 @@ const PLANNER_OUTPUT_SCHEMA = {
 } as const;
 
 type PlannerResponse = {
-  issues: PlannedIssueDraft[];
+  issues: unknown[];
 };
 
 function normalizeTitle(title: string): string {
   return title.trim().toLowerCase();
+}
+
+function validatePlannedIssueDraft(issue: unknown, index: number): PlannedIssueDraft | null {
+  if (!issue || typeof issue !== "object") {
+    console.warn(`Planner returned invalid issue draft at index ${index}: expected an object.`);
+    return null;
+  }
+
+  const draft = issue as { title?: unknown; description?: unknown };
+  if (typeof draft.title !== "string" || typeof draft.description !== "string") {
+    console.warn(`Planner returned invalid issue draft at index ${index}: title and description must be strings.`);
+    return null;
+  }
+
+  const title = draft.title.trim();
+  const description = draft.description.trim();
+  if (!title || !description) {
+    console.warn(`Planner returned invalid issue draft at index ${index}: title and description cannot be empty.`);
+    return null;
+  }
+
+  return { title, description };
 }
 
 function dedupePlannedIssues(issues: PlannedIssueDraft[]): PlannedIssueDraft[] {
@@ -57,15 +79,13 @@ function dedupePlannedIssues(issues: PlannedIssueDraft[]): PlannedIssueDraft[] {
   const unique: PlannedIssueDraft[] = [];
 
   for (const issue of issues) {
-    const title = issue.title.trim();
-    const description = issue.description.trim();
-    const key = normalizeTitle(title);
-    if (!title || !description || seen.has(key)) {
+    const key = normalizeTitle(issue.title);
+    if (seen.has(key)) {
       continue;
     }
 
     seen.add(key);
-    unique.push({ title, description });
+    unique.push(issue);
   }
 
   return unique;
@@ -77,7 +97,10 @@ function parsePlannerResponse(finalResponse: string): PlannedIssueDraft[] {
     throw new Error("Planner response did not contain an issues array.");
   }
 
-  return dedupePlannedIssues(parsed.issues);
+  const validIssues = parsed.issues
+    .map((issue, index) => validatePlannedIssueDraft(issue, index))
+    .filter((issue): issue is PlannedIssueDraft => issue !== null);
+  return dedupePlannedIssues(validIssues);
 }
 
 function formatIssueListForPrompt(issues: IssueSummary[]): string {


### PR DESCRIPTION
## Summary
- add explicit runtime validation for each planner draft entry before trimming/deduping
- skip malformed entries with indexed diagnostics instead of throwing during replenish planning
- add malformed payload coverage in planner agent tests

## Validation
- pnpm vitest run src/agents/plannerAgent.test.ts

Closes #291