### PR TITLE
fix: dedupe closed planner history before 25-item cap (#292)

### DIFF
--- a/src/agents/plannerAgent.test.ts
+++ b/src/agents/plannerAgent.test.ts
@@ -102,6 +102,58 @@ describe("plannerAgent", () => {
     });
   });
 
+  it("deduplicates repeated closed-issue follow-ups before applying the 25-item prompt cap", async () => {
+    threadRunMock.mockResolvedValueOnce({
+      finalResponse: JSON.stringify({ issues: [] }),
+    });
+    const createPlannedIssuesMock = vi.fn().mockResolvedValueOnce({ created: [] });
+    const repeatedFollowUps = Array.from({ length: 30 }, (_, index) => ({
+      number: 2000 + index,
+      title: `Startup bootstrap reliability hardening (follow-up ${index + 1})`,
+      description: "Repeated thread title with follow-up suffix.",
+      state: "closed" as const,
+      labels: [],
+    }));
+    const diverseHistory = Array.from({ length: 30 }, (_, index) => ({
+      number: 3000 + index,
+      title: `Diverse closed issue ${index + 1}`,
+      description: "Distinct historical signal.",
+      state: "closed" as const,
+      labels: [],
+    }));
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValueOnce([]),
+      listRecentClosedIssues: vi.fn().mockResolvedValueOnce([...repeatedFollowUps, ...diverseHistory]),
+      createPlannedIssues: createPlannedIssuesMock,
+    } as unknown as import("../issues/taskIssueManager.js").TaskIssueManager;
+    const { runPlannerAgent } = await import("./plannerAgent.js");
+
+    await runPlannerAgent({
+      cycle: 2,
+      openIssueCount: 0,
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issueManager,
+      workDir: "/tmp/evolvo",
+    });
+
+    const plannerPrompt = threadRunMock.mock.calls[0]?.[0] as string;
+    const recentlyClosedSection = plannerPrompt
+      .split("Recently closed issues:\n")[1]
+      ?.split("\n\nReturn only structured JSON matching the schema.")[0] ?? "";
+    const recentClosedLines = recentlyClosedSection.split("\n").filter((line) => line.startsWith("- #"));
+
+    expect(recentClosedLines).toHaveLength(25);
+    expect(plannerPrompt.match(/Startup bootstrap reliability hardening/gi)).toHaveLength(1);
+    expect(plannerPrompt).toContain("Diverse closed issue 24");
+    expect(plannerPrompt).not.toContain("Diverse closed issue 25");
+    expect(createPlannedIssuesMock).toHaveBeenCalledWith({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issues: [],
+    });
+  });
+
   it("skips malformed planner issue drafts and logs diagnostics", async () => {
     threadRunMock.mockResolvedValueOnce({
       finalResponse: JSON.stringify({

--- a/src/agents/plannerAgent.ts
+++ b/src/agents/plannerAgent.ts
@@ -52,6 +52,29 @@ function normalizeTitle(title: string): string {
   return title.trim().toLowerCase();
 }
 
+function normalizeClosedIssueTitle(title: string): string {
+  return normalizeTitle(title)
+    .replace(/\s*\(follow-up\s+\d+\)\s*$/i, "")
+    .replace(/\s+/g, " ");
+}
+
+function dedupeClosedIssueHistory(issues: IssueSummary[]): IssueSummary[] {
+  const seen = new Set<string>();
+  const unique: IssueSummary[] = [];
+
+  for (const issue of issues) {
+    const key = normalizeClosedIssueTitle(issue.title);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    unique.push(issue);
+  }
+
+  return unique;
+}
+
 function validatePlannedIssueDraft(issue: unknown, index: number): PlannedIssueDraft | null {
   if (!issue || typeof issue !== "object") {
     console.warn(`Planner returned invalid issue draft at index ${index}: expected an object.`);
@@ -114,6 +137,8 @@ function formatIssueListForPrompt(issues: IssueSummary[]): string {
 }
 
 function buildPlannerPrompt(input: PlannerAgentInput, openIssues: IssueSummary[], recentClosedIssues: IssueSummary[]): string {
+  const recentClosedIssueHistory = dedupeClosedIssueHistory(recentClosedIssues).slice(0, 25);
+
   return [
     "Inspect this repository and propose new GitHub issues for Evolvo.",
     "",
@@ -129,7 +154,7 @@ function buildPlannerPrompt(input: PlannerAgentInput, openIssues: IssueSummary[]
     formatIssueListForPrompt(openIssues),
     "",
     "Recently closed issues:",
-    formatIssueListForPrompt(recentClosedIssues.slice(0, 25)),
+    formatIssueListForPrompt(recentClosedIssueHistory),
     "",
     "Return only structured JSON matching the schema.",
   ].join("\n");


### PR DESCRIPTION
## Summary
- normalize recent closed issue titles by trimming, lowercasing, collapsing whitespace, and removing trailing `(follow-up N)`
- deduplicate recent closed history before applying the 25-item prompt cap
- add regression coverage proving repeated follow-ups collapse and the capped prompt keeps diverse history entries

## Validation
- pnpm vitest run src/agents/plannerAgent.test.ts

Closes #292