### PR TITLE
fix: normalize planned issue follow-up title comparisons

### DIFF
--- a/src/agents/plannerAgent.test.ts
+++ b/src/agents/plannerAgent.test.ts
@@ -65,12 +65,15 @@ describe("plannerAgent", () => {
     ]);
   });
 
-  it("deduplicates repeated planner titles before creating issues", async () => {
+  it("deduplicates repeated planner titles after follow-up normalization before creating issues", async () => {
     threadRunMock.mockResolvedValueOnce({
       finalResponse: JSON.stringify({
         issues: [
           { title: "Harden planner duplicate filtering", description: "Use recent issue history to prevent repeats." },
-          { title: "Harden planner duplicate filtering", description: "This duplicate should be ignored." },
+          {
+            title: "Harden planner duplicate filtering (follow-up 1)",
+            description: "This follow-up variant should also be ignored.",
+          },
           { title: "Improve Codex planner diagnostics", description: "Capture planner failures with clearer logs." },
         ],
       }),

--- a/src/agents/plannerAgent.ts
+++ b/src/agents/plannerAgent.ts
@@ -1,5 +1,10 @@
 import { Codex, type ThreadOptions } from "@openai/codex-sdk";
-import type { IssueSummary, PlannedIssueDraft, TaskIssueManager } from "../issues/taskIssueManager.js";
+import {
+  normalizePlannedIssueComparisonTitle,
+  type IssueSummary,
+  type PlannedIssueDraft,
+  type TaskIssueManager,
+} from "../issues/taskIssueManager.js";
 
 export type PlannerAgentInput = {
   cycle: number;
@@ -48,22 +53,12 @@ type PlannerResponse = {
   issues: unknown[];
 };
 
-function normalizeTitle(title: string): string {
-  return title.trim().toLowerCase();
-}
-
-function normalizeClosedIssueTitle(title: string): string {
-  return normalizeTitle(title)
-    .replace(/\s*\(follow-up\s+\d+\)\s*$/i, "")
-    .replace(/\s+/g, " ");
-}
-
 function dedupeClosedIssueHistory(issues: IssueSummary[]): IssueSummary[] {
   const seen = new Set<string>();
   const unique: IssueSummary[] = [];
 
   for (const issue of issues) {
-    const key = normalizeClosedIssueTitle(issue.title);
+    const key = normalizePlannedIssueComparisonTitle(issue.title);
     if (seen.has(key)) {
       continue;
     }
@@ -102,7 +97,7 @@ function dedupePlannedIssues(issues: PlannedIssueDraft[]): PlannedIssueDraft[] {
   const unique: PlannedIssueDraft[] = [];
 
   for (const issue of issues) {
-    const key = normalizeTitle(issue.title);
+    const key = normalizePlannedIssueComparisonTitle(issue.title);
     if (seen.has(key)) {
       continue;
     }

--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -150,6 +150,66 @@ describe("TaskIssueManager", () => {
     expect(client.post).toHaveBeenCalledWith("", expect.objectContaining({ title: "Candidate B" }));
   });
 
+  it("skips planned titles that collide with recent follow-up history after normalization", async () => {
+    const client = createClientMock();
+    client.get
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        createIssue({
+          number: 4,
+          state: "closed",
+          title: "Startup bootstrap reliability hardening (follow-up 2)",
+        }),
+      ]);
+    client.post.mockResolvedValueOnce(createIssue({ number: 31, title: "Distinct candidate" }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.createPlannedIssues({
+      minimumIssueCount: 2,
+      maximumOpenIssues: 4,
+      issues: [
+        { title: "Startup bootstrap reliability hardening", description: "Should be blocked by history." },
+        { title: "Distinct candidate", description: "Should still be created." },
+      ],
+    });
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]?.title).toBe("Distinct candidate");
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith("", expect.objectContaining({ title: "Distinct candidate" }));
+  });
+
+  it("deduplicates planned titles that only differ by a follow-up suffix", async () => {
+    const client = createClientMock();
+    client.get
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    client.post.mockResolvedValueOnce(
+      createIssue({ number: 31, title: "Startup bootstrap reliability hardening" }),
+    );
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.createPlannedIssues({
+      minimumIssueCount: 2,
+      maximumOpenIssues: 4,
+      issues: [
+        { title: "Startup bootstrap reliability hardening", description: "Keep the base title." },
+        {
+          title: "Startup bootstrap reliability hardening (follow-up 1)",
+          description: "This should be treated as the same planned title.",
+        },
+      ],
+    });
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]?.title).toBe("Startup bootstrap reliability hardening");
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({ title: "Startup bootstrap reliability hardening" }),
+    );
+  });
+
   it("replenishes empty queue with provided repository-derived candidates", async () => {
     const client = createClientMock();
     client.get

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -2,6 +2,7 @@ import { GitHubApiError, GitHubClient } from "../github/githubClient.js";
 
 const IN_PROGRESS_LABEL = "in progress";
 const COMPLETED_LABEL = "completed";
+const FOLLOW_UP_TITLE_SUFFIX_PATTERN = /\s*\(follow-up\s+\d+\)\s*$/i;
 
 type GitHubLabel = {
   name: string;
@@ -70,6 +71,17 @@ type IssueEvidenceSource = {
   title: string;
   body: string | null;
 };
+
+function normalizeIssueTitle(title: string): string {
+  return title.trim().toLowerCase();
+}
+
+export function normalizePlannedIssueComparisonTitle(title: string): string {
+  return normalizeIssueTitle(title)
+    .replace(FOLLOW_UP_TITLE_SUFFIX_PATTERN, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
 function buildFollowUpTemplate(template: IssueTemplate, sequence: number): IssueTemplate {
   return {
@@ -356,7 +368,7 @@ export class TaskIssueManager {
     const recentClosed = await this.listRecentClosedIssues();
     const existingTitles = new Set(
       [...openIssues.map((issue) => issue.title), ...recentClosed.map((issue) => issue.title)].map((title) =>
-        title.trim().toLowerCase()
+        normalizePlannedIssueComparisonTitle(title)
       ),
     );
 
@@ -370,7 +382,7 @@ export class TaskIssueManager {
 
       const title = plannedIssue.title.trim();
       const description = plannedIssue.description.trim();
-      const normalizedTitle = title.toLowerCase();
+      const normalizedTitle = normalizePlannedIssueComparisonTitle(title);
       if (!title || existingTitles.has(normalizedTitle)) {
         continue;
       }


### PR DESCRIPTION
## Summary
- share planned-issue comparison normalization between planner dedupe and issue creation
- treat `(follow-up N)` title variants as collisions when creating planned issues
- add regression coverage for follow-up/base title collisions in planner and issue-manager tests

## Validation
- pnpm vitest run src/issues/taskIssueManager.test.ts src/agents/plannerAgent.test.ts
- pnpm typecheck

Closes #302