### PR TITLE
fix: paginate recent closed issue screening history

### DIFF
--- a/src/agents/plannerAgent.test.ts
+++ b/src/agents/plannerAgent.test.ts
@@ -52,6 +52,7 @@ describe("plannerAgent", () => {
       approvalPolicy: "never",
       networkAccessEnabled: false,
     }));
+    expect(issueManager.listRecentClosedIssues).toHaveBeenCalledWith(300);
     expect(createPlannedIssuesMock).toHaveBeenCalledWith({
       minimumIssueCount: 3,
       maximumOpenIssues: 5,

--- a/src/agents/plannerAgent.ts
+++ b/src/agents/plannerAgent.ts
@@ -1,5 +1,6 @@
 import { Codex, type ThreadOptions } from "@openai/codex-sdk";
 import {
+  PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT,
   normalizePlannedIssueComparisonTitle,
   type IssueSummary,
   type PlannedIssueDraft,
@@ -160,7 +161,9 @@ export async function runPlannerAgent(input: PlannerAgentInput): Promise<Planner
 
   try {
     const openIssues = await input.issueManager.listOpenIssues();
-    const recentClosedIssues = await input.issueManager.listRecentClosedIssues();
+    const recentClosedIssues = await input.issueManager.listRecentClosedIssues(
+      PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT,
+    );
     const thread = codex.startThread({
       ...PLANNER_THREAD_OPTIONS,
       workingDirectory: input.workDir,

--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -125,6 +125,29 @@ describe("TaskIssueManager", () => {
     ]);
   });
 
+  it("paginates recent closed issues until the requested non-PR limit is satisfied", async () => {
+    const client = createClientMock();
+    const firstPage = Array.from({ length: 100 }, (_, index) =>
+      createIssue({ number: index + 1, state: "closed" }),
+    );
+    firstPage[0] = createIssue({ number: 1, state: "closed", pull_request: { url: "pr-1" } });
+    client.get
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([
+        createIssue({ number: 101, state: "closed", pull_request: { url: "pr-2" } }),
+        createIssue({ number: 102, state: "closed" }),
+      ]);
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.listRecentClosedIssues(100);
+
+    expect(client.get).toHaveBeenNthCalledWith(1, "?state=closed&sort=updated&direction=desc&per_page=100&page=1");
+    expect(client.get).toHaveBeenNthCalledWith(2, "?state=closed&sort=updated&direction=desc&per_page=100&page=2");
+    expect(result).toHaveLength(100);
+    expect(result[0]?.number).toBe(2);
+    expect(result[99]?.number).toBe(102);
+  });
+
   it("creates planned issues without generating follow-up titles", async () => {
     const client = createClientMock();
     client.get
@@ -177,6 +200,41 @@ describe("TaskIssueManager", () => {
     expect(result.created[0]?.title).toBe("Distinct candidate");
     expect(client.post).toHaveBeenCalledTimes(1);
     expect(client.post).toHaveBeenCalledWith("", expect.objectContaining({ title: "Distinct candidate" }));
+  });
+
+  it("skips planned duplicates found beyond the first recent-closed page", async () => {
+    const client = createClientMock();
+    const firstClosedPage = Array.from({ length: 100 }, (_, index) =>
+      createIssue({
+        number: index + 1,
+        state: "closed",
+        title: `Closed issue ${index + 1}`,
+      }),
+    );
+    client.get
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(firstClosedPage)
+      .mockResolvedValueOnce([
+        createIssue({ number: 101, state: "closed", title: "Late duplicate candidate" }),
+      ]);
+    client.post.mockResolvedValueOnce(createIssue({ number: 201, title: "Fresh candidate" }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.createPlannedIssues({
+      minimumIssueCount: 2,
+      maximumOpenIssues: 4,
+      issues: [
+        { title: "Late duplicate candidate", description: "Should be skipped from page two history." },
+        { title: "Fresh candidate", description: "Should still be created." },
+      ],
+    });
+
+    expect(client.get).toHaveBeenNthCalledWith(2, "?state=closed&sort=updated&direction=desc&per_page=100&page=1");
+    expect(client.get).toHaveBeenNthCalledWith(3, "?state=closed&sort=updated&direction=desc&per_page=100&page=2");
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]?.title).toBe("Fresh candidate");
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith("", expect.objectContaining({ title: "Fresh candidate" }));
   });
 
   it("deduplicates planned titles that only differ by a follow-up suffix", async () => {

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -3,6 +3,7 @@ import { GitHubApiError, GitHubClient } from "../github/githubClient.js";
 const IN_PROGRESS_LABEL = "in progress";
 const COMPLETED_LABEL = "completed";
 const FOLLOW_UP_TITLE_SUFFIX_PATTERN = /\s*\(follow-up\s+\d+\)\s*$/i;
+export const PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT = 300;
 
 type GitHubLabel = {
   name: string;
@@ -339,11 +340,25 @@ export class TaskIssueManager {
   }
 
   public async listRecentClosedIssues(limit = TaskIssueManager.ISSUES_PER_PAGE): Promise<IssueSummary[]> {
-    const perPage = Math.max(1, Math.min(TaskIssueManager.ISSUES_PER_PAGE, Math.floor(limit)));
-    const issues = await this.client.get<GitHubIssue[]>(
-      `?state=closed&sort=updated&direction=desc&per_page=${perPage}&page=1`,
-    );
-    return issues.filter((issue) => issue.pull_request === undefined).map(formatIssue);
+    const requestedLimit = Math.max(1, Math.floor(limit));
+    const perPage = Math.max(1, Math.min(TaskIssueManager.ISSUES_PER_PAGE, requestedLimit));
+    const issues: IssueSummary[] = [];
+    let page = 1;
+
+    while (issues.length < requestedLimit) {
+      const batch = await this.client.get<GitHubIssue[]>(
+        `?state=closed&sort=updated&direction=desc&per_page=${perPage}&page=${page}`,
+      );
+      issues.push(...batch.filter((issue) => issue.pull_request === undefined).map(formatIssue));
+
+      if (batch.length < perPage) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return issues.slice(0, requestedLimit);
   }
 
   public async createPlannedIssues(options: {
@@ -365,7 +380,7 @@ export class TaskIssueManager {
       return { created: [] };
     }
 
-    const recentClosed = await this.listRecentClosedIssues();
+    const recentClosed = await this.listRecentClosedIssues(PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT);
     const existingTitles = new Set(
       [...openIssues.map((issue) => issue.title), ...recentClosed.map((issue) => issue.title)].map((title) =>
         normalizePlannedIssueComparisonTitle(title)


### PR DESCRIPTION
## Summary
- paginate recent closed issue reads until the requested history window is satisfied or GitHub history is exhausted
- increase the planner and planned-issue duplicate-screening lookback so later closed-issue pages can actually block repeats
- add regressions for paginated recent-closed reads and duplicate filtering beyond page one

## Validation
- pnpm vitest run src/issues/taskIssueManager.test.ts src/agents/plannerAgent.test.ts
- pnpm typecheck

Closes #310