### PR TITLE
fix: trim required environment values before validation

### DIFF
--- a/src/environment.test.ts
+++ b/src/environment.test.ts
@@ -1,13 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const REQUIRED_ENV = {
-  CONTEXT7_API_KEY: "ctx",
-  OPENAI_API_KEY: "openai",
-  GITHUB_TOKEN: "github-token",
-  GITHUB_OWNER: "owner",
-  GITHUB_REPO: "repo",
-} as const;
-
 async function importEnvironment() {
   vi.resetModules();
   return import("./environment.js");
@@ -20,9 +12,11 @@ describe("environment", () => {
   });
 
   it("exports the required environment variables", async () => {
-    for (const [key, value] of Object.entries(REQUIRED_ENV)) {
-      vi.stubEnv(key, value);
-    }
+    vi.stubEnv("CONTEXT7_API_KEY", "  ctx  ");
+    vi.stubEnv("OPENAI_API_KEY", "\topenai\t");
+    vi.stubEnv("GITHUB_TOKEN", " github-token ");
+    vi.stubEnv("GITHUB_OWNER", "  owner");
+    vi.stubEnv("GITHUB_REPO", "repo  ");
 
     const environment = await importEnvironment();
 
@@ -35,6 +29,18 @@ describe("environment", () => {
 
   it("throws when a required environment variable is missing", async () => {
     vi.stubEnv("CONTEXT7_API_KEY", "");
+    vi.stubEnv("OPENAI_API_KEY", "openai");
+    vi.stubEnv("GITHUB_TOKEN", "github-token");
+    vi.stubEnv("GITHUB_OWNER", "owner");
+    vi.stubEnv("GITHUB_REPO", "repo");
+
+    await expect(importEnvironment()).rejects.toThrow(
+      "CONTEXT7_API_KEY is not set in the environment variables.",
+    );
+  });
+
+  it("throws when a required environment variable is whitespace-only", async () => {
+    vi.stubEnv("CONTEXT7_API_KEY", "   ");
     vi.stubEnv("OPENAI_API_KEY", "openai");
     vi.stubEnv("GITHUB_TOKEN", "github-token");
     vi.stubEnv("GITHUB_OWNER", "owner");

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,5 +1,5 @@
 function requireEnv(name: string): string {
-  const value = process.env[name];
+  const value = process.env[name]?.trim();
 
   if (!value) {
     throw new Error(`${name} is not set in the environment variables.`);


### PR DESCRIPTION
## Summary
- trim required env values in `src/environment.ts` before validating and exporting them
- reject whitespace-only required env vars with the existing startup error
- extend environment tests to cover trimmed exports and whitespace-only failures

## Validation
- pnpm vitest run src/environment.test.ts src/github/githubConfig.test.ts
- pnpm typecheck

Closes #301