### PR TITLE
Add graceful Discord /quit shutdown

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -26,6 +26,10 @@ const writeRuntimeReadinessSignalMock = vi.fn();
 const requestCycleLimitDecisionFromOperatorMock = vi.fn();
 const runDiscordOperatorControlStartupCheckMock = vi.fn();
 const notifyIssueStartedInDiscordMock = vi.fn();
+const pollDiscordGracefulShutdownCommandMock = vi.fn();
+const startDiscordGracefulShutdownListenerMock = vi.fn();
+const stopDiscordGracefulShutdownListenerMock = vi.fn();
+const consumeGracefulShutdownRequestMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
@@ -103,10 +107,16 @@ vi.mock("./runtime/runtimeReadiness.js", () => ({
   writeRuntimeReadinessSignal: writeRuntimeReadinessSignalMock,
 }));
 
+vi.mock("./runtime/gracefulShutdown.js", () => ({
+  consumeGracefulShutdownRequest: consumeGracefulShutdownRequestMock,
+}));
+
 vi.mock("./runtime/operatorControl.js", () => ({
   notifyIssueStartedInDiscord: notifyIssueStartedInDiscordMock,
+  pollDiscordGracefulShutdownCommand: pollDiscordGracefulShutdownCommandMock,
   requestCycleLimitDecisionFromOperator: requestCycleLimitDecisionFromOperatorMock,
   runDiscordOperatorControlStartupCheck: runDiscordOperatorControlStartupCheckMock,
+  startDiscordGracefulShutdownListener: startDiscordGracefulShutdownListenerMock,
 }));
 
 vi.mock("./issues/runIssueCommand.js", () => ({
@@ -261,12 +271,22 @@ describe("main", () => {
     buildLifecycleStateCommentMock.mockReturnValue("## Canonical Lifecycle State");
     writeRuntimeReadinessSignalMock.mockReset();
     writeRuntimeReadinessSignalMock.mockResolvedValue("/tmp/evolvo/.evolvo/runtime-readiness.json");
+    consumeGracefulShutdownRequestMock.mockReset();
+    consumeGracefulShutdownRequestMock.mockResolvedValue(null);
+    pollDiscordGracefulShutdownCommandMock.mockReset();
+    pollDiscordGracefulShutdownCommandMock.mockResolvedValue(null);
     requestCycleLimitDecisionFromOperatorMock.mockReset();
     requestCycleLimitDecisionFromOperatorMock.mockResolvedValue(null);
     runDiscordOperatorControlStartupCheckMock.mockReset();
     runDiscordOperatorControlStartupCheckMock.mockResolvedValue(undefined);
     notifyIssueStartedInDiscordMock.mockReset();
     notifyIssueStartedInDiscordMock.mockResolvedValue(undefined);
+    stopDiscordGracefulShutdownListenerMock.mockReset();
+    stopDiscordGracefulShutdownListenerMock.mockResolvedValue(undefined);
+    startDiscordGracefulShutdownListenerMock.mockReset();
+    startDiscordGracefulShutdownListenerMock.mockResolvedValue({
+      stop: stopDiscordGracefulShutdownListenerMock,
+    });
     process.argv = ["node", "test-runner.ts"];
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -311,6 +331,8 @@ describe("main", () => {
     await main();
 
     expect(runDiscordOperatorControlStartupCheckMock).toHaveBeenCalledTimes(1);
+    expect(startDiscordGracefulShutdownListenerMock).toHaveBeenCalledWith("/tmp/evolvo");
+    expect(stopDiscordGracefulShutdownListenerMock).toHaveBeenCalledTimes(1);
   });
 
   it("selects an open issue and uses it as the prompt", async () => {
@@ -1173,6 +1195,57 @@ describe("main", () => {
     expect(requestCycleLimitDecisionFromOperatorMock).toHaveBeenCalledWith(5);
     expect(console.error).toHaveBeenCalledWith("Operator decision via Discord: quit.");
     expect(console.error).toHaveBeenCalledWith("Reached the maximum number of issue cycles (5).");
+  });
+
+  it("stops before starting a new task when a graceful shutdown request is already pending", async () => {
+    consumeGracefulShutdownRequestMock.mockResolvedValueOnce({
+      version: 1,
+      source: "discord",
+      command: "/quit",
+      messageId: "9001",
+      requestedAt: "2026-03-07T12:00:00.000Z",
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(listOpenIssuesMock).not.toHaveBeenCalled();
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      "Graceful shutdown requested via Discord /quit. Stopping before starting a new task.",
+    );
+  });
+
+  it("finishes the current task and stops before selecting another issue after /quit is requested", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 301, title: "Current task", description: "finish this", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([
+        { number: 302, title: "Next task", description: "should not start", state: "open", labels: [] },
+      ]);
+    consumeGracefulShutdownRequestMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        version: 1,
+        source: "discord",
+        command: "/quit",
+        messageId: "9002",
+        requestedAt: "2026-03-07T12:05:00.000Z",
+      });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #301: Current task\n\nfinish this");
+    expect(markInProgressMock).toHaveBeenCalledWith(301);
+    expect(markInProgressMock).not.toHaveBeenCalledWith(302);
+    expect(console.log).toHaveBeenCalledWith(
+      "Graceful shutdown requested via Discord /quit. Current task completed. Stopping before starting another issue.",
+    );
   });
 
   it("adds a lifecycle issue comment when agent execution fails", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,9 +31,15 @@ import {
   waitForRunLoopRetry,
 } from "./runtime/loopUtils.js";
 import {
+  consumeGracefulShutdownRequest,
+  type GracefulShutdownRequest,
+} from "./runtime/gracefulShutdown.js";
+import {
   notifyIssueStartedInDiscord,
+  pollDiscordGracefulShutdownCommand,
   requestCycleLimitDecisionFromOperator,
   runDiscordOperatorControlStartupCheck,
+  startDiscordGracefulShutdownListener,
 } from "./runtime/operatorControl.js";
 import {
   addIssueLifecycleComment,
@@ -149,6 +155,24 @@ async function signalRestartReadinessIfRequested(workDir: string): Promise<void>
   console.log(`[startup] Runtime readiness signal written: ${signalPath}`);
 }
 
+function buildGracefulShutdownLogMessage(
+  request: GracefulShutdownRequest,
+  reason: string,
+): string {
+  return `Graceful shutdown requested via Discord ${request.command}. ${reason}`;
+}
+
+async function stopIfGracefulShutdownRequested(workDir: string, reason: string): Promise<boolean> {
+  await pollDiscordGracefulShutdownCommand(workDir);
+  const request = await consumeGracefulShutdownRequest(workDir);
+  if (request === null) {
+    return false;
+  }
+
+  console.log(buildGracefulShutdownLogMessage(request, reason));
+  return true;
+}
+
 export async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const issueCommandHandled = await runIssueCommand(args);
@@ -164,282 +188,319 @@ export async function main(): Promise<void> {
   console.log(`Working directory: ${WORK_DIR}`);
   await signalRestartReadinessIfRequested(WORK_DIR);
   await runDiscordOperatorControlStartupCheck();
+  const gracefulShutdownListener = await startDiscordGracefulShutdownListener(WORK_DIR);
 
-  let cycleLimit = MAX_ISSUE_CYCLES;
-  issueCycleLoop: for (let cycle = 1; ; cycle += 1) {
-    if (cycle > cycleLimit) {
-      const operatorDecision = await requestCycleLimitDecisionFromOperator(cycleLimit);
-      if (operatorDecision?.decision === "continue" && operatorDecision.additionalCycles > 0) {
-        cycleLimit += operatorDecision.additionalCycles;
-        console.log(
-          `Operator decision via Discord: continue (+${operatorDecision.additionalCycles} cycles). New limit=${cycleLimit}.`,
-        );
-        continue;
-      }
-      if (operatorDecision?.decision === "quit") {
-        console.error("Operator decision via Discord: quit.");
-      }
-      console.error(`Reached the maximum number of issue cycles (${cycleLimit}).`);
+  try {
+    if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
       return;
     }
 
-    let retryAttempt = 0;
-    while (true) {
-      try {
-        const openIssues = await issueManager.listOpenIssues();
-        const actionableIssues: IssueSummary[] = [];
+    let cycleLimit = MAX_ISSUE_CYCLES;
+    issueCycleLoop: for (let cycle = 1; ; cycle += 1) {
+      if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+        return;
+      }
 
-        for (const issue of openIssues) {
-          if (!isOutdatedIssue(issue)) {
-            actionableIssues.push(issue);
-            continue;
-          }
-
-          const result = await issueManager.closeIssue(issue.number);
-          if (result.ok) {
-            console.log(`Closed outdated issue ${formatIssueForLog(issue)}.`);
-          } else {
-            console.error(`Could not close outdated issue #${issue.number}: ${result.message}`);
-          }
+      if (cycle > cycleLimit) {
+        const operatorDecision = await requestCycleLimitDecisionFromOperator(cycleLimit);
+        if (operatorDecision?.decision === "continue" && operatorDecision.additionalCycles > 0) {
+          cycleLimit += operatorDecision.additionalCycles;
+          console.log(
+            `Operator decision via Discord: continue (+${operatorDecision.additionalCycles} cycles). New limit=${cycleLimit}.`,
+          );
+          continue;
         }
+        if (operatorDecision?.decision === "quit") {
+          console.error("Operator decision via Discord: quit.");
+        }
+        console.error(`Reached the maximum number of issue cycles (${cycleLimit}).`);
+        return;
+      }
 
-        const retryEligibleIssues = await applyChallengeRetryGate({
-          issueManager,
-          openIssues: actionableIssues,
-          issues: actionableIssues,
-          cycle,
-          onBlockedTransition: async (issue, transitionCycle, reason) => {
-            await transitionIssueLifecycleState(issueManager, {
-              issue,
-              nextState: "blocked",
-              reason: `retry gate decision: ${reason}`,
-              cycle: transitionCycle,
-            });
-          },
-        });
-        const selectedIssue = selectIssueForWork(retryEligibleIssues);
+      let retryAttempt = 0;
+      while (true) {
+        try {
+          const openIssues = await issueManager.listOpenIssues();
+          const actionableIssues: IssueSummary[] = [];
 
-        if (!selectedIssue) {
-          const plannerResult = await runPlannerAgent({
-            cycle,
-            openIssueCount: openIssues.length,
-            minimumIssueCount: MIN_REPLENISH_ISSUES,
-            maximumOpenIssues: MAX_OPEN_ISSUES,
+          for (const issue of openIssues) {
+            if (!isOutdatedIssue(issue)) {
+              actionableIssues.push(issue);
+              continue;
+            }
+
+            const result = await issueManager.closeIssue(issue.number);
+            if (result.ok) {
+              console.log(`Closed outdated issue ${formatIssueForLog(issue)}.`);
+            } else {
+              console.error(`Could not close outdated issue #${issue.number}: ${result.message}`);
+            }
+          }
+
+          const retryEligibleIssues = await applyChallengeRetryGate({
             issueManager,
-            workDir: WORK_DIR,
+            openIssues: actionableIssues,
+            issues: actionableIssues,
+            cycle,
+            onBlockedTransition: async (issue, transitionCycle, reason) => {
+              await transitionIssueLifecycleState(issueManager, {
+                issue,
+                nextState: "blocked",
+                reason: `retry gate decision: ${reason}`,
+                cycle: transitionCycle,
+              });
+            },
           });
-          const createdIssues = plannerResult.created;
+          if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+            return;
+          }
+
+          const selectedIssue = selectIssueForWork(retryEligibleIssues);
+
+          if (!selectedIssue) {
+            if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before planner replenishment.")) {
+              return;
+            }
+
+            const plannerResult = await runPlannerAgent({
+              cycle,
+              openIssueCount: openIssues.length,
+              minimumIssueCount: MIN_REPLENISH_ISSUES,
+              maximumOpenIssues: MAX_OPEN_ISSUES,
+              issueManager,
+              workDir: WORK_DIR,
+            });
+            const createdIssues = plannerResult.created;
+            logCycleQueueHealth({
+              cycle,
+              openCount: openIssues.length,
+              selectedIssue: null,
+              queueAction: {
+                type: plannerResult.startupBootstrap ? "bootstrap" : "replenish",
+                createdCount: createdIssues.length,
+                outcome: createdIssues.length > 0 ? "continue" : "stop",
+              },
+            });
+
+            if (createdIssues.length > 0) {
+              if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+                return;
+              }
+
+              if (plannerResult.startupBootstrap) {
+                console.log("No open issues found on startup. Bootstrapped issue queue from repository analysis.");
+              }
+              logCreatedIssues(createdIssues);
+              continue issueCycleLoop;
+            }
+
+            if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+              return;
+            }
+
+            if (cycle === 1) {
+              console.log(DEFAULT_PROMPT);
+            } else {
+              console.log("No actionable open issues remaining and no new issues were created. Issue loop stopped.");
+            }
+            return;
+          }
+
           logCycleQueueHealth({
             cycle,
             openCount: openIssues.length,
-            selectedIssue: null,
-            queueAction: {
-              type: plannerResult.startupBootstrap ? "bootstrap" : "replenish",
-              createdCount: createdIssues.length,
-              outcome: createdIssues.length > 0 ? "continue" : "stop",
-            },
+            selectedIssue,
+          });
+          await transitionIssueLifecycleState(issueManager, {
+            issue: selectedIssue,
+            nextState: "selected",
+            reason: "issue selected for active execution in this cycle",
+            cycle,
           });
 
-          if (createdIssues.length > 0) {
-            if (plannerResult.startupBootstrap) {
-              console.log("No open issues found on startup. Bootstrapped issue queue from repository analysis.");
+          let startedThisCycle = false;
+          if (!hasIssueLabel(selectedIssue, "in progress")) {
+            const result = await issueManager.markInProgress(selectedIssue.number);
+            if (!result.ok) {
+              console.error(`Could not mark issue #${selectedIssue.number} as in progress: ${result.message}`);
+            } else {
+              startedThisCycle = true;
             }
-            logCreatedIssues(createdIssues);
+          }
+
+          if (startedThisCycle) {
+            await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue));
+            await notifyIssueStartedInDiscord({
+              issueNumber: selectedIssue.number,
+              issueTitle: selectedIssue.title,
+              issueUrl: `https://github.com/${repositoryName}/issues/${selectedIssue.number}`,
+              repository: repositoryName,
+              lifecycleState: "selected -> executing",
+            });
+          }
+
+          const prompt = buildPromptFromIssue(selectedIssue);
+          console.log(`Prompt: ${prompt}`);
+          await transitionIssueLifecycleState(issueManager, {
+            issue: selectedIssue,
+            nextState: "executing",
+            reason: "coding agent execution started",
+            cycle,
+          });
+
+          let runError: unknown = null;
+          const runResult = await runCodingAgent(prompt).catch((error) => {
+            runError = error;
+            console.error("Error running the coding agent:", error);
+            return null;
+          });
+
+          if (runError) {
+            await transitionIssueLifecycleState(issueManager, {
+              issue: selectedIssue,
+              nextState: "failed",
+              reason: "runtime error during coding agent execution",
+              cycle,
+            });
+            const challengeEvidence = await persistChallengeAttemptEvidence(WORK_DIR, selectedIssue, runError, runResult);
+            await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
+            await addIssueLifecycleComment(
+              issueManager,
+              selectedIssue.number,
+              buildIssueFailureComment(selectedIssue, runError, challengeEvidence),
+            );
             continue issueCycleLoop;
           }
 
-          if (cycle === 1) {
-            console.log(DEFAULT_PROMPT);
-          } else {
-            console.log("No actionable open issues remaining and no new issues were created. Issue loop stopped.");
-          }
-          return;
-        }
-
-        logCycleQueueHealth({
-          cycle,
-          openCount: openIssues.length,
-          selectedIssue,
-        });
-        await transitionIssueLifecycleState(issueManager, {
-          issue: selectedIssue,
-          nextState: "selected",
-          reason: "issue selected for active execution in this cycle",
-          cycle,
-        });
-
-        let startedThisCycle = false;
-        if (!hasIssueLabel(selectedIssue, "in progress")) {
-          const result = await issueManager.markInProgress(selectedIssue.number);
-          if (!result.ok) {
-            console.error(`Could not mark issue #${selectedIssue.number} as in progress: ${result.message}`);
-          } else {
-            startedThisCycle = true;
-          }
-        }
-
-        if (startedThisCycle) {
-          await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue));
-          await notifyIssueStartedInDiscord({
-            issueNumber: selectedIssue.number,
-            issueTitle: selectedIssue.title,
-            issueUrl: `https://github.com/${repositoryName}/issues/${selectedIssue.number}`,
-            repository: repositoryName,
-            lifecycleState: "selected -> executing",
-          });
-        }
-
-        const prompt = buildPromptFromIssue(selectedIssue);
-        console.log(`Prompt: ${prompt}`);
-        await transitionIssueLifecycleState(issueManager, {
-          issue: selectedIssue,
-          nextState: "executing",
-          reason: "coding agent execution started",
-          cycle,
-        });
-
-        let runError: unknown = null;
-        const runResult = await runCodingAgent(prompt).catch((error) => {
-          runError = error;
-          console.error("Error running the coding agent:", error);
-          return null;
-        });
-
-        if (runError) {
-          await transitionIssueLifecycleState(issueManager, {
-            issue: selectedIssue,
-            nextState: "failed",
-            reason: "runtime error during coding agent execution",
-            cycle,
-          });
-          const challengeEvidence = await persistChallengeAttemptEvidence(WORK_DIR, selectedIssue, runError, runResult);
-          await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
-          await addIssueLifecycleComment(
-            issueManager,
-            selectedIssue.number,
-            buildIssueFailureComment(selectedIssue, runError, challengeEvidence),
-          );
-          continue issueCycleLoop;
-        }
-
-        let mergedDefaultBranch: string | null = null;
-        if (runResult) {
-          mergedDefaultBranch = runResult.mergedPullRequest
-            ? await tryResolveRepositoryDefaultBranch(WORK_DIR)
-            : null;
-          await transitionIssueLifecycleState(issueManager, {
-            issue: selectedIssue,
-            nextState: "under_review",
-            reason: "coding agent execution completed and review result is being processed",
-            cycle,
-            runResult,
-          });
-          await transitionIssueLifecycleState(issueManager, {
-            issue: selectedIssue,
-            nextState: mapReviewOutcomeToLifecycleState(runResult.summary.reviewOutcome),
-            reason: `review outcome received: ${runResult.summary.reviewOutcome}`,
-            cycle,
-            runResult,
-          });
-          if (runResult.summary.reviewOutcome === "accepted" && runResult.summary.pullRequestCreated) {
+          let mergedDefaultBranch: string | null = null;
+          if (runResult) {
+            mergedDefaultBranch = runResult.mergedPullRequest
+              ? await tryResolveRepositoryDefaultBranch(WORK_DIR)
+              : null;
             await transitionIssueLifecycleState(issueManager, {
               issue: selectedIssue,
-              nextState: "committed",
-              reason: "commit evidence observed through pull request creation",
+              nextState: "under_review",
+              reason: "coding agent execution completed and review result is being processed",
               cycle,
               runResult,
             });
-          }
-          if (runResult.summary.pullRequestCreated) {
             await transitionIssueLifecycleState(issueManager, {
               issue: selectedIssue,
-              nextState: "pr_opened",
-              reason: "pull request created for this lifecycle",
+              nextState: mapReviewOutcomeToLifecycleState(runResult.summary.reviewOutcome),
+              reason: `review outcome received: ${runResult.summary.reviewOutcome}`,
               cycle,
               runResult,
             });
-          }
-          const challengeEvidence = await persistChallengeAttemptEvidence(WORK_DIR, selectedIssue, runError, runResult);
-          await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
-          await addIssueLifecycleComment(
-            issueManager,
-            selectedIssue.number,
-            buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence, mergedDefaultBranch),
-          );
-          const challengeCompleted = await finalizeChallengeSuccess(
-            issueManager,
-            selectedIssue,
-            runResult,
-            mergedDefaultBranch,
-          );
-          if (challengeCompleted) {
-            await transitionIssueLifecycleState(issueManager, {
-              issue: selectedIssue,
-              nextState: "completed",
-              reason: "challenge issue marked as completed after accepted review outcome",
-              cycle,
+            if (runResult.summary.reviewOutcome === "accepted" && runResult.summary.pullRequestCreated) {
+              await transitionIssueLifecycleState(issueManager, {
+                issue: selectedIssue,
+                nextState: "committed",
+                reason: "commit evidence observed through pull request creation",
+                cycle,
+                runResult,
+              });
+            }
+            if (runResult.summary.pullRequestCreated) {
+              await transitionIssueLifecycleState(issueManager, {
+                issue: selectedIssue,
+                nextState: "pr_opened",
+                reason: "pull request created for this lifecycle",
+                cycle,
+                runResult,
+              });
+            }
+            const challengeEvidence = await persistChallengeAttemptEvidence(WORK_DIR, selectedIssue, runError, runResult);
+            await updateChallengeMetrics(issueManager, selectedIssue, runError, runResult);
+            await addIssueLifecycleComment(
+              issueManager,
+              selectedIssue.number,
+              buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence, mergedDefaultBranch),
+            );
+            const challengeCompleted = await finalizeChallengeSuccess(
+              issueManager,
+              selectedIssue,
               runResult,
-            });
-          }
-        }
-
-        if (runResult?.mergedPullRequest) {
-          await transitionIssueLifecycleState(issueManager, {
-            issue: selectedIssue,
-            nextState: "merged",
-            reason: buildMergedPullRequestReason(mergedDefaultBranch),
-            cycle,
-            runResult,
-          });
-          await addIssueLifecycleComment(
-            issueManager,
-            selectedIssue.number,
-            buildMergeOutcomeComment(selectedIssue, mergedDefaultBranch),
-          );
-          console.log("Merged pull request detected. Running post-merge restart workflow.");
-          try {
-            await runPostMergeSelfRestart(WORK_DIR);
-            await transitionIssueLifecycleState(issueManager, {
-              issue: selectedIssue,
-              nextState: "restarted",
-              reason: "post-merge restart workflow completed successfully",
-              cycle,
-              runResult,
-            });
-            console.log("Post-merge restart workflow completed. Exiting current runtime.");
-          } catch (error) {
-            if (error instanceof Error) {
-              console.error(error.message);
-            } else {
-              console.error("Post-merge restart failed with an unknown error.");
+              mergedDefaultBranch,
+            );
+            if (challengeCompleted) {
+              await transitionIssueLifecycleState(issueManager, {
+                issue: selectedIssue,
+                nextState: "completed",
+                reason: "challenge issue marked as completed after accepted review outcome",
+                cycle,
+                runResult,
+              });
             }
           }
 
+          if (runResult?.mergedPullRequest) {
+            await transitionIssueLifecycleState(issueManager, {
+              issue: selectedIssue,
+              nextState: "merged",
+              reason: buildMergedPullRequestReason(mergedDefaultBranch),
+              cycle,
+              runResult,
+            });
+            await addIssueLifecycleComment(
+              issueManager,
+              selectedIssue.number,
+              buildMergeOutcomeComment(selectedIssue, mergedDefaultBranch),
+            );
+            console.log("Merged pull request detected. Running post-merge restart workflow.");
+            try {
+              await runPostMergeSelfRestart(WORK_DIR);
+              await transitionIssueLifecycleState(issueManager, {
+                issue: selectedIssue,
+                nextState: "restarted",
+                reason: "post-merge restart workflow completed successfully",
+                cycle,
+                runResult,
+              });
+              console.log("Post-merge restart workflow completed. Exiting current runtime.");
+            } catch (error) {
+              if (error instanceof Error) {
+                console.error(error.message);
+              } else {
+                console.error("Post-merge restart failed with an unknown error.");
+              }
+            }
+
+            return;
+          }
+
+          if (
+            await stopIfGracefulShutdownRequested(
+              WORK_DIR,
+              "Current task completed. Stopping before starting another issue.",
+            )
+          ) {
+            return;
+          }
+
+          break;
+        } catch (error) {
+          if (isTransientGitHubError(error) && retryAttempt < RUN_LOOP_GITHUB_MAX_RETRIES) {
+            retryAttempt += 1;
+            const delayMs = getRunLoopRetryDelayMs(retryAttempt);
+            const message = error instanceof Error ? error.message : "unknown error";
+            console.error(
+              `Transient GitHub issue sync failure on cycle ${cycle} (attempt ${retryAttempt}/${RUN_LOOP_GITHUB_MAX_RETRIES}). Retrying in ${delayMs}ms. Error: ${message}`,
+            );
+            await waitForRunLoopRetry(delayMs);
+            continue;
+          }
+
+          logGitHubFallback(error);
+          if (cycle === 1) {
+            console.log(DEFAULT_PROMPT);
+          }
           return;
         }
-
-        break;
-      } catch (error) {
-        if (isTransientGitHubError(error) && retryAttempt < RUN_LOOP_GITHUB_MAX_RETRIES) {
-          retryAttempt += 1;
-          const delayMs = getRunLoopRetryDelayMs(retryAttempt);
-          const message = error instanceof Error ? error.message : "unknown error";
-          console.error(
-            `Transient GitHub issue sync failure on cycle ${cycle} (attempt ${retryAttempt}/${RUN_LOOP_GITHUB_MAX_RETRIES}). Retrying in ${delayMs}ms. Error: ${message}`,
-          );
-          await waitForRunLoopRetry(delayMs);
-          continue;
-        }
-
-        logGitHubFallback(error);
-        if (cycle === 1) {
-          console.log(DEFAULT_PROMPT);
-        }
-        return;
       }
     }
+  } finally {
+    await gracefulShutdownListener?.stop();
   }
-
 }
 
 const isDirectExecution =

--- a/src/runtime/gracefulShutdown.test.ts
+++ b/src/runtime/gracefulShutdown.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  consumeGracefulShutdownRequest,
+  getDiscordControlCursorPath,
+  getGracefulShutdownRequestPath,
+  readDiscordControlCursor,
+  readGracefulShutdownRequest,
+  recordGracefulShutdownRequest,
+  writeDiscordControlCursor,
+} from "./gracefulShutdown.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "graceful-shutdown-"));
+}
+
+describe("gracefulShutdown", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+  });
+
+  it("records a pending graceful shutdown request once and preserves the first request details", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const first = await recordGracefulShutdownRequest(workDir, {
+      messageId: "9001",
+      requestedAt: "2026-03-07T12:00:00.000Z",
+    });
+    const second = await recordGracefulShutdownRequest(workDir, {
+      messageId: "9002",
+      requestedAt: "2026-03-07T12:05:00.000Z",
+    });
+
+    expect(first).toEqual({
+      created: true,
+      request: {
+        version: 1,
+        source: "discord",
+        command: "/quit",
+        messageId: "9001",
+        requestedAt: "2026-03-07T12:00:00.000Z",
+      },
+    });
+    expect(second).toEqual({
+      created: false,
+      request: first.request,
+    });
+    await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual(first.request);
+  });
+
+  it("consumes and clears a pending graceful shutdown request", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordGracefulShutdownRequest(workDir, {
+      messageId: "9010",
+      requestedAt: "2026-03-07T13:00:00.000Z",
+    });
+
+    await expect(consumeGracefulShutdownRequest(workDir)).resolves.toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit",
+      messageId: "9010",
+      requestedAt: "2026-03-07T13:00:00.000Z",
+    });
+    await expect(consumeGracefulShutdownRequest(workDir)).resolves.toBeNull();
+  });
+
+  it("normalizes persisted cursor and malformed shutdown payloads", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await writeDiscordControlCursor(workDir, "  7777  ");
+    expect(await readDiscordControlCursor(workDir)).toBe("7777");
+
+    await writeFile(getDiscordControlCursorPath(workDir), "{not-json", "utf8");
+    await expect(readDiscordControlCursor(workDir)).resolves.toBeNull();
+
+    await writeFile(
+      getGracefulShutdownRequestPath(workDir),
+      JSON.stringify({ version: 1, source: "discord", command: "/quit", messageId: "   " }),
+      "utf8",
+    );
+    await expect(readGracefulShutdownRequest(workDir)).resolves.toBeNull();
+  });
+});

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+
+const EVOLVO_DIRECTORY_NAME = ".evolvo";
+const GRACEFUL_SHUTDOWN_REQUEST_FILE_NAME = "graceful-shutdown-request.json";
+const DISCORD_CONTROL_CURSOR_FILE_NAME = "discord-control-cursor.json";
+const GRACEFUL_SHUTDOWN_REQUEST_VERSION = 1;
+
+export type GracefulShutdownRequest = {
+  version: typeof GRACEFUL_SHUTDOWN_REQUEST_VERSION;
+  source: "discord";
+  command: "/quit";
+  messageId: string;
+  requestedAt: string;
+};
+
+type DiscordControlCursorState = {
+  lastSeenMessageId: string | null;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeMessageId(value: unknown): string | null {
+  if (!isNonEmptyString(value)) {
+    return null;
+  }
+
+  return value.trim();
+}
+
+function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest | null {
+  if (typeof raw !== "object" || raw === null) {
+    return null;
+  }
+
+  const candidate = raw as Partial<GracefulShutdownRequest>;
+  const messageId = normalizeMessageId(candidate.messageId);
+  if (candidate.source !== "discord" || candidate.command !== "/quit" || messageId === null) {
+    return null;
+  }
+
+  const requestedAt = isNonEmptyString(candidate.requestedAt) ? candidate.requestedAt.trim() : null;
+  if (requestedAt === null) {
+    return null;
+  }
+
+  return {
+    version: GRACEFUL_SHUTDOWN_REQUEST_VERSION,
+    source: "discord",
+    command: "/quit",
+    messageId,
+    requestedAt,
+  };
+}
+
+function normalizeDiscordControlCursorState(raw: unknown): DiscordControlCursorState {
+  if (typeof raw !== "object" || raw === null) {
+    return { lastSeenMessageId: null };
+  }
+
+  const candidate = raw as Partial<DiscordControlCursorState>;
+  return {
+    lastSeenMessageId: normalizeMessageId(candidate.lastSeenMessageId),
+  };
+}
+
+async function readJsonFile(path: string): Promise<unknown | null> {
+  try {
+    const raw = await fs.readFile(path, "utf8");
+    return JSON.parse(raw) as unknown;
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT" || error instanceof SyntaxError) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+async function writeJsonFile(path: string, value: unknown): Promise<void> {
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export function getGracefulShutdownRequestPath(workDir: string): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, GRACEFUL_SHUTDOWN_REQUEST_FILE_NAME);
+}
+
+export function getDiscordControlCursorPath(workDir: string): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, DISCORD_CONTROL_CURSOR_FILE_NAME);
+}
+
+export async function readGracefulShutdownRequest(workDir: string): Promise<GracefulShutdownRequest | null> {
+  const raw = await readJsonFile(getGracefulShutdownRequestPath(workDir));
+  return normalizeGracefulShutdownRequest(raw);
+}
+
+export async function recordGracefulShutdownRequest(
+  workDir: string,
+  input: {
+    messageId: string;
+    requestedAt?: string;
+  },
+): Promise<{ request: GracefulShutdownRequest; created: boolean }> {
+  const existing = await readGracefulShutdownRequest(workDir);
+  if (existing !== null) {
+    return { request: existing, created: false };
+  }
+
+  const messageId = normalizeMessageId(input.messageId);
+  if (messageId === null) {
+    throw new Error("Graceful shutdown request message ID cannot be empty.");
+  }
+
+  const requestedAt = isNonEmptyString(input.requestedAt)
+    ? input.requestedAt.trim()
+    : new Date().toISOString();
+
+  const request: GracefulShutdownRequest = {
+    version: GRACEFUL_SHUTDOWN_REQUEST_VERSION,
+    source: "discord",
+    command: "/quit",
+    messageId,
+    requestedAt,
+  };
+  await writeJsonFile(getGracefulShutdownRequestPath(workDir), request);
+  return { request, created: true };
+}
+
+export async function consumeGracefulShutdownRequest(workDir: string): Promise<GracefulShutdownRequest | null> {
+  const request = await readGracefulShutdownRequest(workDir);
+  if (request === null) {
+    return null;
+  }
+
+  await fs.rm(getGracefulShutdownRequestPath(workDir), { force: true });
+  return request;
+}
+
+export async function readDiscordControlCursor(workDir: string): Promise<string | null> {
+  const raw = await readJsonFile(getDiscordControlCursorPath(workDir));
+  return normalizeDiscordControlCursorState(raw).lastSeenMessageId;
+}
+
+export async function writeDiscordControlCursor(workDir: string, lastSeenMessageId: string | null): Promise<void> {
+  await writeJsonFile(getDiscordControlCursorPath(workDir), {
+    lastSeenMessageId: normalizeMessageId(lastSeenMessageId),
+  } satisfies DiscordControlCursorState);
+}

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -1,17 +1,28 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getDiscordControlConfigFromEnv,
   notifyIssueStartedInDiscord,
+  pollDiscordGracefulShutdownCommand,
   requestCycleLimitDecisionFromOperator,
   runDiscordOperatorControlStartupCheck,
 } from "./operatorControl.js";
 
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "operator-control-"));
+}
+
 describe("operatorControl", () => {
+  const tempDirs: string[] = [];
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
@@ -77,6 +88,14 @@ describe("operatorControl", () => {
       "Discord operator control startup preflight passed (verify-channel, read-history).",
     );
     expect(logSpy).toHaveBeenCalledWith("Discord operator control startup boot message posted.");
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("graceful shutdown"),
+      }),
+    );
   });
 
   it("logs startup preflight step when Discord channel verification fails", async () => {
@@ -280,7 +299,7 @@ describe("operatorControl", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
-  it("returns quit when operator replies quit", async () => {
+  it("returns quit when operator replies /quit", async () => {
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
     vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
     vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
@@ -297,7 +316,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "5001", content: "quit", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "5001", content: "/quit", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       );
@@ -312,6 +331,75 @@ describe("operatorControl", () => {
       additionalCycles: 0,
       source: "discord",
     });
+  });
+
+  it("records and acknowledges an authorized /quit graceful shutdown command", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7000", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7001", content: "/quit", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(request).toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit",
+      messageId: "7001",
+      requestedAt: expect.any(String),
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1> Graceful shutdown requested.\nEvolvo will finish the current task and then stop before starting another issue.",
+        }),
+      }),
+    );
+  });
+
+  it("ignores /quit messages from unauthorized users", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "8000", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "8001", content: "/quit", author: { id: "intruder-1" } }]),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(request).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
   it("returns null when Discord API fails and logs a Missing Access hint", async () => {

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -1,3 +1,10 @@
+import {
+  recordGracefulShutdownRequest,
+  readDiscordControlCursor,
+  type GracefulShutdownRequest,
+  writeDiscordControlCursor,
+} from "./gracefulShutdown.js";
+
 type DiscordControlConfig = {
   botToken: string;
   guildId: string;
@@ -25,7 +32,9 @@ type DiscordOperatorStep =
   | "send-boot-message"
   | "send-prompt"
   | "wait-for-reply"
-  | "send-issue-start";
+  | "send-issue-start"
+  | "read-quit-commands"
+  | "send-quit-ack";
 
 type DiscordIssueStartNotification = {
   issueNumber: number;
@@ -82,14 +91,18 @@ export function getDiscordControlConfigFromEnv(
 
 function parseOperatorDecision(content: string): "continue" | "quit" | null {
   const normalized = content.trim().toLowerCase();
-  if (normalized === "continue") {
+  if (normalized === "continue" || normalized === "/continue") {
     return "continue";
   }
-  if (normalized === "quit") {
+  if (normalized === "quit" || normalized === "/quit") {
     return "quit";
   }
 
   return null;
+}
+
+function isGracefulShutdownCommand(content: string): boolean {
+  return content.trim().toLowerCase() === "/quit";
 }
 
 function buildAuthHeaders(config: DiscordControlConfig): Record<string, string> {
@@ -125,7 +138,7 @@ async function sendCycleLimitPrompt(
 ): Promise<{ id: string }> {
   const content = [
     `<@${config.operatorUserId}> Evolvo has reached its cycle limit (${currentLimit}).`,
-    `Reply in this channel with \`continue\` to add ${config.cycleExtension} more cycles, or \`quit\` to stop.`,
+    `Reply in this channel with \`continue\` to add ${config.cycleExtension} more cycles, or \`quit\` / \`/quit\` to stop.`,
   ].join("\n");
 
   return fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
@@ -138,7 +151,7 @@ async function sendStartupBootMessage(config: DiscordControlConfig): Promise<voi
   const startedAt = new Date().toISOString();
   const content = [
     "🤖 Evolvo runtime booted.",
-    "Operator control is online for cycle-limit decisions.",
+    "Operator control is online for cycle-limit decisions and graceful shutdown.",
     `Started at: ${startedAt}`,
   ].join("\n");
 
@@ -189,6 +202,18 @@ async function sendIssueStartNotification(
         },
       ],
     }),
+  });
+}
+
+async function sendGracefulShutdownAcknowledgement(config: DiscordControlConfig): Promise<void> {
+  const content = [
+    `<@${config.operatorUserId}> Graceful shutdown requested.`,
+    "Evolvo will finish the current task and then stop before starting another issue.",
+  ].join("\n");
+
+  await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ content }),
   });
 }
 
@@ -249,6 +274,45 @@ async function verifyControlChannel(config: DiscordControlConfig): Promise<void>
   }
 }
 
+async function fetchControlChannelMessages(
+  config: DiscordControlConfig,
+  options: {
+    afterId?: string | null;
+    limit?: number;
+  } = {},
+): Promise<Array<{
+  id: string;
+  content: string;
+  author?: { id?: string };
+}>> {
+  const query = new URLSearchParams();
+  query.set("limit", String(options.limit ?? 50));
+  if (options.afterId && options.afterId.trim().length > 0) {
+    query.set("after", options.afterId);
+  }
+
+  return fetchDiscordJson<Array<{
+    id: string;
+    content: string;
+    author?: { id?: string };
+  }>>(config, `/channels/${config.controlChannelId}/messages?${query.toString()}`);
+}
+
+async function initializeDiscordControlCursor(
+  config: DiscordControlConfig,
+  workDir: string,
+): Promise<string | null> {
+  const existingCursor = await readDiscordControlCursor(workDir);
+  if (existingCursor !== null) {
+    return existingCursor;
+  }
+
+  const messages = await fetchControlChannelMessages(config, { limit: 1 });
+  const lastSeenMessageId = messages[0]?.id ?? null;
+  await writeDiscordControlCursor(workDir, lastSeenMessageId);
+  return lastSeenMessageId;
+}
+
 function buildStepFailureMessage(step: DiscordOperatorStep, error: unknown): string {
   const message = error instanceof Error ? error.message : "unknown error";
   return `[${step}] ${message}`;
@@ -301,6 +365,110 @@ export async function runDiscordOperatorControlStartupCheck(): Promise<void> {
   }
 
   console.log("Discord operator control startup boot message posted.");
+}
+
+export async function pollDiscordGracefulShutdownCommand(
+  workDir: string,
+): Promise<GracefulShutdownRequest | null> {
+  const config = getDiscordControlConfigFromEnv();
+  if (!config) {
+    return null;
+  }
+
+  try {
+    const afterId = await initializeDiscordControlCursor(config, workDir);
+    const messages = await fetchControlChannelMessages(config, { afterId, limit: 50 });
+    if (messages.length === 0) {
+      return null;
+    }
+
+    await writeDiscordControlCursor(workDir, getHighestSnowflakeId(messages.map((message) => message.id)));
+
+    const quitMessage = messages.find((message) =>
+      message.author?.id === config.operatorUserId && isGracefulShutdownCommand(message.content)
+    );
+    if (!quitMessage) {
+      return null;
+    }
+
+    const recordedRequest = await recordGracefulShutdownRequest(workDir, {
+      messageId: quitMessage.id,
+    });
+    if (!recordedRequest.created) {
+      return recordedRequest.request;
+    }
+
+    try {
+      await sendGracefulShutdownAcknowledgement(config);
+    } catch (error) {
+      const message = buildStepFailureMessage("send-quit-ack", error);
+      console.error(`Discord graceful shutdown acknowledgement failed: ${message}`);
+      logDiscordMissingAccessHint(message);
+    }
+
+    return recordedRequest.request;
+  } catch (error) {
+    const message = buildStepFailureMessage("read-quit-commands", error);
+    console.error(`Discord graceful shutdown polling failed: ${message}`);
+    logDiscordMissingAccessHint(message);
+    return null;
+  }
+}
+
+export type DiscordGracefulShutdownListener = {
+  stop: () => Promise<void>;
+};
+
+export async function startDiscordGracefulShutdownListener(
+  workDir: string,
+): Promise<DiscordGracefulShutdownListener | null> {
+  const config = getDiscordControlConfigFromEnv();
+  if (!config) {
+    return null;
+  }
+
+  try {
+    await initializeDiscordControlCursor(config, workDir);
+  } catch (error) {
+    const message = buildStepFailureMessage("read-quit-commands", error);
+    console.error(`Discord graceful shutdown listener bootstrap failed: ${message}`);
+    logDiscordMissingAccessHint(message);
+  }
+
+  let stopped = false;
+  let pendingPoll: Promise<void> | null = null;
+  let timer: NodeJS.Timeout | null = null;
+
+  const scheduleNextPoll = (): void => {
+    if (stopped) {
+      return;
+    }
+
+    timer = setTimeout(() => {
+      pendingPoll = pollDiscordGracefulShutdownCommand(workDir)
+        .catch(() => undefined)
+        .then(() => undefined)
+        .finally(() => {
+          pendingPoll = null;
+          scheduleNextPoll();
+        });
+    }, config.pollIntervalMs);
+    timer.unref?.();
+  };
+
+  scheduleNextPoll();
+
+  return {
+    stop: async () => {
+      stopped = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      if (pendingPoll !== null) {
+        await pendingPoll;
+      }
+    },
+  };
 }
 
 export async function notifyIssueStartedInDiscord(


### PR DESCRIPTION
## Summary
- add a persisted graceful shutdown request and Discord cursor state under .evolvo
- poll the configured control channel for authorized /quit commands and acknowledge them
- stop the main loop after the current task finishes instead of starting a new issue

## Testing
- pnpm vitest run src/runtime/gracefulShutdown.test.ts src/runtime/operatorControl.test.ts src/main.test.ts src/main.replenishment.integration.test.ts
- pnpm typecheck

Closes #312