### PR TITLE
fix: detect repository default branch in post-merge flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ pnpm dev -- issues create "<title>" "<description>"
 
 Post-merge workflow runs:
 
-1. `git checkout main`
+1. `git checkout <repository default branch>`
+   The branch is detected from git remote metadata first, with GitHub repository metadata as a fallback.
 2. `git pull --ff-only`
 3. `pnpm i`
 4. `pnpm build`

--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -14,6 +14,7 @@ const persistChallengeAttemptArtifactMock = vi.fn();
 const transitionCanonicalLifecycleStateMock = vi.fn();
 const buildLifecycleStateCommentMock = vi.fn();
 const writeRuntimeReadinessSignalMock = vi.fn();
+const tryResolveRepositoryDefaultBranchMock = vi.fn();
 
 type MockIssue = {
   number: number;
@@ -109,6 +110,18 @@ vi.mock("./issues/runIssueCommand.js", () => ({
 
 vi.mock("./runtime/selfRestart.js", () => ({
   runPostMergeSelfRestart: runPostMergeSelfRestartMock,
+}));
+
+vi.mock("./runtime/defaultBranch.js", () => ({
+  buildMergedPullRequestReason: (defaultBranch: string | null | undefined) =>
+    defaultBranch && defaultBranch.trim().length > 0
+      ? `pull request merged into ${defaultBranch.trim()}`
+      : "pull request merged into repository default branch",
+  describeRepositoryDefaultBranch: (defaultBranch: string | null | undefined) =>
+    defaultBranch && defaultBranch.trim().length > 0
+      ? `\`${defaultBranch.trim()}\``
+      : "the repository default branch",
+  tryResolveRepositoryDefaultBranch: tryResolveRepositoryDefaultBranchMock,
 }));
 
 vi.mock("./challenges/challengeMetrics.js", () => ({
@@ -274,6 +287,8 @@ describe("main replenishment integration", () => {
       });
     runPostMergeSelfRestartMock.mockReset();
     runPostMergeSelfRestartMock.mockResolvedValue(undefined);
+    tryResolveRepositoryDefaultBranchMock.mockReset();
+    tryResolveRepositoryDefaultBranchMock.mockResolvedValue("main");
     getGitHubConfigMock.mockReset();
     getGitHubConfigMock.mockReturnValue({
       token: "token",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -26,6 +26,7 @@ const writeRuntimeReadinessSignalMock = vi.fn();
 const requestCycleLimitDecisionFromOperatorMock = vi.fn();
 const runDiscordOperatorControlStartupCheckMock = vi.fn();
 const notifyIssueStartedInDiscordMock = vi.fn();
+const tryResolveRepositoryDefaultBranchMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -62,6 +63,18 @@ vi.mock("./agents/plannerAgent.js", () => ({
 
 vi.mock("./runtime/selfRestart.js", () => ({
   runPostMergeSelfRestart: runPostMergeSelfRestartMock,
+}));
+
+vi.mock("./runtime/defaultBranch.js", () => ({
+  buildMergedPullRequestReason: (defaultBranch: string | null | undefined) =>
+    defaultBranch && defaultBranch.trim().length > 0
+      ? `pull request merged into ${defaultBranch.trim()}`
+      : "pull request merged into repository default branch",
+  describeRepositoryDefaultBranch: (defaultBranch: string | null | undefined) =>
+    defaultBranch && defaultBranch.trim().length > 0
+      ? `\`${defaultBranch.trim()}\``
+      : "the repository default branch",
+  tryResolveRepositoryDefaultBranch: tryResolveRepositoryDefaultBranchMock,
 }));
 
 vi.mock("./challenges/challengeMetrics.js", () => ({
@@ -164,6 +177,8 @@ describe("main", () => {
     });
     runPostMergeSelfRestartMock.mockReset();
     runPostMergeSelfRestartMock.mockResolvedValue(undefined);
+    tryResolveRepositoryDefaultBranchMock.mockReset();
+    tryResolveRepositoryDefaultBranchMock.mockResolvedValue("main");
     runIssueCommandMock.mockReset();
     runIssueCommandMock.mockResolvedValue(false);
     getGitHubConfigMock.mockReset();
@@ -517,6 +532,7 @@ describe("main", () => {
     listOpenIssuesMock.mockResolvedValueOnce([
       { number: 11, title: "Restart flow", description: "Restart", state: "open", labels: [] },
     ]);
+    tryResolveRepositoryDefaultBranchMock.mockResolvedValueOnce("release");
     runCodingAgentMock.mockResolvedValueOnce({
       ...DEFAULT_RUN_RESULT,
       mergedPullRequest: true,
@@ -526,7 +542,14 @@ describe("main", () => {
 
     await main();
 
-    expect(addProgressCommentMock).toHaveBeenCalledWith(11, expect.stringContaining("## Merge Outcome"));
+    expect(addProgressCommentMock).toHaveBeenCalledWith(11, expect.stringContaining("merged into `release`"));
+    expect(transitionCanonicalLifecycleStateMock).toHaveBeenCalledWith(
+      "/tmp/evolvo",
+      expect.objectContaining({
+        nextState: "merged",
+        reason: "pull request merged into release",
+      }),
+    );
     expect(runPostMergeSelfRestartMock).toHaveBeenCalledWith("/tmp/evolvo");
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,10 @@ import {
   type CanonicalLifecycleState,
 } from "./runtime/lifecycleState.js";
 import { writeRuntimeReadinessSignal } from "./runtime/runtimeReadiness.js";
+import {
+  buildMergedPullRequestReason,
+  tryResolveRepositoryDefaultBranch,
+} from "./runtime/defaultBranch.js";
 import { runPostMergeSelfRestart } from "./runtime/selfRestart.js";
 import {
   DEFAULT_PROMPT as LOOP_DEFAULT_PROMPT,
@@ -318,7 +322,11 @@ export async function main(): Promise<void> {
           continue issueCycleLoop;
         }
 
+        let mergedDefaultBranch: string | null = null;
         if (runResult) {
+          mergedDefaultBranch = runResult.mergedPullRequest
+            ? await tryResolveRepositoryDefaultBranch(WORK_DIR)
+            : null;
           await transitionIssueLifecycleState(issueManager, {
             issue: selectedIssue,
             nextState: "under_review",
@@ -356,9 +364,14 @@ export async function main(): Promise<void> {
           await addIssueLifecycleComment(
             issueManager,
             selectedIssue.number,
-            buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence),
+            buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence, mergedDefaultBranch),
           );
-          const challengeCompleted = await finalizeChallengeSuccess(issueManager, selectedIssue, runResult);
+          const challengeCompleted = await finalizeChallengeSuccess(
+            issueManager,
+            selectedIssue,
+            runResult,
+            mergedDefaultBranch,
+          );
           if (challengeCompleted) {
             await transitionIssueLifecycleState(issueManager, {
               issue: selectedIssue,
@@ -374,11 +387,15 @@ export async function main(): Promise<void> {
           await transitionIssueLifecycleState(issueManager, {
             issue: selectedIssue,
             nextState: "merged",
-            reason: "pull request merged into main",
+            reason: buildMergedPullRequestReason(mergedDefaultBranch),
             cycle,
             runResult,
           });
-          await addIssueLifecycleComment(issueManager, selectedIssue.number, buildMergeOutcomeComment(selectedIssue));
+          await addIssueLifecycleComment(
+            issueManager,
+            selectedIssue.number,
+            buildMergeOutcomeComment(selectedIssue, mergedDefaultBranch),
+          );
           console.log("Merged pull request detected. Running post-merge restart workflow.");
           try {
             await runPostMergeSelfRestart(WORK_DIR);

--- a/src/runtime/challengeLifecycle.test.ts
+++ b/src/runtime/challengeLifecycle.test.ts
@@ -174,6 +174,21 @@ describe("challengeLifecycle", () => {
     );
   });
 
+  it("uses the resolved default branch in challenge completion summaries", async () => {
+    const issueManager = createIssueManager();
+    const issue = createIssue({ number: 48 });
+    const runResult = createRunResult({ reviewOutcome: "accepted" });
+    runResult.mergedPullRequest = true;
+
+    const completed = await finalizeChallengeSuccess(issueManager, issue, runResult, "release");
+
+    expect(completed).toBe(true);
+    expect(issueManager.markCompleted).toHaveBeenCalledWith(
+      issue.number,
+      expect.stringContaining("Pull request status: merged into `release`."),
+    );
+  });
+
   it("treats already-terminal completion response as success", async () => {
     const issueManager = createIssueManager();
     vi.mocked(issueManager.markCompleted).mockResolvedValueOnce({

--- a/src/runtime/challengeLifecycle.ts
+++ b/src/runtime/challengeLifecycle.ts
@@ -21,6 +21,7 @@ import {
 import { hasIssueLabel, isChallengeIssue } from "../issues/challengeIssue.js";
 import type { IssueSummary, TaskIssueManager } from "../issues/taskIssueManager.js";
 import { addIssueLifecycleComment } from "./issueLifecyclePresentation.js";
+import { describeRepositoryDefaultBranch } from "./defaultBranch.js";
 
 const CHALLENGE_MAX_ATTEMPTS = 3;
 const CHALLENGE_RETRY_COOLDOWN_MS = 60 * 60 * 1000;
@@ -140,10 +141,16 @@ export function buildChallengeRetryGateComment(issue: IssueSummary, decision: Ch
   ].join("\n");
 }
 
-function buildChallengeCompletionSummary(issue: IssueSummary, result: CodingAgentRunResult): string {
+function buildChallengeCompletionSummary(
+  issue: IssueSummary,
+  result: CodingAgentRunResult,
+  defaultBranch: string | null = null,
+): string {
   const reviewOutcome = result.summary.reviewOutcome;
   const validationStatus = result.summary.failedValidationCommands.length === 0 ? "all passed" : "had failures";
-  const mergeStatus = result.mergedPullRequest ? "merged into main" : "not merged in this run";
+  const mergeStatus = result.mergedPullRequest
+    ? `merged into ${describeRepositoryDefaultBranch(defaultBranch)}`
+    : "not merged in this run";
   return [
     "## Challenge Completion",
     `- Challenge issue #${issue.number} succeeded.`,
@@ -158,12 +165,16 @@ export async function finalizeChallengeSuccess(
   issueManager: TaskIssueManager,
   issue: IssueSummary,
   runResult: CodingAgentRunResult,
+  defaultBranch: string | null = null,
 ): Promise<boolean> {
   if (!isChallengeIssue(issue) || runResult.summary.reviewOutcome !== "accepted") {
     return false;
   }
 
-  const completionResult = await issueManager.markCompleted(issue.number, buildChallengeCompletionSummary(issue, runResult));
+  const completionResult = await issueManager.markCompleted(
+    issue.number,
+    buildChallengeCompletionSummary(issue, runResult, defaultBranch),
+  );
   const alreadyTerminal =
     /already marked as completed/i.test(completionResult.message) ||
     /is closed and cannot be completed/i.test(completionResult.message);

--- a/src/runtime/defaultBranch.test.ts
+++ b/src/runtime/defaultBranch.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.fn();
+const getGitHubConfigMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock("../github/githubConfig.js", () => ({
+  getGitHubConfig: getGitHubConfigMock,
+}));
+
+describe("defaultBranch", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    getGitHubConfigMock.mockReset();
+    getGitHubConfigMock.mockReturnValue({
+      token: "token",
+      owner: "owner",
+      repo: "repo",
+      apiBaseUrl: "https://api.github.com",
+    });
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves the default branch from origin HEAD symbolic ref", async () => {
+    execFileMock.mockImplementationOnce(
+      (_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+        callback(null, "origin/trunk\n", "");
+      },
+    );
+
+    const { resolveRepositoryDefaultBranch } = await import("./defaultBranch.js");
+
+    await expect(resolveRepositoryDefaultBranch("/tmp/evolvo")).resolves.toBe("trunk");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to git remote show output when origin HEAD symbolic ref is unavailable", async () => {
+    execFileMock
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+          callback(new Error("missing origin HEAD"), "", "");
+        },
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+          callback(null, "  HEAD branch: release\n", "");
+        },
+      );
+
+    const { resolveRepositoryDefaultBranch } = await import("./defaultBranch.js");
+
+    await expect(resolveRepositoryDefaultBranch("/tmp/evolvo")).resolves.toBe("release");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to GitHub repository metadata when git metadata is unavailable", async () => {
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+        callback(new Error("git metadata unavailable"), "", "");
+      },
+    );
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ default_branch: "develop" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { tryResolveRepositoryDefaultBranch } = await import("./defaultBranch.js");
+
+    await expect(tryResolveRepositoryDefaultBranch("/tmp/evolvo")).resolves.toBe("develop");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/owner/repo",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+        }),
+      }),
+    );
+  });
+
+  it("throws actionable diagnostics when git and GitHub detection both fail", async () => {
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
+        callback(new Error("git metadata unavailable"), "", "");
+      },
+    );
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("{}", {
+        status: 500,
+      }),
+    );
+
+    const { resolveRepositoryDefaultBranch } = await import("./defaultBranch.js");
+
+    await expect(resolveRepositoryDefaultBranch("/tmp/evolvo")).rejects.toThrow(
+      "Could not resolve repository default branch from git or GitHub. git: origin default branch was not available from git remote metadata. GitHub: GitHub repository metadata request failed with status 500.",
+    );
+  });
+
+  it("formats branch labels and merge reasons without hardcoding main", async () => {
+    const {
+      buildMergedPullRequestReason,
+      describeRepositoryDefaultBranch,
+    } = await import("./defaultBranch.js");
+
+    expect(describeRepositoryDefaultBranch("origin/release")).toBe("`release`");
+    expect(describeRepositoryDefaultBranch("   ")).toBe("the repository default branch");
+    expect(buildMergedPullRequestReason("release")).toBe("pull request merged into release");
+    expect(buildMergedPullRequestReason("")).toBe("pull request merged into repository default branch");
+  });
+});

--- a/src/runtime/defaultBranch.ts
+++ b/src/runtime/defaultBranch.ts
@@ -1,0 +1,135 @@
+import { execFile } from "node:child_process";
+import { getGitHubConfig } from "../github/githubConfig.js";
+
+type BranchResolutionAttempt = {
+  branch: string | null;
+  reason: string | null;
+};
+
+type GitHubRepositoryMetadata = {
+  default_branch?: unknown;
+};
+
+function normalizeBranchName(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value
+    .trim()
+    .replace(/^refs\/remotes\/origin\//, "")
+    .replace(/^origin\//, "");
+  return normalized || null;
+}
+
+async function readGitCommandOutput(workingDirectory: string, args: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("git", args, { cwd: workingDirectory }, (error, stdout) => {
+      if (error) {
+        resolve(null);
+        return;
+      }
+
+      resolve(String(stdout).trim());
+    });
+  });
+}
+
+async function resolveDefaultBranchFromGit(workingDirectory: string): Promise<BranchResolutionAttempt> {
+  const symbolicRef = normalizeBranchName(
+    await readGitCommandOutput(workingDirectory, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]),
+  );
+  if (symbolicRef) {
+    return { branch: symbolicRef, reason: null };
+  }
+
+  const remoteShow = await readGitCommandOutput(workingDirectory, ["remote", "show", "origin"]);
+  const remoteHeadMatch = remoteShow?.match(/^\s*HEAD branch:\s*(.+)\s*$/m);
+  const remoteHeadBranch = normalizeBranchName(remoteHeadMatch?.[1]);
+  if (remoteHeadBranch) {
+    return { branch: remoteHeadBranch, reason: null };
+  }
+
+  return {
+    branch: null,
+    reason: "origin default branch was not available from git remote metadata.",
+  };
+}
+
+async function resolveDefaultBranchFromGitHub(): Promise<BranchResolutionAttempt> {
+  try {
+    const config = getGitHubConfig();
+    const apiBaseUrl = config.apiBaseUrl.replace(/\/+$/, "");
+    const response = await fetch(
+      `${apiBaseUrl}/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${config.token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      return {
+        branch: null,
+        reason: `GitHub repository metadata request failed with status ${response.status}.`,
+      };
+    }
+
+    const repository = await response.json() as GitHubRepositoryMetadata;
+    const defaultBranch = normalizeBranchName(
+      typeof repository.default_branch === "string" ? repository.default_branch : null,
+    );
+    if (defaultBranch) {
+      return { branch: defaultBranch, reason: null };
+    }
+
+    return {
+      branch: null,
+      reason: "GitHub repository metadata did not include a default_branch value.",
+    };
+  } catch (error) {
+    return {
+      branch: null,
+      reason: error instanceof Error ? error.message : "unknown GitHub metadata error",
+    };
+  }
+}
+
+export async function tryResolveRepositoryDefaultBranch(workingDirectory: string): Promise<string | null> {
+  const gitAttempt = await resolveDefaultBranchFromGit(workingDirectory);
+  if (gitAttempt.branch) {
+    return gitAttempt.branch;
+  }
+
+  const githubAttempt = await resolveDefaultBranchFromGitHub();
+  return githubAttempt.branch;
+}
+
+export async function resolveRepositoryDefaultBranch(workingDirectory: string): Promise<string> {
+  const gitAttempt = await resolveDefaultBranchFromGit(workingDirectory);
+  if (gitAttempt.branch) {
+    return gitAttempt.branch;
+  }
+
+  const githubAttempt = await resolveDefaultBranchFromGitHub();
+  if (githubAttempt.branch) {
+    return githubAttempt.branch;
+  }
+
+  throw new Error(
+    `Could not resolve repository default branch from git or GitHub. git: ${gitAttempt.reason ?? "unknown error"} GitHub: ${githubAttempt.reason ?? "unknown error"}`,
+  );
+}
+
+export function describeRepositoryDefaultBranch(defaultBranch: string | null | undefined): string {
+  const branch = normalizeBranchName(defaultBranch);
+  return branch ? `\`${branch}\`` : "the repository default branch";
+}
+
+export function buildMergedPullRequestReason(defaultBranch: string | null | undefined): string {
+  const branch = normalizeBranchName(defaultBranch);
+  return branch ? `pull request merged into ${branch}` : "pull request merged into repository default branch";
+}

--- a/src/runtime/issueLifecyclePresentation.test.ts
+++ b/src/runtime/issueLifecyclePresentation.test.ts
@@ -3,6 +3,7 @@ import type { CodingAgentRunResult } from "../agents/runCodingAgent.js";
 import type { IssueSummary, TaskIssueManager } from "../issues/taskIssueManager.js";
 import {
   addIssueLifecycleComment,
+  buildMergeOutcomeComment,
   buildIssueExecutionComment,
   buildIssueFailureComment,
   buildIssueStartComment,
@@ -118,6 +119,19 @@ describe("issueLifecyclePresentation", () => {
     expect(comment).toContain("### Challenge Attempt Artifact");
     expect(comment).toContain("Artifact path: `.evolvo/challenge-attempts/12/0001.json`");
     expect(comment).toContain("Runtime error message: none");
+  });
+
+  it("uses the resolved default branch in merge-related lifecycle comments", () => {
+    const issue = createIssue({ number: 21 });
+    const runResult = createRunResult();
+    runResult.summary.pullRequestCreated = true;
+    runResult.mergedPullRequest = true;
+
+    const executionComment = buildIssueExecutionComment(issue, runResult, null, "release");
+    const mergeComment = buildMergeOutcomeComment(issue, "release");
+
+    expect(executionComment).toContain("PR merged into `release`: yes.");
+    expect(mergeComment).toContain("Pull request for issue #21 was merged into `release`.");
   });
 
   it("builds failure comment with fallback unknown runtime message", () => {

--- a/src/runtime/issueLifecyclePresentation.ts
+++ b/src/runtime/issueLifecyclePresentation.ts
@@ -2,6 +2,7 @@ import type { CodingAgentRunResult, CommandExecutionSummary } from "../agents/ru
 import { persistChallengeAttemptArtifact } from "../challenges/challengeAttemptArtifacts.js";
 import { isChallengeIssue } from "../issues/challengeIssue.js";
 import type { TaskIssueManager, IssueSummary } from "../issues/taskIssueManager.js";
+import { describeRepositoryDefaultBranch } from "./defaultBranch.js";
 
 export type ChallengeAttemptEvidence = {
   artifactPath: string;
@@ -153,6 +154,7 @@ export function buildIssueExecutionComment(
   issue: IssueSummary,
   result: CodingAgentRunResult,
   challengeEvidence: ChallengeAttemptEvidence | null,
+  defaultBranch: string | null = null,
 ): string {
   const inspectedAreas = result.summary.inspectedAreas.length > 0
     ? result.summary.inspectedAreas.map((area) => `- \`${area}\``)
@@ -165,7 +167,7 @@ export function buildIssueExecutionComment(
     : ["- No validation command was captured."];
   const prLines = [
     `- PR created: ${result.summary.pullRequestCreated ? "yes" : "no"}.`,
-    `- PR merged into main: ${result.mergedPullRequest ? "yes" : "no"}.`,
+    `- PR merged into ${describeRepositoryDefaultBranch(defaultBranch)}: ${result.mergedPullRequest ? "yes" : "no"}.`,
   ];
   const externalRepositoryLines = result.summary.externalRepositories.length > 0
     ? result.summary.externalRepositories.map((url) => `- ${url}`)
@@ -224,10 +226,10 @@ export function buildIssueFailureComment(
   ].join("\n");
 }
 
-export function buildMergeOutcomeComment(issue: IssueSummary): string {
+export function buildMergeOutcomeComment(issue: IssueSummary, defaultBranch: string | null = null): string {
   return [
     "## Merge Outcome",
-    `- Pull request for issue #${issue.number} was merged into main.`,
+    `- Pull request for issue #${issue.number} was merged into ${describeRepositoryDefaultBranch(defaultBranch)}.`,
     "- Runtime will exit so the host can perform post-merge restart orchestration.",
   ].join("\n");
 }

--- a/src/runtime/selfRestart.test.ts
+++ b/src/runtime/selfRestart.test.ts
@@ -5,6 +5,7 @@ const spawnMock = vi.fn();
 const rmMock = vi.fn();
 const getRuntimeReadinessSignalPathMock = vi.fn();
 const waitForRuntimeReadinessSignalMock = vi.fn();
+const resolveRepositoryDefaultBranchMock = vi.fn();
 
 vi.mock("node:child_process", () => ({
   execFile: execFileMock,
@@ -20,6 +21,10 @@ vi.mock("node:fs", () => ({
 vi.mock("./runtimeReadiness.js", () => ({
   getRuntimeReadinessSignalPath: getRuntimeReadinessSignalPathMock,
   waitForRuntimeReadinessSignal: waitForRuntimeReadinessSignalMock,
+}));
+
+vi.mock("./defaultBranch.js", () => ({
+  resolveRepositoryDefaultBranch: resolveRepositoryDefaultBranchMock,
 }));
 
 function createChildProcessStub(overrides: {
@@ -71,6 +76,8 @@ describe("runPostMergeSelfRestart", () => {
       pid: 1234,
       startedAt: "2026-01-01T00:00:00.000Z",
     });
+    resolveRepositoryDefaultBranchMock.mockReset();
+    resolveRepositoryDefaultBranchMock.mockResolvedValue("main");
     vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
@@ -79,10 +86,11 @@ describe("runPostMergeSelfRestart", () => {
     vi.restoreAllMocks();
   });
 
-  it("runs checkout, pull, install, build and starts runtime", async () => {
+  it("runs checkout on the detected default branch, then pulls, installs, builds and starts runtime", async () => {
     execFileMock.mockImplementation((_command: string, _args: string[], _options: unknown, callback: (error: unknown, stdout: string, stderr: string) => void) => {
       callback(null, "", "");
     });
+    resolveRepositoryDefaultBranchMock.mockResolvedValueOnce("trunk");
     const onceHandlers: Record<string, (...args: unknown[]) => void> = {};
     const child = createChildProcessStub({
       once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
@@ -94,7 +102,8 @@ describe("runPostMergeSelfRestart", () => {
     const { runPostMergeSelfRestart } = await import("./selfRestart.js");
     await expect(runPostMergeSelfRestart("/tmp/evolvo")).resolves.toBeUndefined();
 
-    expect(execFileMock).toHaveBeenNthCalledWith(1, "git", ["checkout", "main"], { cwd: "/tmp/evolvo" }, expect.any(Function));
+    expect(resolveRepositoryDefaultBranchMock).toHaveBeenCalledWith("/tmp/evolvo");
+    expect(execFileMock).toHaveBeenNthCalledWith(1, "git", ["checkout", "trunk"], { cwd: "/tmp/evolvo" }, expect.any(Function));
     expect(execFileMock).toHaveBeenNthCalledWith(2, "git", ["pull", "--ff-only"], { cwd: "/tmp/evolvo" }, expect.any(Function));
     expect(execFileMock).toHaveBeenNthCalledWith(3, "pnpm", ["i"], { cwd: "/tmp/evolvo" }, expect.any(Function));
     expect(execFileMock).toHaveBeenNthCalledWith(4, "pnpm", ["build"], { cwd: "/tmp/evolvo" }, expect.any(Function));
@@ -128,11 +137,12 @@ describe("runPostMergeSelfRestart", () => {
       const error = Object.assign(new Error("failed"), { stderr: "checkout failed" });
       callback(error, "", "checkout failed");
     });
+    resolveRepositoryDefaultBranchMock.mockResolvedValueOnce("release");
 
     const { runPostMergeSelfRestart } = await import("./selfRestart.js");
 
     await expect(runPostMergeSelfRestart("/tmp/evolvo")).rejects.toThrow(
-      "Post-merge restart step failed: git checkout main. Output: checkout failed",
+      "Post-merge restart step failed: git checkout release. Output: checkout failed",
     );
     expect(spawnMock).not.toHaveBeenCalled();
   });

--- a/src/runtime/selfRestart.ts
+++ b/src/runtime/selfRestart.ts
@@ -2,6 +2,7 @@ import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
+import { resolveRepositoryDefaultBranch } from "./defaultBranch.js";
 import { getRuntimeReadinessSignalPath, waitForRuntimeReadinessSignal } from "./runtimeReadiness.js";
 
 const execFileAsync = promisify(execFile);
@@ -114,7 +115,8 @@ async function startUpdatedRuntime(workingDirectory: string): Promise<void> {
 }
 
 export async function runPostMergeSelfRestart(workingDirectory: string): Promise<void> {
-  await runStep("git", ["checkout", "main"], workingDirectory);
+  const defaultBranch = await resolveRepositoryDefaultBranch(workingDirectory);
+  await runStep("git", ["checkout", defaultBranch], workingDirectory);
   await runStep("git", ["pull", "--ff-only"], workingDirectory);
   await runStep("pnpm", ["i"], workingDirectory);
   await runStep("pnpm", ["build"], workingDirectory);


### PR DESCRIPTION
## Summary
- detect the repository default branch from git remote metadata with a GitHub metadata fallback
- use the resolved branch in post-merge restart checkout and merge-facing runtime messaging
- add focused non-main branch coverage for the resolver, restart flow, lifecycle comments, challenge completion, and merged-PR main loop path

## Validation
- pnpm vitest run src/runtime/defaultBranch.test.ts src/runtime/selfRestart.test.ts src/runtime/issueLifecyclePresentation.test.ts src/runtime/challengeLifecycle.test.ts src/main.test.ts src/main.replenishment.integration.test.ts
- pnpm typecheck

Closes #300