### PR TITLE
fix: recover from malformed lifecycle state store

### DIFF
--- a/src/runtime/lifecycleState.test.ts
+++ b/src/runtime/lifecycleState.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildLifecycleStateComment,
   readCanonicalLifecycleState,
@@ -16,6 +16,8 @@ describe("lifecycleState", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
   });
 
@@ -208,6 +210,35 @@ describe("lifecycleState", () => {
     expect(Object.keys(state.issues)).toEqual(["12"]);
     expect(state.issues["12"]?.state).toBe("blocked");
     expect(state.version).toBe(1);
+  });
+
+  it("preserves malformed lifecycle state JSON and resets to a default store", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-07T21:00:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "runtime-lifecycle-state.json");
+    const corruptPath = join(evolvoDir, `runtime-lifecycle-state.corrupt-${recoveryAtMs}.json`);
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(statePath, "{\"issues\":", "utf8");
+
+    const state = await readCanonicalLifecycleState(workDir);
+
+    expect(state).toEqual({
+      version: 1,
+      issues: {},
+    });
+    expect(await readFile(corruptPath, "utf8")).toBe("{\"issues\":");
+    expect(JSON.parse(await readFile(statePath, "utf8"))).toEqual({
+      version: 1,
+      issues: {},
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed lifecycle state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
   });
 
   it("formats canonical lifecycle comments with canonical and derived sections", () => {

--- a/src/runtime/lifecycleState.ts
+++ b/src/runtime/lifecycleState.ts
@@ -105,11 +105,23 @@ function getStatePath(workDir: string): string {
   return join(workDir, EVOLVO_DIRECTORY_NAME, LIFECYCLE_STATE_FILE_NAME);
 }
 
+function getCorruptStatePath(workDir: string, atMs = Date.now()): string {
+  return join(
+    workDir,
+    EVOLVO_DIRECTORY_NAME,
+    `runtime-lifecycle-state.corrupt-${Math.max(0, Math.floor(atMs))}.json`,
+  );
+}
+
 function createDefaultStateStore(): LifecycleStateStore {
   return {
     version: LIFECYCLE_STATE_VERSION,
     issues: {},
   };
+}
+
+function isMalformedStateStoreError(error: unknown): boolean {
+  return error instanceof SyntaxError;
 }
 
 function normalizeStateStore(raw: unknown): LifecycleStateStore {
@@ -194,6 +206,9 @@ export async function readCanonicalLifecycleState(workDir: string): Promise<Life
     if (errorCode === "ENOENT") {
       return createDefaultStateStore();
     }
+    if (isMalformedStateStoreError(error)) {
+      return recoverMalformedLifecycleState(workDir, statePath);
+    }
 
     throw error;
   }
@@ -202,6 +217,17 @@ export async function readCanonicalLifecycleState(workDir: string): Promise<Life
 async function writeCanonicalLifecycleState(workDir: string, state: LifecycleStateStore): Promise<void> {
   await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
   await fs.writeFile(getStatePath(workDir), `${JSON.stringify(normalizeStateStore(state), null, 2)}\n`, "utf8");
+}
+
+async function recoverMalformedLifecycleState(workDir: string, statePath: string): Promise<LifecycleStateStore> {
+  const corruptPath = getCorruptStatePath(workDir);
+  await fs.rename(statePath, corruptPath);
+  const defaultStateStore = createDefaultStateStore();
+  await writeCanonicalLifecycleState(workDir, defaultStateStore);
+  console.warn(
+    `Recovered malformed lifecycle state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+  );
+  return defaultStateStore;
 }
 
 export async function transitionCanonicalLifecycleState(


### PR DESCRIPTION
## Summary
- recover from malformed `.evolvo/runtime-lifecycle-state.json` reads instead of crashing the runtime
- preserve the corrupt payload under a timestamped sibling file for inspection and rewrite a clean default state store
- add a focused regression test for malformed JSON recovery and keep main-loop regression coverage green

## Validation
- pnpm vitest run src/runtime/lifecycleState.test.ts src/main.test.ts
- pnpm typecheck

Closes #309