### PR TITLE
feat: send Discord issue-start embed notifications

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -25,6 +25,7 @@ const buildLifecycleStateCommentMock = vi.fn();
 const writeRuntimeReadinessSignalMock = vi.fn();
 const requestCycleLimitDecisionFromOperatorMock = vi.fn();
 const runDiscordOperatorControlStartupCheckMock = vi.fn();
+const notifyIssueStartedInDiscordMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -90,6 +91,7 @@ vi.mock("./runtime/runtimeReadiness.js", () => ({
 }));
 
 vi.mock("./runtime/operatorControl.js", () => ({
+  notifyIssueStartedInDiscord: notifyIssueStartedInDiscordMock,
   requestCycleLimitDecisionFromOperator: requestCycleLimitDecisionFromOperatorMock,
   runDiscordOperatorControlStartupCheck: runDiscordOperatorControlStartupCheckMock,
 }));
@@ -248,6 +250,8 @@ describe("main", () => {
     requestCycleLimitDecisionFromOperatorMock.mockResolvedValue(null);
     runDiscordOperatorControlStartupCheckMock.mockReset();
     runDiscordOperatorControlStartupCheckMock.mockResolvedValue(undefined);
+    notifyIssueStartedInDiscordMock.mockReset();
+    notifyIssueStartedInDiscordMock.mockResolvedValue(undefined);
     process.argv = ["node", "test-runner.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -309,6 +313,13 @@ describe("main", () => {
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Canonical Lifecycle State"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Start"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Execution Log"));
+    expect(notifyIssueStartedInDiscordMock).toHaveBeenCalledWith({
+      issueNumber: 12,
+      issueTitle: "Fix login redirect",
+      issueUrl: "https://github.com/owner/repo/issues/12",
+      repository: "owner/repo",
+      lifecycleState: "selected -> executing",
+    });
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #12: Fix login redirect\n\nHandle callback URL.");
     expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=1 selected=#12");
     expect(recordChallengeAttemptMetricsMock).not.toHaveBeenCalled();
@@ -420,6 +431,7 @@ describe("main", () => {
     await main();
 
     expect(markInProgressMock).not.toHaveBeenCalled();
+    expect(notifyIssueStartedInDiscordMock).not.toHaveBeenCalled();
     expect(addProgressCommentMock).not.toHaveBeenCalledWith(9, expect.stringContaining("## Task Start"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(9, expect.stringContaining("## Task Execution Log"));
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #9: B\n\nB");

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
   waitForRunLoopRetry,
 } from "./runtime/loopUtils.js";
 import {
+  notifyIssueStartedInDiscord,
   requestCycleLimitDecisionFromOperator,
   runDiscordOperatorControlStartupCheck,
 } from "./runtime/operatorControl.js";
@@ -153,6 +154,7 @@ export async function main(): Promise<void> {
 
   const { GITHUB_OWNER, GITHUB_REPO } = await import("./environment.js");
   const issueManager = new TaskIssueManager(new GitHubClient(getGitHubConfig()));
+  const repositoryName = `${GITHUB_OWNER}/${GITHUB_REPO}`;
 
   console.log(`Hello from ${GITHUB_OWNER}/${GITHUB_REPO}!`);
   console.log(`Working directory: ${WORK_DIR}`);
@@ -274,6 +276,13 @@ export async function main(): Promise<void> {
 
         if (startedThisCycle) {
           await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue));
+          await notifyIssueStartedInDiscord({
+            issueNumber: selectedIssue.number,
+            issueTitle: selectedIssue.title,
+            issueUrl: `https://github.com/${repositoryName}/issues/${selectedIssue.number}`,
+            repository: repositoryName,
+            lifecycleState: "selected -> executing",
+          });
         }
 
         const prompt = buildPromptFromIssue(selectedIssue);

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getDiscordControlConfigFromEnv,
+  notifyIssueStartedInDiscord,
   requestCycleLimitDecisionFromOperator,
   runDiscordOperatorControlStartupCheck,
 } from "./operatorControl.js";
@@ -22,12 +23,35 @@ describe("operatorControl", () => {
   });
 
   it("returns null decision when Discord operator control is not configured", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "");
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
 
     const decision = await requestCycleLimitDecisionFromOperator(100);
 
     expect(decision).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not send an issue-start notification when Discord operator control is not configured", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyIssueStartedInDiscord({
+      issueNumber: 298,
+      issueTitle: "Send Discord start embed",
+      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
+      repository: "evolvo-auto/evolvo-ts",
+      lifecycleState: "selected -> executing",
+    });
+
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -104,6 +128,116 @@ describe("operatorControl", () => {
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Discord operator control startup boot message failed: [send-boot-message]"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Discord bot is missing access to the configured control channel. Verify DISCORD_CONTROL_GUILD_ID, DISCORD_CONTROL_CHANNEL_ID, and bot channel permissions.",
+    );
+  });
+
+  it("sends an embed issue-start notification with a GitHub link button", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "channel-1", guild_id: "guild-1" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "message-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyIssueStartedInDiscord({
+      issueNumber: 298,
+      issueTitle: "Send a Discord embed notification with GitHub issue link when starting a new issue",
+      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
+      repository: "evolvo-auto/evolvo-ts",
+      lifecycleState: "selected -> executing",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      "https://discord.com/api/v10/channels/channel-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bot bot-token",
+        }),
+      }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1>",
+          embeds: [
+            {
+              title: "Started Issue #298",
+              description: "Send a Discord embed notification with GitHub issue link when starting a new issue",
+              url: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
+              fields: [
+                {
+                  name: "State",
+                  value: "selected -> executing",
+                  inline: true,
+                },
+                {
+                  name: "Repository",
+                  value: "evolvo-auto/evolvo-ts",
+                  inline: true,
+                },
+              ],
+            },
+          ],
+          components: [
+            {
+              type: 1,
+              components: [
+                {
+                  type: 2,
+                  style: 5,
+                  label: "Open GitHub Issue",
+                  url: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
+                },
+              ],
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("logs and swallows issue-start notification failures", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "channel-1", guild_id: "guild-1" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ message: "Missing Access", code: 50001 }),
+          { status: 403 },
+        ),
+      );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyIssueStartedInDiscord({
+      issueNumber: 298,
+      issueTitle: "Send Discord start embed",
+      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
+      repository: "evolvo-auto/evolvo-ts",
+      lifecycleState: "selected -> executing",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Discord issue start notification failed: [send-issue-start]"),
     );
     expect(errorSpy).toHaveBeenCalledWith(
       "Discord bot is missing access to the configured control channel. Verify DISCORD_CONTROL_GUILD_ID, DISCORD_CONTROL_CHANNEL_ID, and bot channel permissions.",

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -19,7 +19,21 @@ const DEFAULT_POLL_INTERVAL_MS = 5 * 1000;
 const DEFAULT_CYCLE_EXTENSION = 25;
 const DISCORD_API_BASE_URL = "https://discord.com/api/v10";
 
-type DiscordOperatorStep = "verify-channel" | "read-history" | "send-boot-message" | "send-prompt" | "wait-for-reply";
+type DiscordOperatorStep =
+  | "verify-channel"
+  | "read-history"
+  | "send-boot-message"
+  | "send-prompt"
+  | "wait-for-reply"
+  | "send-issue-start";
+
+type DiscordIssueStartNotification = {
+  issueNumber: number;
+  issueTitle: string;
+  issueUrl: string;
+  repository: string;
+  lifecycleState: string;
+};
 
 function getRequiredTrimmedEnv(name: string, env: NodeJS.ProcessEnv): string | null {
   const value = env[name]?.trim();
@@ -134,6 +148,50 @@ async function sendStartupBootMessage(config: DiscordControlConfig): Promise<voi
   });
 }
 
+async function sendIssueStartNotification(
+  config: DiscordControlConfig,
+  notification: DiscordIssueStartNotification,
+): Promise<void> {
+  await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify({
+      content: `<@${config.operatorUserId}>`,
+      embeds: [
+        {
+          title: `Started Issue #${notification.issueNumber}`,
+          description: notification.issueTitle,
+          url: notification.issueUrl,
+          fields: [
+            {
+              name: "State",
+              value: notification.lifecycleState,
+              inline: true,
+            },
+            {
+              name: "Repository",
+              value: notification.repository,
+              inline: true,
+            },
+          ],
+        },
+      ],
+      components: [
+        {
+          type: 1,
+          components: [
+            {
+              type: 2,
+              style: 5,
+              label: "Open GitHub Issue",
+              url: notification.issueUrl,
+            },
+          ],
+        },
+      ],
+    }),
+  });
+}
+
 function getHighestSnowflakeId(ids: string[]): string {
   let highest = ids[0] ?? "0";
   for (const id of ids) {
@@ -243,6 +301,33 @@ export async function runDiscordOperatorControlStartupCheck(): Promise<void> {
   }
 
   console.log("Discord operator control startup boot message posted.");
+}
+
+export async function notifyIssueStartedInDiscord(
+  notification: DiscordIssueStartNotification,
+): Promise<void> {
+  const config = getDiscordControlConfigFromEnv();
+  if (!config) {
+    return;
+  }
+
+  try {
+    try {
+      await verifyControlChannel(config);
+    } catch (error) {
+      throw new Error(buildStepFailureMessage("verify-channel", error));
+    }
+
+    try {
+      await sendIssueStartNotification(config, notification);
+    } catch (error) {
+      throw new Error(buildStepFailureMessage("send-issue-start", error));
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    console.error(`Discord issue start notification failed: ${message}`);
+    logDiscordMissingAccessHint(message);
+  }
 }
 
 export async function requestCycleLimitDecisionFromOperator(


### PR DESCRIPTION
## Summary
- send a Discord embed notification through the existing control-channel path when Evolvo starts a new issue in the run loop
- include the issue number, title, lifecycle state, repository, direct GitHub issue URL, and a link button in the Discord message
- add regression coverage for the new notifier, the no-config fallback, and the main-loop call boundary when an issue is newly started versus already in progress

Closes #298.

## Validation
- `pnpm exec vitest run src/runtime/operatorControl.test.ts src/main.test.ts`
- `pnpm typecheck`
- `pnpm test`
- operator-facing exercise: `notifyIssueStartedInDiscord` invoked for issue `#298` with the configured Discord env in this workspace