### PR TITLE
fix: terminate restarted child when post-merge readiness fails

### DIFF
--- a/src/runtime/selfRestart.test.ts
+++ b/src/runtime/selfRestart.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.fn();
 const spawnMock = vi.fn();
+const rmMock = vi.fn();
 const getRuntimeReadinessSignalPathMock = vi.fn();
 const waitForRuntimeReadinessSignalMock = vi.fn();
 
@@ -10,21 +11,47 @@ vi.mock("node:child_process", () => ({
   spawn: spawnMock,
 }));
 
+vi.mock("node:fs", () => ({
+  promises: {
+    rm: rmMock,
+  },
+}));
+
 vi.mock("./runtimeReadiness.js", () => ({
   getRuntimeReadinessSignalPath: getRuntimeReadinessSignalPathMock,
   waitForRuntimeReadinessSignal: waitForRuntimeReadinessSignalMock,
 }));
 
 function createChildProcessStub(overrides: {
+  exitCode?: number | null;
+  signalCode?: NodeJS.Signals | null;
+  killed?: boolean;
+  kill?: (signal?: NodeJS.Signals | number) => boolean;
   pid?: number;
   once?: (event: string, handler: (...args: unknown[]) => void) => void;
   removeListener?: (event: string, handler: (...args: unknown[]) => void) => void;
 } = {}) {
   return {
+    exitCode: overrides.exitCode ?? null,
+    signalCode: overrides.signalCode ?? null,
+    killed: overrides.killed ?? false,
+    kill: overrides.kill ?? vi.fn(() => true),
     pid: overrides.pid ?? 999,
     once: overrides.once ?? vi.fn(),
     removeListener: overrides.removeListener ?? vi.fn(),
   };
+}
+
+async function waitForSpawn(iterations = 20): Promise<void> {
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    if (spawnMock.mock.calls.length > 0) {
+      return;
+    }
+
+    await Promise.resolve();
+  }
+
+  throw new Error("Timed out waiting for pnpm start to be spawned.");
 }
 
 describe("runPostMergeSelfRestart", () => {
@@ -33,6 +60,8 @@ describe("runPostMergeSelfRestart", () => {
     vi.useFakeTimers();
     execFileMock.mockReset();
     spawnMock.mockReset();
+    rmMock.mockReset();
+    rmMock.mockResolvedValue(undefined);
     getRuntimeReadinessSignalPathMock.mockReset();
     getRuntimeReadinessSignalPathMock.mockReturnValue("/tmp/evolvo/.evolvo/runtime-readiness.json");
     waitForRuntimeReadinessSignalMock.mockReset();
@@ -132,7 +161,8 @@ describe("runPostMergeSelfRestart", () => {
     execFileMock.mockImplementation((_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
       callback(null, "", "");
     });
-    const child = createChildProcessStub();
+    const kill = vi.fn(() => true);
+    const child = createChildProcessStub({ kill });
     spawnMock.mockReturnValue(child);
     waitForRuntimeReadinessSignalMock.mockRejectedValueOnce(new Error("Timed out waiting for readiness token"));
 
@@ -140,5 +170,28 @@ describe("runPostMergeSelfRestart", () => {
     await expect(runPostMergeSelfRestart("/tmp/evolvo")).rejects.toThrow(
       "Post-merge restart readiness check failed: Timed out waiting for readiness token",
     );
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("terminates the restarted child when readiness times out", async () => {
+    execFileMock.mockImplementation((_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+      callback(null, "", "");
+    });
+    const kill = vi.fn(() => true);
+    const child = createChildProcessStub({ kill });
+    spawnMock.mockReturnValue(child);
+    waitForRuntimeReadinessSignalMock.mockImplementation(() => new Promise(() => {}));
+
+    const { runPostMergeSelfRestart } = await import("./selfRestart.js");
+    const restartPromise = runPostMergeSelfRestart("/tmp/evolvo");
+    const rejectionExpectation = expect(restartPromise).rejects.toThrow(
+      "Post-merge restart readiness check failed: timed out after 15000ms",
+    );
+
+    await waitForSpawn();
+    await vi.advanceTimersByTimeAsync(15000);
+
+    await rejectionExpectation;
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
   });
 });

--- a/src/runtime/selfRestart.ts
+++ b/src/runtime/selfRestart.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
@@ -32,6 +32,14 @@ async function runStep(command: string, args: string[], workingDirectory: string
   }
 }
 
+function terminateSpawnedRuntime(child: ChildProcess): void {
+  if (child.killed || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+}
+
 async function startUpdatedRuntime(workingDirectory: string): Promise<void> {
   console.log("[restart] Running: pnpm start");
   const readinessToken = randomUUID();
@@ -53,6 +61,7 @@ async function startUpdatedRuntime(workingDirectory: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
       cleanup();
+      terminateSpawnedRuntime(child);
       reject(
         new Error(
           `Post-merge restart readiness check failed: timed out after ${STARTUP_READINESS_TIMEOUT_MS}ms waiting for token ${readinessToken} at ${readinessSignalPath}.`,
@@ -90,6 +99,7 @@ async function startUpdatedRuntime(workingDirectory: string): Promise<void> {
       resolve();
     }).catch((error) => {
       cleanup();
+      terminateSpawnedRuntime(child);
       reject(new Error(
         `Post-merge restart readiness check failed: ${
           error instanceof Error ? error.message : "unknown error"


### PR DESCRIPTION
## Summary
- terminate the spawned `pnpm start` child when the post-merge readiness handshake times out or returns an error
- keep the cleanup scoped to readiness-failure paths so successful starts and early exits keep their existing behavior
- cover both readiness-error and readiness-timeout paths in `selfRestart.test.ts`

Closes #289.

## Validation
- `pnpm exec vitest run src/runtime/selfRestart.test.ts`
- `pnpm typecheck`
- `pnpm test` *(fails only on the pre-existing `src/runtime/operatorControl.test.ts` assertion about Discord fetch not being called)*