### PR TITLE
fix: honor GitHub rate-limit headers in retry backoff (#290)

### DIFF
--- a/src/github/githubClient.test.ts
+++ b/src/github/githubClient.test.ts
@@ -121,6 +121,79 @@ describe("GitHubClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("uses Retry-After header delay before retrying", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ message: "Rate limit exceeded" }), {
+            status: 429,
+            headers: {
+              "content-type": "application/json",
+              "retry-after": "2",
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify([{ number: 9 }]), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      const client = createClient({ maxRetries: 1, retryBaseDelayMs: 1 });
+      const resultPromise = client.get<Array<{ number: number }>>("?state=open");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(resultPromise).resolves.toEqual([{ number: 9 }]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses X-RateLimit-Reset header delay before retrying", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      const rateLimitResetEpochSeconds = Math.floor((Date.now() + 3_000) / 1_000);
+
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ message: "Service unavailable" }), {
+            status: 503,
+            headers: {
+              "content-type": "application/json",
+              "x-ratelimit-reset": String(rateLimitResetEpochSeconds),
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ number: 7 }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      const client = createClient({ maxRetries: 1, retryBaseDelayMs: 1 });
+      const resultPromise = client.get<{ number: number }>("/7");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(2_999);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(resultPromise).resolves.toEqual({ number: 7 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not retry non-retryable statuses", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ message: "Bad credentials" }), {

--- a/src/github/githubClient.ts
+++ b/src/github/githubClient.ts
@@ -3,12 +3,14 @@ import type { GitHubConfig } from "./githubConfig.js";
 export class GitHubApiError extends Error {
   public readonly status: number;
   public readonly responseBody: unknown;
+  public readonly responseHeaders: Headers | null;
 
-  public constructor(message: string, status: number, responseBody: unknown) {
+  public constructor(message: string, status: number, responseBody: unknown, responseHeaders?: Headers | null) {
     super(message);
     this.name = "GitHubApiError";
     this.status = status;
     this.responseBody = responseBody;
+    this.responseHeaders = responseHeaders ?? null;
   }
 }
 
@@ -97,7 +99,7 @@ export class GitHubClient {
 
         if (!response.ok) {
           const message = this.getErrorMessage(responseBody, response.status);
-          throw new GitHubApiError(message, response.status, responseBody);
+          throw new GitHubApiError(message, response.status, responseBody, response.headers);
         }
 
         return responseBody as T;
@@ -107,7 +109,7 @@ export class GitHubClient {
           throw error;
         }
 
-        await this.waitBeforeRetry(attempt);
+        await this.waitBeforeRetry(this.getRetryDelayMs(attempt, error));
       }
     }
 
@@ -169,11 +171,57 @@ export class GitHubClient {
     return false;
   }
 
-  private async waitBeforeRetry(attempt: number): Promise<void> {
-    const delayMs = this.retryBaseDelayMs * attempt;
+  private async waitBeforeRetry(delayMs: number): Promise<void> {
+    const normalizedDelayMs = Math.max(0, Math.floor(delayMs));
     await new Promise((resolve) => {
-      setTimeout(resolve, delayMs);
+      setTimeout(resolve, normalizedDelayMs);
     });
+  }
+
+  private getRetryDelayMs(attempt: number, error: unknown): number {
+    const attemptDelayMs = this.retryBaseDelayMs * attempt;
+    if (!(error instanceof GitHubApiError)) {
+      return attemptDelayMs;
+    }
+
+    const retryAfterDelayMs = this.parseRetryAfterDelayMs(error.responseHeaders);
+    const rateLimitResetDelayMs = this.parseRateLimitResetDelayMs(error.responseHeaders);
+    const advertisedDelayMs = Math.max(retryAfterDelayMs, rateLimitResetDelayMs);
+    return Math.max(attemptDelayMs, advertisedDelayMs);
+  }
+
+  private parseRetryAfterDelayMs(headers: Headers | null): number {
+    const rawValue = headers?.get("retry-after")?.trim();
+    if (!rawValue) {
+      return 0;
+    }
+
+    const seconds = Number(rawValue);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Math.ceil(seconds * 1000);
+    }
+
+    const parsedDateMs = Date.parse(rawValue);
+    if (Number.isNaN(parsedDateMs)) {
+      return 0;
+    }
+
+    return Math.max(0, parsedDateMs - Date.now());
+  }
+
+  private parseRateLimitResetDelayMs(headers: Headers | null): number {
+    const rawValue = headers?.get("x-ratelimit-reset")?.trim();
+    if (!rawValue) {
+      return 0;
+    }
+
+    const resetAtSeconds = Number(rawValue);
+    if (!Number.isFinite(resetAtSeconds) || resetAtSeconds < 0) {
+      return 0;
+    }
+
+    const resetAtMs = Math.floor(resetAtSeconds * 1000);
+    return Math.max(0, resetAtMs - Date.now());
   }
 
   private async readResponseBody(response: Response): Promise<unknown> {


### PR DESCRIPTION
## Summary
- attach response headers to `GitHubApiError` for retry decisioning
- compute retry delays from `Retry-After` and `X-RateLimit-Reset` headers when present
- keep linear backoff as fallback and lower bound
- add focused timing tests for both headers in `githubClient.test.ts`

## Validation
- pnpm vitest run src/github/githubClient.test.ts

Closes #290