### PR TITLE
Add project provisioning request flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ web_modules/
 # Output of 'npm pack'
 *.tgz
 
+# Managed project workspaces
+/projects/
+
 # Yarn Integrity file
 .yarn-integrity
 

--- a/src/github/githubAdminClient.test.ts
+++ b/src/github/githubAdminClient.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { GitHubAdminClient } from "./githubAdminClient.js";
+import { GitHubApiError } from "./githubClient.js";
+
+function createClientMock() {
+  return {
+    getApi: vi.fn(),
+    postApi: vi.fn(),
+  };
+}
+
+describe("GitHubAdminClient", () => {
+  it("does not recreate an existing tracker label", async () => {
+    const client = createClientMock();
+    client.getApi.mockResolvedValue({ name: "project:habit-cli" });
+    const adminClient = new GitHubAdminClient(client as never, {
+      token: "token",
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      apiBaseUrl: "https://api.github.com",
+    });
+
+    await adminClient.ensureLabel({
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      name: "project:habit-cli",
+    });
+
+    expect(client.getApi).toHaveBeenCalledWith("/repos/evolvo-auto/evolvo-ts/labels/project%3Ahabit-cli");
+    expect(client.postApi).not.toHaveBeenCalled();
+  });
+
+  it("creates a tracker label when it does not exist", async () => {
+    const client = createClientMock();
+    client.getApi.mockRejectedValueOnce(new GitHubApiError("missing", 404, null));
+    client.postApi.mockResolvedValue({ name: "project:habit-cli" });
+    const adminClient = new GitHubAdminClient(client as never, {
+      token: "token",
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      apiBaseUrl: "https://api.github.com",
+    });
+
+    await adminClient.ensureLabel({
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      name: "project:habit-cli",
+      description: "Issues for Habit CLI",
+    });
+
+    expect(client.postApi).toHaveBeenCalledWith(
+      "/repos/evolvo-auto/evolvo-ts/labels",
+      expect.objectContaining({
+        name: "project:habit-cli",
+        description: "Issues for Habit CLI",
+      }),
+    );
+  });
+
+  it("tolerates concurrent tracker label creation by re-reading the label", async () => {
+    const client = createClientMock();
+    client.getApi
+      .mockRejectedValueOnce(new GitHubApiError("missing", 404, null))
+      .mockResolvedValueOnce({ name: "project:habit-cli" });
+    client.postApi.mockRejectedValueOnce(new GitHubApiError("already exists", 422, null));
+    const adminClient = new GitHubAdminClient(client as never, {
+      token: "token",
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      apiBaseUrl: "https://api.github.com",
+    });
+
+    await adminClient.ensureLabel({
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      name: "project:habit-cli",
+    });
+
+    expect(client.getApi).toHaveBeenCalledTimes(2);
+    expect(client.postApi).toHaveBeenCalledTimes(1);
+  });
+
+  it("verifies and returns an existing managed repository", async () => {
+    const client = createClientMock();
+    client.getApi.mockResolvedValueOnce({
+      name: "habit-cli",
+      html_url: "https://github.com/evolvo-auto/habit-cli",
+      default_branch: "main",
+      owner: {
+        login: "evolvo-auto",
+      },
+    });
+    const adminClient = new GitHubAdminClient(client as never, {
+      token: "token",
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      apiBaseUrl: "https://api.github.com",
+    });
+
+    await expect(
+      adminClient.ensureRepository({
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+      }),
+    ).resolves.toEqual({
+      owner: "evolvo-auto",
+      repo: "habit-cli",
+      url: "https://github.com/evolvo-auto/habit-cli",
+      defaultBranch: "main",
+    });
+    expect(client.postApi).not.toHaveBeenCalled();
+  });
+
+  it("creates and verifies an organization repository when it does not exist", async () => {
+    const client = createClientMock();
+    client.getApi
+      .mockRejectedValueOnce(new GitHubApiError("missing", 404, null))
+      .mockResolvedValueOnce({ login: "evolvo-auto", type: "Organization" })
+      .mockResolvedValueOnce({
+        name: "habit-cli",
+        html_url: "https://github.com/evolvo-auto/habit-cli",
+        default_branch: "main",
+        owner: {
+          login: "evolvo-auto",
+        },
+      });
+    client.postApi.mockResolvedValueOnce({});
+    const adminClient = new GitHubAdminClient(client as never, {
+      token: "token",
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      apiBaseUrl: "https://api.github.com",
+    });
+
+    const result = await adminClient.ensureRepository({
+      owner: "evolvo-auto",
+      repo: "habit-cli",
+      description: "Managed project",
+    });
+
+    expect(client.getApi).toHaveBeenNthCalledWith(2, "/users/evolvo-auto");
+    expect(client.postApi).toHaveBeenCalledWith(
+      "/orgs/evolvo-auto/repos",
+      expect.objectContaining({
+        name: "habit-cli",
+        description: "Managed project",
+        has_issues: true,
+      }),
+    );
+    expect(result).toEqual({
+      owner: "evolvo-auto",
+      repo: "habit-cli",
+      url: "https://github.com/evolvo-auto/habit-cli",
+      defaultBranch: "main",
+    });
+  });
+});

--- a/src/github/githubAdminClient.ts
+++ b/src/github/githubAdminClient.ts
@@ -1,0 +1,170 @@
+import type { GitHubConfig } from "./githubConfig.js";
+import { GitHubApiError, GitHubClient } from "./githubClient.js";
+
+type GitHubOwnerResponse = {
+  login?: unknown;
+  type?: unknown;
+};
+
+type GitHubLabelResponse = {
+  name?: unknown;
+  color?: unknown;
+  description?: unknown;
+};
+
+type GitHubRepositoryResponse = {
+  name?: unknown;
+  html_url?: unknown;
+  default_branch?: unknown;
+  owner?: {
+    login?: unknown;
+  };
+};
+
+export type GitHubAdminRepository = {
+  owner: string;
+  repo: string;
+  url: string;
+  defaultBranch: string | null;
+};
+
+export class GitHubAdminClient {
+  public constructor(
+    private readonly client: GitHubClient,
+    private readonly config: GitHubConfig,
+  ) {}
+
+  public async ensureLabel(options: {
+    owner: string;
+    repo: string;
+    name: string;
+    color?: string;
+    description?: string;
+  }): Promise<void> {
+    const labelPath = this.buildLabelPath(options.owner, options.repo, options.name);
+
+    try {
+      await this.client.getApi<GitHubLabelResponse>(labelPath);
+      return;
+    } catch (error) {
+      if (!(error instanceof GitHubApiError) || error.status !== 404) {
+        throw error;
+      }
+    }
+
+    try {
+      await this.client.postApi<GitHubLabelResponse>(
+        `/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.repo)}/labels`,
+        {
+          name: options.name,
+          color: options.color ?? "0e8a16",
+          description: options.description?.trim() || undefined,
+        },
+      );
+    } catch (error) {
+      if (!(error instanceof GitHubApiError) || error.status !== 422) {
+        throw error;
+      }
+
+      await this.client.getApi<GitHubLabelResponse>(labelPath);
+    }
+  }
+
+  public async ensureRepository(options: {
+    owner: string;
+    repo: string;
+    description?: string;
+  }): Promise<GitHubAdminRepository> {
+    try {
+      return await this.getRepository(options.owner, options.repo);
+    } catch (error) {
+      if (!(error instanceof GitHubApiError) || error.status !== 404) {
+        throw error;
+      }
+    }
+
+    const ownerType = await this.getOwnerType(options.owner);
+    if (ownerType === "Organization") {
+      await this.client.postApi<GitHubRepositoryResponse>(
+        `/orgs/${encodeURIComponent(options.owner)}/repos`,
+        {
+          name: options.repo,
+          description: options.description?.trim() || undefined,
+          has_issues: true,
+        },
+      );
+    } else if (ownerType === "User") {
+      await this.client.postApi<GitHubRepositoryResponse>("/user/repos", {
+        name: options.repo,
+        description: options.description?.trim() || undefined,
+        has_issues: true,
+      });
+    } else {
+      throw new Error(`Unsupported GitHub owner type for ${options.owner}.`);
+    }
+
+    const repository = await this.getRepository(options.owner, options.repo);
+    if (repository.owner !== options.owner) {
+      throw new Error(
+        `GitHub created repository ${repository.owner}/${repository.repo} instead of requested owner ${options.owner}.`,
+      );
+    }
+
+    return repository;
+  }
+
+  public async getRepository(owner: string, repo: string): Promise<GitHubAdminRepository> {
+    const response = await this.client.getApi<GitHubRepositoryResponse>(
+      `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+    );
+    const repositoryOwner = this.normalizeNonEmptyString(response.owner?.login);
+    const repositoryName = this.normalizeNonEmptyString(response.name);
+    const repositoryUrl = this.normalizeNonEmptyString(response.html_url);
+    if (!repositoryOwner || !repositoryName || !repositoryUrl) {
+      throw new Error(
+        `GitHub repository metadata for ${owner}/${repo} was missing owner, name, or html_url.`,
+      );
+    }
+
+    return {
+      owner: repositoryOwner,
+      repo: repositoryName,
+      url: repositoryUrl,
+      defaultBranch: this.normalizeNonEmptyString(response.default_branch),
+    };
+  }
+
+  private async getOwnerType(owner: string): Promise<"Organization" | "User"> {
+    const response = await this.client.getApi<GitHubOwnerResponse>(`/users/${encodeURIComponent(owner)}`);
+    const ownerType = this.normalizeNonEmptyString(response.type);
+    const ownerLogin = this.normalizeNonEmptyString(response.login);
+    if (!ownerType || !ownerLogin) {
+      throw new Error(`GitHub owner metadata for ${owner} was incomplete.`);
+    }
+
+    if (ownerType !== "Organization" && ownerType !== "User") {
+      throw new Error(`Unsupported GitHub owner type for ${owner}: ${ownerType}`);
+    }
+
+    if (ownerType === "User" && ownerLogin !== this.config.owner) {
+      throw new Error(
+        `GitHub owner ${ownerLogin} is a user account, but the configured tracker owner is ${this.config.owner}.`,
+      );
+    }
+
+    return ownerType;
+  }
+
+  private buildLabelPath(owner: string, repo: string, label: string): string {
+    return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/labels/${encodeURIComponent(label)}`;
+  }
+
+  private normalizeNonEmptyString(value: unknown): string | null {
+    if (typeof value !== "string") {
+      return null;
+    }
+
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+}

--- a/src/github/githubClient.test.ts
+++ b/src/github/githubClient.test.ts
@@ -55,6 +55,31 @@ describe("GitHubClient", () => {
     );
   });
 
+  it("calls generic GitHub API paths with auth headers", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ login: "owner", type: "Organization" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const client = createClient();
+
+    const result = await client.getApi<{ login: string; type: string }>("/users/owner");
+
+    expect(result).toEqual({ login: "owner", type: "Organization" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/users/owner",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret-token",
+          Accept: "application/vnd.github+json",
+        }),
+      }),
+    );
+  });
+
   it("throws GitHubApiError with API message", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ message: "Not Found" }), {

--- a/src/github/githubClient.ts
+++ b/src/github/githubClient.ts
@@ -49,6 +49,7 @@ function readNonNegativeInteger(value: number | undefined, fallback: number, nam
 }
 
 export class GitHubClient {
+  private readonly apiBaseUrl: string;
   private readonly baseIssueUrl: string;
   private readonly token: string;
   private readonly requestTimeoutMs: number;
@@ -56,8 +57,8 @@ export class GitHubClient {
   private readonly retryBaseDelayMs: number;
 
   public constructor(config: GitHubConfig) {
-    const apiBase = config.apiBaseUrl.replace(/\/+$/, "");
-    this.baseIssueUrl = `${apiBase}/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/issues`;
+    this.apiBaseUrl = config.apiBaseUrl.replace(/\/+$/, "");
+    this.baseIssueUrl = `${this.apiBaseUrl}/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/issues`;
     this.token = config.token;
     this.requestTimeoutMs = readPositiveInteger(
       config.requestTimeoutMs,
@@ -73,23 +74,38 @@ export class GitHubClient {
   }
 
   public async get<T>(path: string): Promise<T> {
-    return this.request<T>(path, { method: "GET" });
+    return this.request<T>(`${this.baseIssueUrl}${path}`, { method: "GET" });
   }
 
   public async post<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>(path, { method: "POST", body });
+    return this.request<T>(`${this.baseIssueUrl}${path}`, { method: "POST", body });
   }
 
   public async patch<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>(path, { method: "PATCH", body });
+    return this.request<T>(`${this.baseIssueUrl}${path}`, { method: "PATCH", body });
   }
 
   public async delete(path: string): Promise<void> {
-    await this.request<null>(path, { method: "DELETE" });
+    await this.request<null>(`${this.baseIssueUrl}${path}`, { method: "DELETE" });
   }
 
-  private async request<T>(path: string, options: RequestOptions): Promise<T> {
-    const url = `${this.baseIssueUrl}${path}`;
+  public async getApi<T>(path: string): Promise<T> {
+    return this.request<T>(`${this.apiBaseUrl}${path}`, { method: "GET" });
+  }
+
+  public async postApi<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>(`${this.apiBaseUrl}${path}`, { method: "POST", body });
+  }
+
+  public async patchApi<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>(`${this.apiBaseUrl}${path}`, { method: "PATCH", body });
+  }
+
+  public async deleteApi(path: string): Promise<void> {
+    await this.request<null>(`${this.apiBaseUrl}${path}`, { method: "DELETE" });
+  }
+
+  private async request<T>(url: string, options: RequestOptions): Promise<T> {
     const totalAttempts = this.maxRetries + 1;
 
     for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {

--- a/src/issues/projectProvisioningIssue.test.ts
+++ b/src/issues/projectProvisioningIssue.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProjectProvisioningIssueBody,
+  buildProjectProvisioningIssueTitle,
+  isProjectProvisioningIssue,
+  parseProjectProvisioningIssueMetadata,
+} from "./projectProvisioningIssue.js";
+import type { IssueSummary } from "./taskIssueManager.js";
+
+function createIssue(overrides: Partial<IssueSummary> = {}): IssueSummary {
+  return {
+    number: 1,
+    title: "Issue",
+    description: "Description",
+    state: "open",
+    labels: [],
+    ...overrides,
+  };
+}
+
+describe("projectProvisioningIssue", () => {
+  it("builds and parses project provisioning metadata blocks", () => {
+    const body = buildProjectProvisioningIssueBody({
+      owner: "evolvo-auto",
+      displayName: "Habit CLI",
+      slug: "habit-cli",
+      repositoryName: "habit-cli",
+      issueLabel: "project:habit-cli",
+      workspaceRelativePath: "projects/habit-cli",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-07T12:00:00.000Z",
+    });
+
+    expect(buildProjectProvisioningIssueTitle("Habit CLI")).toBe("Start project Habit CLI");
+    expect(parseProjectProvisioningIssueMetadata(body)).toEqual({
+      owner: "evolvo-auto",
+      displayName: "Habit CLI",
+      slug: "habit-cli",
+      repositoryName: "habit-cli",
+      issueLabel: "project:habit-cli",
+      workspaceRelativePath: "projects/habit-cli",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-07T12:00:00.000Z",
+    });
+  });
+
+  it("recognizes provisioning issues by metadata block", () => {
+    const issue = createIssue({
+      title: "Start project Habit CLI",
+      description: buildProjectProvisioningIssueBody({
+        owner: "evolvo-auto",
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        issueLabel: "project:habit-cli",
+        workspaceRelativePath: "projects/habit-cli",
+        requestedBy: "discord:operator-1",
+        requestedAt: "2026-03-07T12:00:00.000Z",
+      }),
+    });
+
+    expect(isProjectProvisioningIssue(issue)).toBe(true);
+  });
+
+  it("returns null for malformed provisioning metadata", () => {
+    expect(
+      parseProjectProvisioningIssueMetadata("<!-- evolvo:project-provisioning\nslug: habit-cli\n-->"),
+    ).toBeNull();
+    expect(isProjectProvisioningIssue(createIssue())).toBe(false);
+  });
+});

--- a/src/issues/projectProvisioningIssue.ts
+++ b/src/issues/projectProvisioningIssue.ts
@@ -1,0 +1,142 @@
+import type { IssueSummary } from "./taskIssueManager.js";
+
+export type ProjectProvisioningIssueMetadata = {
+  owner: string;
+  displayName: string;
+  slug: string;
+  repositoryName: string;
+  issueLabel: string;
+  workspaceRelativePath: string;
+  requestedBy: string;
+  requestedAt: string;
+};
+
+function normalizeNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function buildProjectProvisioningIssueTitle(displayName: string): string {
+  return `Start project ${displayName.trim()}`;
+}
+
+export function buildProjectProvisioningIssueBody(metadata: ProjectProvisioningIssueMetadata): string {
+  return [
+    "## Summary",
+    `Provision managed project \`${metadata.displayName}\`.`,
+    "",
+    "<!-- evolvo:project-provisioning",
+    `owner: ${metadata.owner}`,
+    `display_name: ${metadata.displayName}`,
+    `slug: ${metadata.slug}`,
+    `repo_name: ${metadata.repositoryName}`,
+    `issue_label: ${metadata.issueLabel}`,
+    `workspace_relative_path: ${metadata.workspaceRelativePath}`,
+    `requested_by: ${metadata.requestedBy}`,
+    `requested_at: ${metadata.requestedAt}`,
+    "-->",
+    "",
+    "## Requested Targets",
+    `- Tracker label: \`${metadata.issueLabel}\``,
+    `- Managed repository: \`${metadata.owner}/${metadata.repositoryName}\``,
+    `- Local workspace: \`${metadata.workspaceRelativePath}\``,
+    "",
+    "## Execution Notes",
+    "- Run provisioning on the default Evolvo workflow.",
+    "- Preserve partial provisioning progress in `.evolvo/projects.json` if a later step fails.",
+  ].join("\n");
+}
+
+export function parseProjectProvisioningIssueMetadata(
+  description: string,
+): ProjectProvisioningIssueMetadata | null {
+  const match = description.match(/<!--\s*evolvo:project-provisioning([\s\S]*?)-->/i);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const metadata: Partial<ProjectProvisioningIssueMetadata> = {};
+  const lines = match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex < 1 || separatorIndex >= line.length - 1) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim().toLowerCase();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (!value) {
+      continue;
+    }
+
+    if (key === "owner") {
+      metadata.owner = value;
+    }
+    if (key === "display_name") {
+      metadata.displayName = value;
+    }
+    if (key === "slug") {
+      metadata.slug = value;
+    }
+    if (key === "repo_name") {
+      metadata.repositoryName = value;
+    }
+    if (key === "issue_label") {
+      metadata.issueLabel = value;
+    }
+    if (key === "workspace_relative_path") {
+      metadata.workspaceRelativePath = value;
+    }
+    if (key === "requested_by") {
+      metadata.requestedBy = value;
+    }
+    if (key === "requested_at") {
+      metadata.requestedAt = value;
+    }
+  }
+
+  const owner = normalizeNonEmptyString(metadata.owner);
+  const displayName = normalizeNonEmptyString(metadata.displayName);
+  const slug = normalizeNonEmptyString(metadata.slug);
+  const repositoryName = normalizeNonEmptyString(metadata.repositoryName);
+  const issueLabel = normalizeNonEmptyString(metadata.issueLabel);
+  const workspaceRelativePath = normalizeNonEmptyString(metadata.workspaceRelativePath);
+  const requestedBy = normalizeNonEmptyString(metadata.requestedBy);
+  const requestedAt = normalizeNonEmptyString(metadata.requestedAt);
+
+  if (
+    !owner ||
+    !displayName ||
+    !slug ||
+    !repositoryName ||
+    !issueLabel ||
+    !workspaceRelativePath ||
+    !requestedBy ||
+    !requestedAt
+  ) {
+    return null;
+  }
+
+  return {
+    owner,
+    displayName,
+    slug,
+    repositoryName,
+    issueLabel,
+    workspaceRelativePath,
+    requestedBy,
+    requestedAt,
+  };
+}
+
+export function isProjectProvisioningIssue(issue: IssueSummary): boolean {
+  return parseProjectProvisioningIssueMetadata(issue.description) !== null;
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -31,6 +31,11 @@ const startDiscordGracefulShutdownListenerMock = vi.fn();
 const stopDiscordGracefulShutdownListenerMock = vi.fn();
 const consumeGracefulShutdownRequestMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
+const createProjectProvisioningRequestIssueMock = vi.fn();
+const executeProjectProvisioningIssueMock = vi.fn();
+const isProjectProvisioningRequestIssueMock = vi.fn();
+const buildProjectProvisioningOutcomeCommentMock = vi.fn();
+const buildProjectProvisioningCompletionSummaryMock = vi.fn();
 
 const DEFAULT_RUN_RESULT = {
   mergedPullRequest: false,
@@ -119,6 +124,14 @@ vi.mock("./runtime/operatorControl.js", () => ({
   startDiscordGracefulShutdownListener: startDiscordGracefulShutdownListenerMock,
 }));
 
+vi.mock("./projects/projectProvisioning.js", () => ({
+  buildProjectProvisioningCompletionSummary: buildProjectProvisioningCompletionSummaryMock,
+  buildProjectProvisioningOutcomeComment: buildProjectProvisioningOutcomeCommentMock,
+  createProjectProvisioningRequestIssue: createProjectProvisioningRequestIssueMock,
+  executeProjectProvisioningIssue: executeProjectProvisioningIssueMock,
+  isProjectProvisioningRequestIssue: isProjectProvisioningRequestIssueMock,
+}));
+
 vi.mock("./issues/runIssueCommand.js", () => ({
   runIssueCommand: runIssueCommandMock,
 }));
@@ -189,6 +202,63 @@ describe("main", () => {
     runPostMergeSelfRestartMock.mockResolvedValue(undefined);
     tryResolveRepositoryDefaultBranchMock.mockReset();
     tryResolveRepositoryDefaultBranchMock.mockResolvedValue("main");
+    createProjectProvisioningRequestIssueMock.mockReset();
+    createProjectProvisioningRequestIssueMock.mockResolvedValue({
+      ok: true,
+      message: "Created issue #400.",
+      issueNumber: 400,
+      issueUrl: "https://github.com/owner/repo/issues/400",
+    });
+    executeProjectProvisioningIssueMock.mockReset();
+    executeProjectProvisioningIssueMock.mockResolvedValue({
+      ok: true,
+      metadata: {
+        owner: "owner",
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        issueLabel: "project:habit-cli",
+        workspaceRelativePath: "projects/habit-cli",
+        requestedBy: "discord:operator-1",
+        requestedAt: "2026-03-07T12:00:00.000Z",
+      },
+      record: {
+        slug: "habit-cli",
+        displayName: "Habit CLI",
+        kind: "managed",
+        issueLabel: "project:habit-cli",
+        trackerRepo: {
+          owner: "owner",
+          repo: "repo",
+          url: "https://github.com/owner/repo",
+        },
+        executionRepo: {
+          owner: "owner",
+          repo: "habit-cli",
+          url: "https://github.com/owner/habit-cli",
+          defaultBranch: "main",
+        },
+        cwd: "/tmp/evolvo/projects/habit-cli",
+        status: "active",
+        sourceIssueNumber: 400,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: true,
+          lastError: null,
+        },
+      },
+      failureStep: null,
+      message: "Provisioned project Habit CLI.",
+    });
+    isProjectProvisioningRequestIssueMock.mockReset();
+    isProjectProvisioningRequestIssueMock.mockReturnValue(false);
+    buildProjectProvisioningOutcomeCommentMock.mockReset();
+    buildProjectProvisioningOutcomeCommentMock.mockReturnValue("## Project Provisioning");
+    buildProjectProvisioningCompletionSummaryMock.mockReset();
+    buildProjectProvisioningCompletionSummaryMock.mockReturnValue("Provisioning complete summary");
     runIssueCommandMock.mockReset();
     runIssueCommandMock.mockResolvedValue(false);
     getGitHubConfigMock.mockReset();
@@ -331,8 +401,115 @@ describe("main", () => {
     await main();
 
     expect(runDiscordOperatorControlStartupCheckMock).toHaveBeenCalledTimes(1);
-    expect(startDiscordGracefulShutdownListenerMock).toHaveBeenCalledWith("/tmp/evolvo");
+    expect(startDiscordGracefulShutdownListenerMock).toHaveBeenCalledWith(
+      "/tmp/evolvo",
+      expect.objectContaining({
+        onStartProject: expect.any(Function),
+      }),
+    );
     expect(stopDiscordGracefulShutdownListenerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("processes provisioning issues without invoking the coding agent", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        {
+          number: 77,
+          title: "Start project Habit CLI",
+          description: "<!-- evolvo:project-provisioning -->",
+          state: "open",
+          labels: [],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    isProjectProvisioningRequestIssueMock.mockReturnValueOnce(true);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(executeProjectProvisioningIssueMock).toHaveBeenCalledWith({
+      issue: {
+        number: 77,
+        title: "Start project Habit CLI",
+        description: "<!-- evolvo:project-provisioning -->",
+        state: "open",
+        labels: [],
+      },
+      workDir: "/tmp/evolvo",
+      trackerOwner: "owner",
+      trackerRepo: "repo",
+      adminClient: expect.any(Object),
+    });
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(addProgressCommentMock).toHaveBeenCalledWith(77, "## Project Provisioning");
+    expect(markCompletedMock).toHaveBeenCalledWith(77, "Provisioning complete summary");
+    expect(closeIssueMock).toHaveBeenCalledWith(77);
+  });
+
+  it("closes failed provisioning issues after writing diagnostics", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        {
+          number: 78,
+          title: "Start project Habit CLI",
+          description: "<!-- evolvo:project-provisioning -->",
+          state: "open",
+          labels: [],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    isProjectProvisioningRequestIssueMock.mockReturnValueOnce(true);
+    executeProjectProvisioningIssueMock.mockResolvedValueOnce({
+      ok: false,
+      metadata: {
+        owner: "owner",
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        issueLabel: "project:habit-cli",
+        workspaceRelativePath: "projects/habit-cli",
+        requestedBy: "discord:operator-1",
+        requestedAt: "2026-03-07T12:00:00.000Z",
+      },
+      record: {
+        slug: "habit-cli",
+        displayName: "Habit CLI",
+        kind: "managed",
+        issueLabel: "project:habit-cli",
+        trackerRepo: {
+          owner: "owner",
+          repo: "repo",
+          url: "https://github.com/owner/repo",
+        },
+        executionRepo: {
+          owner: "owner",
+          repo: "habit-cli",
+          url: "https://github.com/owner/habit-cli",
+          defaultBranch: "main",
+        },
+        cwd: "/tmp/evolvo/projects/habit-cli",
+        status: "failed",
+        sourceIssueNumber: 78,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: false,
+          lastError: "workspace failed",
+        },
+      },
+      failureStep: "workspace",
+      message: "workspace failed",
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(markCompletedMock).not.toHaveBeenCalledWith(78, expect.any(String));
+    expect(updateLabelsMock).toHaveBeenCalledWith(78, { remove: ["in progress"] });
+    expect(closeIssueMock).toHaveBeenCalledWith(78);
   });
 
   it("selects an open issue and uses it as the prompt", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import type { CodingAgentRunResult } from "./agents/runCodingAgent.js";
 import { runCodingAgent } from "./agents/runCodingAgent.js";
 import { runPlannerAgent } from "./agents/plannerAgent.js";
 import { WORK_DIR } from "./constants/workDir.js";
+import { GitHubAdminClient } from "./github/githubAdminClient.js";
 import { GitHubClient } from "./github/githubClient.js";
 import { getGitHubConfig } from "./github/githubConfig.js";
 import {
@@ -39,6 +40,7 @@ import {
   pollDiscordGracefulShutdownCommand,
   requestCycleLimitDecisionFromOperator,
   runDiscordOperatorControlStartupCheck,
+  type DiscordControlHandlers,
   startDiscordGracefulShutdownListener,
 } from "./runtime/operatorControl.js";
 import {
@@ -57,6 +59,13 @@ import {
 import { runIssueCommand } from "./issues/runIssueCommand.js";
 import { hasIssueLabel, isChallengeIssue } from "./issues/challengeIssue.js";
 import { TaskIssueManager, type IssueSummary } from "./issues/taskIssueManager.js";
+import {
+  buildProjectProvisioningCompletionSummary,
+  buildProjectProvisioningOutcomeComment,
+  createProjectProvisioningRequestIssue,
+  executeProjectProvisioningIssue,
+  isProjectProvisioningRequestIssue,
+} from "./projects/projectProvisioning.js";
 
 const MAX_ISSUE_CYCLES = 5;
 const MIN_REPLENISH_ISSUES = 3;
@@ -162,8 +171,12 @@ function buildGracefulShutdownLogMessage(
   return `Graceful shutdown requested via Discord ${request.command}. ${reason}`;
 }
 
-async function stopIfGracefulShutdownRequested(workDir: string, reason: string): Promise<boolean> {
-  await pollDiscordGracefulShutdownCommand(workDir);
+async function stopIfGracefulShutdownRequested(
+  workDir: string,
+  reason: string,
+  discordHandlers: DiscordControlHandlers,
+): Promise<boolean> {
+  await pollDiscordGracefulShutdownCommand(workDir, discordHandlers);
   const request = await consumeGracefulShutdownRequest(workDir);
   if (request === null) {
     return false;
@@ -181,23 +194,38 @@ export async function main(): Promise<void> {
   }
 
   const { GITHUB_OWNER, GITHUB_REPO } = await import("./environment.js");
-  const issueManager = new TaskIssueManager(new GitHubClient(getGitHubConfig()));
+  const githubConfig = getGitHubConfig();
+  const githubClient = new GitHubClient(githubConfig);
+  const issueManager = new TaskIssueManager(githubClient);
+  const adminClient = new GitHubAdminClient(githubClient, githubConfig);
   const repositoryName = `${GITHUB_OWNER}/${GITHUB_REPO}`;
+  const discordHandlers: DiscordControlHandlers = {
+    onStartProject: async (request) =>
+      createProjectProvisioningRequestIssue({
+        issueManager,
+        workDir: WORK_DIR,
+        trackerOwner: GITHUB_OWNER,
+        trackerRepo: GITHUB_REPO,
+        projectName: request.displayName,
+        requestedBy: request.requestedBy,
+        requestedAt: request.requestedAt,
+      }),
+  };
 
   console.log(`Hello from ${GITHUB_OWNER}/${GITHUB_REPO}!`);
   console.log(`Working directory: ${WORK_DIR}`);
   await signalRestartReadinessIfRequested(WORK_DIR);
   await runDiscordOperatorControlStartupCheck();
-  const gracefulShutdownListener = await startDiscordGracefulShutdownListener(WORK_DIR);
+  const gracefulShutdownListener = await startDiscordGracefulShutdownListener(WORK_DIR, discordHandlers);
 
   try {
-    if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+    if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
       return;
     }
 
     let cycleLimit = MAX_ISSUE_CYCLES;
     issueCycleLoop: for (let cycle = 1; ; cycle += 1) {
-      if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+      if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
         return;
       }
 
@@ -251,14 +279,20 @@ export async function main(): Promise<void> {
               });
             },
           });
-          if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+          if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
             return;
           }
 
           const selectedIssue = selectIssueForWork(retryEligibleIssues);
 
           if (!selectedIssue) {
-            if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before planner replenishment.")) {
+            if (
+              await stopIfGracefulShutdownRequested(
+                WORK_DIR,
+                "Stopping before planner replenishment.",
+                discordHandlers,
+              )
+            ) {
               return;
             }
 
@@ -283,7 +317,13 @@ export async function main(): Promise<void> {
             });
 
             if (createdIssues.length > 0) {
-              if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+              if (
+                await stopIfGracefulShutdownRequested(
+                  WORK_DIR,
+                  "Stopping before starting a new task.",
+                  discordHandlers,
+                )
+              ) {
                 return;
               }
 
@@ -294,7 +334,7 @@ export async function main(): Promise<void> {
               continue issueCycleLoop;
             }
 
-            if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.")) {
+            if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
               return;
             }
 
@@ -339,15 +379,89 @@ export async function main(): Promise<void> {
             });
           }
 
-          const prompt = buildPromptFromIssue(selectedIssue);
-          console.log(`Prompt: ${prompt}`);
+          const isProvisioningIssue = isProjectProvisioningRequestIssue(selectedIssue);
           await transitionIssueLifecycleState(issueManager, {
             issue: selectedIssue,
             nextState: "executing",
-            reason: "coding agent execution started",
+            reason: isProvisioningIssue
+              ? "project provisioning execution started"
+              : "coding agent execution started",
             cycle,
           });
 
+          if (isProvisioningIssue) {
+            const provisioningResult = await executeProjectProvisioningIssue({
+              issue: selectedIssue,
+              workDir: WORK_DIR,
+              trackerOwner: GITHUB_OWNER,
+              trackerRepo: GITHUB_REPO,
+              adminClient,
+            });
+            await addIssueLifecycleComment(
+              issueManager,
+              selectedIssue.number,
+              buildProjectProvisioningOutcomeComment(provisioningResult),
+            );
+
+            if (provisioningResult.ok) {
+              await transitionIssueLifecycleState(issueManager, {
+                issue: selectedIssue,
+                nextState: "accepted",
+                reason: "project provisioning request completed successfully",
+                cycle,
+              });
+              const completionResult = await issueManager.markCompleted(
+                selectedIssue.number,
+                buildProjectProvisioningCompletionSummary(provisioningResult),
+              );
+              if (!completionResult.ok) {
+                console.error(`Could not mark issue #${selectedIssue.number} as completed: ${completionResult.message}`);
+              }
+              const closeResult = await issueManager.closeIssue(selectedIssue.number);
+              if (!closeResult.ok) {
+                console.error(`Could not close issue #${selectedIssue.number}: ${closeResult.message}`);
+              } else {
+                await transitionIssueLifecycleState(issueManager, {
+                  issue: selectedIssue,
+                  nextState: "completed",
+                  reason: "project provisioning request completed and issue was closed",
+                  cycle,
+                });
+              }
+            } else {
+              await transitionIssueLifecycleState(issueManager, {
+                issue: selectedIssue,
+                nextState: "failed",
+                reason: `project provisioning failed at ${provisioningResult.failureStep ?? "unknown"} step`,
+                cycle,
+              });
+              const resetLabels = await issueManager.updateLabels(selectedIssue.number, {
+                remove: ["in progress"],
+              });
+              if (!resetLabels.ok) {
+                console.error(`Could not clear in-progress label for issue #${selectedIssue.number}: ${resetLabels.message}`);
+              }
+              const closeResult = await issueManager.closeIssue(selectedIssue.number);
+              if (!closeResult.ok) {
+                console.error(`Could not close failed provisioning issue #${selectedIssue.number}: ${closeResult.message}`);
+              }
+            }
+
+            if (
+              await stopIfGracefulShutdownRequested(
+                WORK_DIR,
+                "Current task completed. Stopping before starting another issue.",
+                discordHandlers,
+              )
+            ) {
+              return;
+            }
+
+            break;
+          }
+
+          const prompt = buildPromptFromIssue(selectedIssue);
+          console.log(`Prompt: ${prompt}`);
           let runError: unknown = null;
           const runResult = await runCodingAgent(prompt).catch((error) => {
             runError = error;
@@ -472,6 +586,7 @@ export async function main(): Promise<void> {
             await stopIfGracefulShutdownRequested(
               WORK_DIR,
               "Current task completed. Stopping before starting another issue.",
+              discordHandlers,
             )
           ) {
             return;

--- a/src/projects/projectNaming.test.ts
+++ b/src/projects/projectNaming.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProjectIssueLabel,
+  normalizeProjectNameInput,
+} from "./projectNaming.js";
+
+describe("projectNaming", () => {
+  it("normalizes a project name into display, slug, label, and workspace paths", () => {
+    expect(normalizeProjectNameInput("  Habit   CLI!  ")).toEqual({
+      displayName: "Habit CLI!",
+      slug: "habit-cli",
+      repositoryName: "habit-cli",
+      issueLabel: "project:habit-cli",
+      workspaceRelativePath: "projects/habit-cli",
+    });
+  });
+
+  it("builds reserved project labels", () => {
+    expect(buildProjectIssueLabel("habit-cli")).toBe("project:habit-cli");
+  });
+
+  it("rejects whitespace-only project names", () => {
+    expect(() => normalizeProjectNameInput("   ")).toThrow("Project name is required.");
+  });
+
+  it("rejects names that normalize to no letters or numbers", () => {
+    expect(() => normalizeProjectNameInput("!!!")).toThrow(
+      "Project name must contain at least one letter or number.",
+    );
+  });
+
+  it("rejects the reserved default project slug", () => {
+    expect(() => normalizeProjectNameInput("Evolvo")).toThrow(
+      "The default project slug `evolvo` is reserved.",
+    );
+  });
+});

--- a/src/projects/projectNaming.ts
+++ b/src/projects/projectNaming.ts
@@ -1,0 +1,46 @@
+export const DEFAULT_PROJECT_SLUG = "evolvo";
+export const PROJECT_LABEL_PREFIX = "project:";
+
+export type NormalizedProjectName = {
+  displayName: string;
+  slug: string;
+  repositoryName: string;
+  issueLabel: string;
+  workspaceRelativePath: string;
+};
+
+export function buildProjectIssueLabel(slug: string): string {
+  return `${PROJECT_LABEL_PREFIX}${slug}`;
+}
+
+export function normalizeProjectNameInput(input: string): NormalizedProjectName {
+  const displayName = input.trim().replace(/\s+/g, " ");
+  if (!displayName) {
+    throw new Error("Project name is required.");
+  }
+
+  const slug = displayName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-");
+  if (!slug) {
+    throw new Error("Project name must contain at least one letter or number.");
+  }
+
+  if (slug === DEFAULT_PROJECT_SLUG) {
+    throw new Error("The default project slug `evolvo` is reserved.");
+  }
+
+  if (slug.length > 63) {
+    throw new Error("Project slug must be 63 characters or fewer after normalization.");
+  }
+
+  return {
+    displayName,
+    slug,
+    repositoryName: slug,
+    issueLabel: buildProjectIssueLabel(slug),
+    workspaceRelativePath: `projects/${slug}`,
+  };
+}

--- a/src/projects/projectProvisioning.test.ts
+++ b/src/projects/projectProvisioning.test.ts
@@ -1,0 +1,335 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildProjectProvisioningIssueBody } from "../issues/projectProvisioningIssue.js";
+import type { IssueSummary } from "../issues/taskIssueManager.js";
+import {
+  buildProjectProvisioningCompletionSummary,
+  buildProjectProvisioningOutcomeComment,
+  createProjectProvisioningRequestIssue,
+  executeProjectProvisioningIssue,
+  isProjectProvisioningRequestIssue,
+} from "./projectProvisioning.js";
+import { getProjectRegistryPath, upsertProjectRecord } from "./projectRegistry.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "project-provisioning-"));
+}
+
+function createProvisioningIssue(description: string): IssueSummary {
+  return {
+    number: 318,
+    title: "Start project Habit CLI",
+    description,
+    state: "open",
+    labels: [],
+  };
+}
+
+describe("projectProvisioning", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+    vi.restoreAllMocks();
+  });
+
+  it("creates a tracker provisioning issue for a normalized project request", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([]),
+      createIssue: vi.fn().mockResolvedValue({
+        ok: true,
+        message: "Created issue #401.",
+        issue: {
+          number: 401,
+          title: "Start project Habit CLI",
+          description: "body",
+          state: "open",
+          labels: [],
+        },
+      }),
+    };
+
+    const result = await createProjectProvisioningRequestIssue({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: " Habit   CLI ",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-07T12:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Created issue #401.",
+      issueNumber: 401,
+      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/401",
+      metadata: {
+        owner: "evolvo-auto",
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        issueLabel: "project:habit-cli",
+        workspaceRelativePath: "projects/habit-cli",
+        requestedBy: "discord:operator-1",
+        requestedAt: "2026-03-07T12:00:00.000Z",
+      },
+    });
+    expect(issueManager.createIssue).toHaveBeenCalledWith(
+      "Start project Habit CLI",
+      expect.stringContaining("project:habit-cli"),
+    );
+  });
+
+  it("rejects duplicate open provisioning requests for the same slug", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          number: 402,
+          title: "Start project Habit CLI",
+          description: buildProjectProvisioningIssueBody({
+            owner: "evolvo-auto",
+            displayName: "Habit CLI",
+            slug: "habit-cli",
+            repositoryName: "habit-cli",
+            issueLabel: "project:habit-cli",
+            workspaceRelativePath: "projects/habit-cli",
+            requestedBy: "discord:operator-1",
+            requestedAt: "2026-03-07T12:00:00.000Z",
+          }),
+          state: "open",
+          labels: [],
+        },
+      ]),
+      createIssue: vi.fn(),
+    };
+
+    const result = await createProjectProvisioningRequestIssue({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Project `habit-cli` already has an open provisioning request issue #402.",
+    });
+    expect(issueManager.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("allows a new provisioning request when the existing registry record is failed", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await upsertProjectRecord(
+      workDir,
+      {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+      },
+      {
+        slug: "habit-cli",
+        displayName: "Habit CLI",
+        kind: "managed",
+        issueLabel: "project:habit-cli",
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "evolvo-ts",
+          url: "https://github.com/evolvo-auto/evolvo-ts",
+        },
+        executionRepo: {
+          owner: "evolvo-auto",
+          repo: "habit-cli",
+          url: "https://github.com/evolvo-auto/habit-cli",
+          defaultBranch: "main",
+        },
+        cwd: resolve(workDir, "projects", "habit-cli"),
+        status: "failed",
+        sourceIssueNumber: 318,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: false,
+          lastError: "workspace creation failed",
+        },
+      },
+    );
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([]),
+      createIssue: vi.fn().mockResolvedValue({
+        ok: true,
+        message: "Created issue #403.",
+        issue: {
+          number: 403,
+          title: "Start project Habit CLI",
+          description: "body",
+          state: "open",
+          labels: [],
+        },
+      }),
+    };
+
+    const result = await createProjectProvisioningRequestIssue({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        issueNumber: 403,
+      }),
+    );
+    expect(issueManager.createIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it("provisions a managed project and records active registry state on success", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const issue = createProvisioningIssue(
+      buildProjectProvisioningIssueBody({
+        owner: "evolvo-auto",
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        issueLabel: "project:habit-cli",
+        workspaceRelativePath: "projects/habit-cli",
+        requestedBy: "discord:operator-1",
+        requestedAt: "2026-03-07T12:00:00.000Z",
+      }),
+    );
+    const adminClient = {
+      ensureLabel: vi.fn().mockResolvedValue(undefined),
+      ensureRepository: vi.fn().mockResolvedValue({
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli",
+        defaultBranch: "main",
+      }),
+    };
+
+    const result = await executeProjectProvisioningIssue({
+      issue,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      adminClient,
+    });
+
+    expect(isProjectProvisioningRequestIssue(issue)).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.failureStep).toBeNull();
+    expect(result.record.status).toBe("active");
+    expect(result.record.provisioning).toEqual({
+      labelCreated: true,
+      repoCreated: true,
+      workspacePrepared: true,
+      lastError: null,
+    });
+    expect(buildProjectProvisioningCompletionSummary(result)).toContain("Provisioned managed project `Habit CLI`.");
+    expect(buildProjectProvisioningOutcomeComment(result)).toContain("- Outcome: succeeded.");
+
+    const registry = JSON.parse(await readFile(getProjectRegistryPath(workDir), "utf8")) as {
+      projects: Array<{ slug: string; status: string; provisioning: { repoCreated: boolean } }>;
+    };
+    const managedProject = registry.projects.find((project) => project.slug === "habit-cli");
+    expect(managedProject).toEqual(
+      expect.objectContaining({
+        slug: "habit-cli",
+        status: "active",
+        provisioning: expect.objectContaining({
+          repoCreated: true,
+        }),
+      }),
+    );
+    expect(resolve(workDir, "projects", "habit-cli")).toBe(result.record.cwd);
+  });
+
+  it("preserves partial success in failed registry state when workspace preparation fails", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await writeFile(join(workDir, "projects"), "not a directory", "utf8");
+    const issue = createProvisioningIssue(
+      buildProjectProvisioningIssueBody({
+        owner: "evolvo-auto",
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        issueLabel: "project:habit-cli",
+        workspaceRelativePath: "projects/habit-cli",
+        requestedBy: "discord:operator-1",
+        requestedAt: "2026-03-07T12:00:00.000Z",
+      }),
+    );
+    const adminClient = {
+      ensureLabel: vi.fn().mockResolvedValue(undefined),
+      ensureRepository: vi.fn().mockResolvedValue({
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli",
+        defaultBranch: "main",
+      }),
+    };
+
+    const result = await executeProjectProvisioningIssue({
+      issue,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      adminClient,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failureStep).toBe("workspace");
+    expect(result.record.status).toBe("failed");
+    expect(result.record.provisioning).toEqual({
+      labelCreated: true,
+      repoCreated: true,
+      workspacePrepared: false,
+      lastError: expect.any(String),
+    });
+    expect(buildProjectProvisioningOutcomeComment(result)).toContain("- Outcome: failed.");
+    expect(buildProjectProvisioningOutcomeComment(result)).toContain("- Recovery: inspect `.evolvo/projects.json`");
+
+    const registry = JSON.parse(await readFile(getProjectRegistryPath(workDir), "utf8")) as {
+      projects: Array<{
+        slug: string;
+        status: string;
+        provisioning: {
+          labelCreated: boolean;
+          repoCreated: boolean;
+          workspacePrepared: boolean;
+          lastError: string | null;
+        };
+      }>;
+    };
+    const managedProject = registry.projects.find((project) => project.slug === "habit-cli");
+    expect(managedProject).toEqual(
+      expect.objectContaining({
+        slug: "habit-cli",
+        status: "failed",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: false,
+          lastError: expect.any(String),
+        },
+      }),
+    );
+  });
+});

--- a/src/projects/projectProvisioning.ts
+++ b/src/projects/projectProvisioning.ts
@@ -1,0 +1,376 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  buildProjectProvisioningIssueBody,
+  buildProjectProvisioningIssueTitle,
+  isProjectProvisioningIssue,
+  parseProjectProvisioningIssueMetadata,
+  type ProjectProvisioningIssueMetadata,
+} from "../issues/projectProvisioningIssue.js";
+import type { IssueSummary, TaskIssueManager } from "../issues/taskIssueManager.js";
+import { normalizeProjectNameInput } from "./projectNaming.js";
+import {
+  findProjectBySlug,
+  readProjectRegistry,
+  upsertProjectRecord,
+  type DefaultProjectContext,
+  type ProjectRecord,
+} from "./projectRegistry.js";
+
+type ProjectProvisioningIssueManager = Pick<TaskIssueManager, "createIssue" | "listOpenIssues">;
+
+export type ProjectProvisioningAdminClient = {
+  ensureLabel: (options: {
+    owner: string;
+    repo: string;
+    name: string;
+    color?: string;
+    description?: string;
+  }) => Promise<void>;
+  ensureRepository: (options: {
+    owner: string;
+    repo: string;
+    description?: string;
+  }) => Promise<{
+    owner: string;
+    repo: string;
+    url: string;
+    defaultBranch: string | null;
+  }>;
+};
+
+export type CreateProjectProvisioningRequestResult =
+  | {
+    ok: true;
+    message: string;
+    issueNumber: number;
+    issueUrl: string;
+    metadata: ProjectProvisioningIssueMetadata;
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
+export type ProjectProvisioningExecutionResult = {
+  ok: boolean;
+  metadata: ProjectProvisioningIssueMetadata;
+  record: ProjectRecord;
+  failureStep: "registry" | "label" | "repository" | "workspace" | null;
+  message: string;
+};
+
+function buildRepositoryUrl(owner: string, repo: string): string {
+  return `https://github.com/${owner}/${repo}`;
+}
+
+function buildDefaultProjectContext(workDir: string, owner: string, repo: string): DefaultProjectContext {
+  return {
+    owner,
+    repo,
+    workDir,
+  };
+}
+
+function buildManagedProjectRecord(
+  metadata: ProjectProvisioningIssueMetadata,
+  options: {
+    workDir: string;
+    trackerOwner: string;
+    trackerRepo: string;
+    issueNumber: number;
+    now: string;
+  },
+  existing: ProjectRecord | null,
+): ProjectRecord {
+  const workspacePath = resolve(options.workDir, metadata.workspaceRelativePath);
+  const createdAt = existing?.createdAt ?? options.now;
+
+  return {
+    slug: metadata.slug,
+    displayName: metadata.displayName,
+    kind: "managed",
+    issueLabel: metadata.issueLabel,
+    trackerRepo: {
+      owner: options.trackerOwner,
+      repo: options.trackerRepo,
+      url: buildRepositoryUrl(options.trackerOwner, options.trackerRepo),
+    },
+    executionRepo: {
+      owner: existing?.executionRepo.owner ?? metadata.owner,
+      repo: existing?.executionRepo.repo ?? metadata.repositoryName,
+      url: existing?.executionRepo.url ?? buildRepositoryUrl(metadata.owner, metadata.repositoryName),
+      defaultBranch: existing?.executionRepo.defaultBranch ?? null,
+    },
+    cwd: existing?.cwd ?? workspacePath,
+    status: existing?.status ?? "provisioning",
+    sourceIssueNumber: options.issueNumber,
+    createdAt,
+    updatedAt: options.now,
+    provisioning: {
+      labelCreated: existing?.provisioning.labelCreated ?? false,
+      repoCreated: existing?.provisioning.repoCreated ?? false,
+      workspacePrepared: existing?.provisioning.workspacePrepared ?? false,
+      lastError: existing?.provisioning.lastError ?? null,
+    },
+  };
+}
+
+export async function createProjectProvisioningRequestIssue(options: {
+  issueManager: ProjectProvisioningIssueManager;
+  workDir: string;
+  trackerOwner: string;
+  trackerRepo: string;
+  projectName: string;
+  requestedBy: string;
+  requestedAt?: string;
+}): Promise<CreateProjectProvisioningRequestResult> {
+  try {
+    const normalized = normalizeProjectNameInput(options.projectName);
+    const defaultProject = buildDefaultProjectContext(options.workDir, options.trackerOwner, options.trackerRepo);
+    const registry = await readProjectRegistry(options.workDir, defaultProject);
+    const existingProject = findProjectBySlug(registry, normalized.slug);
+    if (existingProject && existingProject.status !== "failed") {
+      return {
+        ok: false,
+        message: `Project \`${normalized.slug}\` already exists in the registry with status \`${existingProject.status}\`.`,
+      };
+    }
+
+    const openIssues = await options.issueManager.listOpenIssues();
+    const duplicateIssue = openIssues.find((issue) => {
+      const metadata = parseProjectProvisioningIssueMetadata(issue.description);
+      return metadata?.slug === normalized.slug;
+    });
+    if (duplicateIssue) {
+      return {
+        ok: false,
+        message: `Project \`${normalized.slug}\` already has an open provisioning request issue #${duplicateIssue.number}.`,
+      };
+    }
+
+    const metadata: ProjectProvisioningIssueMetadata = {
+      owner: options.trackerOwner,
+      displayName: normalized.displayName,
+      slug: normalized.slug,
+      repositoryName: normalized.repositoryName,
+      issueLabel: normalized.issueLabel,
+      workspaceRelativePath: normalized.workspaceRelativePath,
+      requestedBy: options.requestedBy,
+      requestedAt: options.requestedAt?.trim() || new Date().toISOString(),
+    };
+    const created = await options.issueManager.createIssue(
+      buildProjectProvisioningIssueTitle(metadata.displayName),
+      buildProjectProvisioningIssueBody(metadata),
+    );
+    if (!created.ok || !created.issue) {
+      return { ok: false, message: created.message };
+    }
+
+    return {
+      ok: true,
+      message: created.message,
+      issueNumber: created.issue.number,
+      issueUrl: `https://github.com/${options.trackerOwner}/${options.trackerRepo}/issues/${created.issue.number}`,
+      metadata,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Unknown project provisioning request error.",
+    };
+  }
+}
+
+export async function executeProjectProvisioningIssue(options: {
+  issue: IssueSummary;
+  workDir: string;
+  trackerOwner: string;
+  trackerRepo: string;
+  adminClient: ProjectProvisioningAdminClient;
+}): Promise<ProjectProvisioningExecutionResult> {
+  const metadata = parseProjectProvisioningIssueMetadata(options.issue.description);
+  if (!metadata) {
+    throw new Error(`Issue #${options.issue.number} is not a valid project provisioning request.`);
+  }
+
+  const defaultProject = buildDefaultProjectContext(options.workDir, options.trackerOwner, options.trackerRepo);
+  const registry = await readProjectRegistry(options.workDir, defaultProject);
+  const existingProject = findProjectBySlug(registry, metadata.slug);
+  let record = buildManagedProjectRecord(metadata, {
+    workDir: options.workDir,
+    trackerOwner: options.trackerOwner,
+    trackerRepo: options.trackerRepo,
+    issueNumber: options.issue.number,
+    now: new Date().toISOString(),
+  }, existingProject);
+
+  const persistRecord = async (
+    overrides: Partial<ProjectRecord>,
+    provisioningOverrides: Partial<ProjectRecord["provisioning"]> = {},
+  ): Promise<void> => {
+    record = {
+      ...record,
+      ...overrides,
+      updatedAt: new Date().toISOString(),
+      provisioning: {
+        ...record.provisioning,
+        ...provisioningOverrides,
+      },
+    };
+    await upsertProjectRecord(options.workDir, defaultProject, record);
+  };
+
+  try {
+    await persistRecord(
+      {
+        status: "provisioning",
+      },
+      {
+        lastError: null,
+      },
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      metadata,
+      record,
+      failureStep: "registry",
+      message: error instanceof Error ? error.message : "Unknown project registry error.",
+    };
+  }
+
+  try {
+    await options.adminClient.ensureLabel({
+      owner: options.trackerOwner,
+      repo: options.trackerRepo,
+      name: metadata.issueLabel,
+      description: `Issues for managed project ${metadata.displayName}`,
+    });
+    await persistRecord({}, { labelCreated: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown tracker label provisioning error.";
+    await persistRecord({ status: "failed" }, { lastError: message }).catch(() => undefined);
+    return {
+      ok: false,
+      metadata,
+      record,
+      failureStep: "label",
+      message,
+    };
+  }
+
+  try {
+    const repository = await options.adminClient.ensureRepository({
+      owner: metadata.owner,
+      repo: metadata.repositoryName,
+      description: `Managed by Evolvo for project ${metadata.displayName}.`,
+    });
+    await persistRecord(
+      {
+        executionRepo: {
+          owner: repository.owner,
+          repo: repository.repo,
+          url: repository.url,
+          defaultBranch: repository.defaultBranch,
+        },
+      },
+      { repoCreated: true },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown managed repository provisioning error.";
+    await persistRecord({ status: "failed" }, { lastError: message }).catch(() => undefined);
+    return {
+      ok: false,
+      metadata,
+      record,
+      failureStep: "repository",
+      message,
+    };
+  }
+
+  try {
+    const workspacePath = resolve(options.workDir, metadata.workspaceRelativePath);
+    await mkdir(workspacePath, { recursive: true });
+    await persistRecord(
+      {
+        cwd: workspacePath,
+        status: "active",
+      },
+      {
+        workspacePrepared: true,
+        lastError: null,
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown workspace provisioning error.";
+    await persistRecord({ status: "failed" }, { lastError: message }).catch(() => undefined);
+    return {
+      ok: false,
+      metadata,
+      record,
+      failureStep: "workspace",
+      message,
+    };
+  }
+
+  return {
+    ok: true,
+    metadata,
+    record,
+    failureStep: null,
+    message: `Provisioned project ${metadata.displayName}.`,
+  };
+}
+
+function formatStepStatus(value: boolean): string {
+  return value ? "yes" : "no";
+}
+
+export function buildProjectProvisioningOutcomeComment(
+  result: ProjectProvisioningExecutionResult,
+): string {
+  const repositoryLine = result.record.provisioning.repoCreated
+    ? `- Managed repository: ${result.record.executionRepo.url}`
+    : `- Managed repository: pending (\`${result.metadata.owner}/${result.metadata.repositoryName}\`)`;
+  const branchLine = result.record.provisioning.repoCreated
+    ? `- Repository default branch: ${result.record.executionRepo.defaultBranch ? `\`${result.record.executionRepo.defaultBranch}\`` : "unknown"}`
+    : "- Repository default branch: not available";
+  const workspaceLine = result.record.provisioning.workspacePrepared
+    ? `- Local workspace: \`${result.record.cwd}\``
+    : `- Local workspace: pending (\`${result.metadata.workspaceRelativePath}\`)`;
+
+  const lines = [
+    "## Project Provisioning",
+    `- Outcome: ${result.ok ? "succeeded" : "failed"}.`,
+    `- Project: \`${result.metadata.displayName}\` (\`${result.metadata.slug}\`)`,
+    `- Tracker label ensured: ${formatStepStatus(result.record.provisioning.labelCreated)} (\`${result.metadata.issueLabel}\`)`,
+    repositoryLine,
+    branchLine,
+    workspaceLine,
+    `- Registry status: \`${result.record.status}\``,
+  ];
+
+  if (!result.ok) {
+    lines.push(`- Failure step: \`${result.failureStep ?? "unknown"}\``);
+    lines.push(`- Error: ${result.message}`);
+    lines.push("- Recovery: inspect `.evolvo/projects.json`, fix the failing step, then resend `/startProject <project-name>` to requeue provisioning.");
+  }
+
+  return lines.join("\n");
+}
+
+export function buildProjectProvisioningCompletionSummary(
+  result: ProjectProvisioningExecutionResult,
+): string {
+  return [
+    `Provisioned managed project \`${result.metadata.displayName}\`.`,
+    `Label: \`${result.metadata.issueLabel}\`.`,
+    `Repository: ${result.record.executionRepo.url}.`,
+    `Workspace: \`${result.record.cwd}\`.`,
+  ].join(" ");
+}
+
+export function isProjectProvisioningRequestIssue(issue: IssueSummary): boolean {
+  return isProjectProvisioningIssue(issue);
+}

--- a/src/projects/projectRegistry.test.ts
+++ b/src/projects/projectRegistry.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  findProjectBySlug,
+  getProjectRegistryPath,
+  readProjectRegistry,
+  upsertProjectRecord,
+  type ProjectRecord,
+} from "./projectRegistry.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "project-registry-"));
+}
+
+describe("projectRegistry", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+  });
+
+  it("returns a default Evolvo project when no registry file exists", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const registry = await readProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    expect(registry.projects).toHaveLength(1);
+    expect(registry.projects[0]).toEqual(
+      expect.objectContaining({
+        slug: "evolvo",
+        issueLabel: "project:evolvo",
+        status: "active",
+        cwd: workDir,
+      }),
+    );
+  });
+
+  it("upserts a managed project record while preserving the default project", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const managedProject: ProjectRecord = {
+      slug: "habit-cli",
+      displayName: "Habit CLI",
+      kind: "managed",
+      issueLabel: "project:habit-cli",
+      trackerRepo: {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        url: "https://github.com/evolvo-auto/evolvo-ts",
+      },
+      executionRepo: {
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli",
+        defaultBranch: "main",
+      },
+      cwd: join(workDir, "projects", "habit-cli"),
+      status: "active",
+      sourceIssueNumber: 318,
+      createdAt: "2026-03-07T12:00:00.000Z",
+      updatedAt: "2026-03-07T12:00:00.000Z",
+      provisioning: {
+        labelCreated: true,
+        repoCreated: true,
+        workspacePrepared: true,
+        lastError: null,
+      },
+    };
+
+    const registry = await upsertProjectRecord(
+      workDir,
+      {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+        defaultBranch: "main",
+      },
+      managedProject,
+    );
+
+    expect(registry.projects.map((project) => project.slug)).toEqual(["evolvo", "habit-cli"]);
+    expect(findProjectBySlug(registry, "habit-cli")).toEqual(managedProject);
+
+    const persisted = JSON.parse(await readFile(getProjectRegistryPath(workDir), "utf8")) as {
+      projects: Array<{ slug: string }>;
+    };
+    expect(persisted.projects.map((project) => project.slug)).toEqual(["evolvo", "habit-cli"]);
+  });
+});

--- a/src/projects/projectRegistry.ts
+++ b/src/projects/projectRegistry.ts
@@ -1,0 +1,281 @@
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+import { buildProjectIssueLabel, DEFAULT_PROJECT_SLUG } from "./projectNaming.js";
+
+const EVOLVO_DIRECTORY_NAME = ".evolvo";
+const PROJECT_REGISTRY_FILE_NAME = "projects.json";
+const PROJECT_REGISTRY_VERSION = 1;
+
+export type ProjectStatus = "active" | "provisioning" | "failed";
+
+export type ProjectRecord = {
+  slug: string;
+  displayName: string;
+  kind: "default" | "managed";
+  issueLabel: string;
+  trackerRepo: {
+    owner: string;
+    repo: string;
+    url: string;
+  };
+  executionRepo: {
+    owner: string;
+    repo: string;
+    url: string;
+    defaultBranch: string | null;
+  };
+  cwd: string;
+  status: ProjectStatus;
+  sourceIssueNumber: number | null;
+  createdAt: string;
+  updatedAt: string;
+  provisioning: {
+    labelCreated: boolean;
+    repoCreated: boolean;
+    workspacePrepared: boolean;
+    lastError: string | null;
+  };
+};
+
+export type ProjectRegistry = {
+  version: typeof PROJECT_REGISTRY_VERSION;
+  projects: ProjectRecord[];
+};
+
+export type DefaultProjectContext = {
+  owner: string;
+  repo: string;
+  workDir: string;
+  defaultBranch?: string | null;
+};
+
+function normalizeNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  return normalizeNonEmptyString(value);
+}
+
+function buildRepositoryUrl(owner: string, repo: string): string {
+  return `https://github.com/${owner}/${repo}`;
+}
+
+export function getProjectRegistryPath(workDir: string): string {
+  return join(workDir, EVOLVO_DIRECTORY_NAME, PROJECT_REGISTRY_FILE_NAME);
+}
+
+export function buildDefaultProjectRecord(context: DefaultProjectContext): ProjectRecord {
+  const createdAt = new Date().toISOString();
+  return {
+    slug: DEFAULT_PROJECT_SLUG,
+    displayName: "Evolvo",
+    kind: "default",
+    issueLabel: buildProjectIssueLabel(DEFAULT_PROJECT_SLUG),
+    trackerRepo: {
+      owner: context.owner,
+      repo: context.repo,
+      url: buildRepositoryUrl(context.owner, context.repo),
+    },
+    executionRepo: {
+      owner: context.owner,
+      repo: context.repo,
+      url: buildRepositoryUrl(context.owner, context.repo),
+      defaultBranch: context.defaultBranch?.trim() || null,
+    },
+    cwd: context.workDir,
+    status: "active",
+    sourceIssueNumber: null,
+    createdAt,
+    updatedAt: createdAt,
+    provisioning: {
+      labelCreated: false,
+      repoCreated: true,
+      workspacePrepared: true,
+      lastError: null,
+    },
+  };
+}
+
+function normalizeProjectRecord(raw: unknown): ProjectRecord | null {
+  if (typeof raw !== "object" || raw === null) {
+    return null;
+  }
+
+  const candidate = raw as Partial<ProjectRecord>;
+  const slug = normalizeNonEmptyString(candidate.slug);
+  const displayName = normalizeNonEmptyString(candidate.displayName);
+  const kind = candidate.kind === "default" ? "default" : candidate.kind === "managed" ? "managed" : null;
+  const issueLabel = normalizeNonEmptyString(candidate.issueLabel);
+  const cwd = normalizeNonEmptyString(candidate.cwd);
+  const status = candidate.status === "active" || candidate.status === "provisioning" || candidate.status === "failed"
+    ? candidate.status
+    : null;
+  const createdAt = normalizeNonEmptyString(candidate.createdAt);
+  const updatedAt = normalizeNonEmptyString(candidate.updatedAt);
+  const sourceIssueNumber = typeof candidate.sourceIssueNumber === "number" && Number.isInteger(candidate.sourceIssueNumber)
+    ? candidate.sourceIssueNumber
+    : null;
+  const trackerOwner = normalizeNonEmptyString(candidate.trackerRepo?.owner);
+  const trackerRepo = normalizeNonEmptyString(candidate.trackerRepo?.repo);
+  const trackerUrl = normalizeNonEmptyString(candidate.trackerRepo?.url);
+  const executionOwner = normalizeNonEmptyString(candidate.executionRepo?.owner);
+  const executionRepo = normalizeNonEmptyString(candidate.executionRepo?.repo);
+  const executionUrl = normalizeNonEmptyString(candidate.executionRepo?.url);
+  if (
+    !slug ||
+    !displayName ||
+    !kind ||
+    !issueLabel ||
+    !cwd ||
+    !status ||
+    !createdAt ||
+    !updatedAt ||
+    !trackerOwner ||
+    !trackerRepo ||
+    !trackerUrl ||
+    !executionOwner ||
+    !executionRepo ||
+    !executionUrl
+  ) {
+    return null;
+  }
+
+  return {
+    slug,
+    displayName,
+    kind,
+    issueLabel,
+    trackerRepo: {
+      owner: trackerOwner,
+      repo: trackerRepo,
+      url: trackerUrl,
+    },
+    executionRepo: {
+      owner: executionOwner,
+      repo: executionRepo,
+      url: executionUrl,
+      defaultBranch: normalizeNullableString(candidate.executionRepo?.defaultBranch),
+    },
+    cwd,
+    status,
+    sourceIssueNumber,
+    createdAt,
+    updatedAt,
+    provisioning: {
+      labelCreated: normalizeBoolean(candidate.provisioning?.labelCreated),
+      repoCreated: normalizeBoolean(candidate.provisioning?.repoCreated),
+      workspacePrepared: normalizeBoolean(candidate.provisioning?.workspacePrepared),
+      lastError: normalizeNullableString(candidate.provisioning?.lastError),
+    },
+  };
+}
+
+function ensureDefaultProject(
+  projects: ProjectRecord[],
+  context: DefaultProjectContext,
+): ProjectRecord[] {
+  const defaultRecord = buildDefaultProjectRecord(context);
+  const withoutDefault = projects.filter((project) => project.slug !== DEFAULT_PROJECT_SLUG);
+  const existingDefault = projects.find((project) => project.slug === DEFAULT_PROJECT_SLUG);
+  if (!existingDefault) {
+    return [defaultRecord, ...withoutDefault];
+  }
+
+  return [
+    {
+      ...existingDefault,
+      ...defaultRecord,
+      createdAt: existingDefault.createdAt,
+      updatedAt: existingDefault.updatedAt,
+      provisioning: existingDefault.provisioning,
+    },
+    ...withoutDefault,
+  ];
+}
+
+export async function readProjectRegistry(
+  workDir: string,
+  defaultProject: DefaultProjectContext,
+): Promise<ProjectRegistry> {
+  try {
+    const raw = await fs.readFile(getProjectRegistryPath(workDir), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    const rawProjects = (parsed as { projects?: unknown }).projects;
+    if (!Array.isArray(rawProjects)) {
+      throw new Error("Project registry file is malformed: missing projects array.");
+    }
+
+    const normalizedProjects = rawProjects.map(normalizeProjectRecord);
+    if (normalizedProjects.some((project) => project === null)) {
+      throw new Error("Project registry file is malformed: invalid project record.");
+    }
+    const existingProjects = normalizedProjects as ProjectRecord[];
+
+    return {
+      version: PROJECT_REGISTRY_VERSION,
+      projects: ensureDefaultProject(existingProjects, defaultProject),
+    };
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return {
+        version: PROJECT_REGISTRY_VERSION,
+        projects: [buildDefaultProjectRecord(defaultProject)],
+      };
+    }
+
+    throw error;
+  }
+}
+
+export async function writeProjectRegistry(workDir: string, registry: ProjectRegistry): Promise<void> {
+  const path = getProjectRegistryPath(workDir);
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(
+    path,
+    `${JSON.stringify({ version: PROJECT_REGISTRY_VERSION, projects: registry.projects }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export async function upsertProjectRecord(
+  workDir: string,
+  defaultProject: DefaultProjectContext,
+  nextRecord: ProjectRecord,
+): Promise<ProjectRegistry> {
+  const registry = await readProjectRegistry(workDir, defaultProject);
+  const nextProjects = registry.projects.filter((project) => project.slug !== nextRecord.slug);
+  nextProjects.push(nextRecord);
+  const normalizedProjects = ensureDefaultProject(nextProjects, defaultProject).sort((left, right) => {
+    if (left.slug === DEFAULT_PROJECT_SLUG) {
+      return -1;
+    }
+
+    if (right.slug === DEFAULT_PROJECT_SLUG) {
+      return 1;
+    }
+
+    return left.slug.localeCompare(right.slug);
+  });
+
+  const nextRegistry: ProjectRegistry = {
+    version: PROJECT_REGISTRY_VERSION,
+    projects: normalizedProjects,
+  };
+  await writeProjectRegistry(workDir, nextRegistry);
+  return nextRegistry;
+}
+
+export function findProjectBySlug(registry: ProjectRegistry, slug: string): ProjectRecord | null {
+  return registry.projects.find((project) => project.slug === slug) ?? null;
+}

--- a/src/runtime/gracefulShutdown.test.ts
+++ b/src/runtime/gracefulShutdown.test.ts
@@ -8,6 +8,7 @@ import {
   getGracefulShutdownRequestPath,
   readDiscordControlCursor,
   readGracefulShutdownRequest,
+  recordDiscordControlCommandReceipt,
   recordGracefulShutdownRequest,
   writeDiscordControlCursor,
 } from "./gracefulShutdown.js";
@@ -88,5 +89,25 @@ describe("gracefulShutdown", () => {
       "utf8",
     );
     await expect(readGracefulShutdownRequest(workDir)).resolves.toBeNull();
+  });
+
+  it("records Discord control receipts once per message id", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await expect(
+      recordDiscordControlCommandReceipt(workDir, {
+        command: "start-project",
+        messageId: "9100",
+        recordedAt: "2026-03-07T14:00:00.000Z",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      recordDiscordControlCommandReceipt(workDir, {
+        command: "start-project",
+        messageId: "9100",
+        recordedAt: "2026-03-07T14:05:00.000Z",
+      }),
+    ).resolves.toBe(false);
   });
 });

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const GRACEFUL_SHUTDOWN_REQUEST_FILE_NAME = "graceful-shutdown-request.json";
 const DISCORD_CONTROL_CURSOR_FILE_NAME = "discord-control-cursor.json";
+const DISCORD_CONTROL_RECEIPTS_DIRECTORY_NAME = "discord-control-receipts";
 const GRACEFUL_SHUTDOWN_REQUEST_VERSION = 1;
 
 export type GracefulShutdownRequest = {
@@ -93,6 +94,15 @@ export function getDiscordControlCursorPath(workDir: string): string {
   return join(workDir, EVOLVO_DIRECTORY_NAME, DISCORD_CONTROL_CURSOR_FILE_NAME);
 }
 
+function getDiscordControlReceiptPath(workDir: string, command: string, messageId: string): string {
+  return join(
+    workDir,
+    EVOLVO_DIRECTORY_NAME,
+    DISCORD_CONTROL_RECEIPTS_DIRECTORY_NAME,
+    `${command}-${messageId}.json`,
+  );
+}
+
 export async function readGracefulShutdownRequest(workDir: string): Promise<GracefulShutdownRequest | null> {
   const raw = await readJsonFile(getGracefulShutdownRequestPath(workDir));
   return normalizeGracefulShutdownRequest(raw);
@@ -149,4 +159,43 @@ export async function writeDiscordControlCursor(workDir: string, lastSeenMessage
   await writeJsonFile(getDiscordControlCursorPath(workDir), {
     lastSeenMessageId: normalizeMessageId(lastSeenMessageId),
   } satisfies DiscordControlCursorState);
+}
+
+export async function recordDiscordControlCommandReceipt(
+  workDir: string,
+  input: {
+    command: "start-project";
+    messageId: string;
+    recordedAt?: string;
+  },
+): Promise<boolean> {
+  const messageId = normalizeMessageId(input.messageId);
+  if (messageId === null) {
+    throw new Error("Discord control receipt message ID cannot be empty.");
+  }
+
+  const path = getDiscordControlReceiptPath(workDir, input.command, messageId);
+  try {
+    await fs.mkdir(dirname(path), { recursive: true });
+    await fs.writeFile(
+      path,
+      `${JSON.stringify({
+        command: input.command,
+        messageId,
+        recordedAt: isNonEmptyString(input.recordedAt) ? input.recordedAt.trim() : new Date().toISOString(),
+      }, null, 2)}\n`,
+      {
+        encoding: "utf8",
+        flag: "wx",
+      },
+    );
+    return true;
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "EEXIST") {
+      return false;
+    }
+
+    throw error;
+  }
 }

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -376,6 +376,105 @@ describe("operatorControl", () => {
     );
   });
 
+  it("queues an authorized /startProject request and acknowledges the created tracker issue", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStartProject = vi.fn().mockResolvedValue({
+      ok: true,
+      message: "Created issue #555.",
+      issueNumber: 555,
+      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/555",
+    });
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7100", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7101", content: "/startProject Habit CLI", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-2" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir, { onStartProject });
+
+    expect(request).toBeNull();
+    expect(onStartProject).toHaveBeenCalledWith({
+      messageId: "7101",
+      requestedAt: expect.any(String),
+      requestedBy: "discord:operator-1",
+      displayName: "Habit CLI",
+      slug: "habit-cli",
+      repositoryName: "habit-cli",
+      issueLabel: "project:habit-cli",
+      workspaceRelativePath: "projects/habit-cli",
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: [
+            "<@operator-1> Project start request queued for `Habit CLI`.",
+            "Tracker issue: #555 (https://github.com/evolvo-auto/evolvo-ts/issues/555)",
+            "Planned label: `project:habit-cli`",
+            "Planned repository: `habit-cli`",
+            "Planned workspace: `projects/habit-cli`",
+          ].join("\n"),
+        }),
+      }),
+    );
+  });
+
+  it("acknowledges invalid authorized /startProject commands without calling the handler", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStartProject = vi.fn();
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7200", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7201", content: "/startProject", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-3" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await pollDiscordGracefulShutdownCommand(workDir, { onStartProject });
+
+    expect(onStartProject).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: [
+            "<@operator-1> Could not queue project start request for `<missing project name>`.",
+            "Project name is required.",
+            "Usage: `/startProject <project-name>`",
+          ].join("\n"),
+        }),
+      }),
+    );
+  });
+
   it("ignores /quit messages from unauthorized users", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
@@ -399,6 +498,33 @@ describe("operatorControl", () => {
     const request = await pollDiscordGracefulShutdownCommand(workDir);
 
     expect(request).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores /startProject messages from unauthorized users", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStartProject = vi.fn();
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7300", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7301", content: "/startProject Habit CLI", author: { id: "intruder-1" } }]),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await pollDiscordGracefulShutdownCommand(workDir, { onStartProject });
+
+    expect(onStartProject).not.toHaveBeenCalled();
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -1,9 +1,11 @@
 import {
+  recordDiscordControlCommandReceipt,
   recordGracefulShutdownRequest,
   readDiscordControlCursor,
   type GracefulShutdownRequest,
   writeDiscordControlCursor,
 } from "./gracefulShutdown.js";
+import { normalizeProjectNameInput } from "../projects/projectNaming.js";
 
 type DiscordControlConfig = {
   botToken: string;
@@ -21,6 +23,33 @@ export type CycleLimitDecision = {
   source: "discord";
 };
 
+export type StartProjectCommandRequest = {
+  messageId: string;
+  requestedAt: string;
+  requestedBy: string;
+  displayName: string;
+  slug: string;
+  repositoryName: string;
+  issueLabel: string;
+  workspaceRelativePath: string;
+};
+
+export type StartProjectCommandResult =
+  | {
+    ok: true;
+    message: string;
+    issueNumber: number;
+    issueUrl: string;
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
+export type DiscordControlHandlers = {
+  onStartProject?: (request: StartProjectCommandRequest) => Promise<StartProjectCommandResult>;
+};
+
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_POLL_INTERVAL_MS = 5 * 1000;
 const DEFAULT_CYCLE_EXTENSION = 25;
@@ -33,8 +62,9 @@ type DiscordOperatorStep =
   | "send-prompt"
   | "wait-for-reply"
   | "send-issue-start"
-  | "read-quit-commands"
-  | "send-quit-ack";
+  | "read-control-commands"
+  | "send-quit-ack"
+  | "send-start-project-ack";
 
 type DiscordIssueStartNotification = {
   issueNumber: number;
@@ -42,6 +72,12 @@ type DiscordIssueStartNotification = {
   issueUrl: string;
   repository: string;
   lifecycleState: string;
+};
+
+type DiscordControlMessage = {
+  id: string;
+  content: string;
+  author?: { id?: string };
 };
 
 function getRequiredTrimmedEnv(name: string, env: NodeJS.ProcessEnv): string | null {
@@ -105,6 +141,15 @@ function isGracefulShutdownCommand(content: string): boolean {
   return content.trim().toLowerCase() === "/quit";
 }
 
+function parseStartProjectName(content: string): string | null {
+  const match = content.match(/^\/startproject(?:\s+(.+))?$/i);
+  if (!match) {
+    return null;
+  }
+
+  return match[1]?.trim() ?? "";
+}
+
 function buildAuthHeaders(config: DiscordControlConfig): Record<string, string> {
   return {
     Authorization: `Bot ${config.botToken}`,
@@ -151,7 +196,7 @@ async function sendStartupBootMessage(config: DiscordControlConfig): Promise<voi
   const startedAt = new Date().toISOString();
   const content = [
     "🤖 Evolvo runtime booted.",
-    "Operator control is online for cycle-limit decisions and graceful shutdown.",
+    "Operator control is online for cycle-limit decisions, graceful shutdown, and `/startProject` requests.",
     `Started at: ${startedAt}`,
   ].join("\n");
 
@@ -210,6 +255,31 @@ async function sendGracefulShutdownAcknowledgement(config: DiscordControlConfig)
     `<@${config.operatorUserId}> Graceful shutdown requested.`,
     "Evolvo will finish the current task and then stop before starting another issue.",
   ].join("\n");
+
+  await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ content }),
+  });
+}
+
+async function sendStartProjectAcknowledgement(
+  config: DiscordControlConfig,
+  request: StartProjectCommandRequest,
+  result: StartProjectCommandResult,
+): Promise<void> {
+  const content = result.ok
+    ? [
+      `<@${config.operatorUserId}> Project start request queued for \`${request.displayName}\`.`,
+      `Tracker issue: #${result.issueNumber} (${result.issueUrl})`,
+      `Planned label: \`${request.issueLabel}\``,
+      `Planned repository: \`${request.repositoryName}\``,
+      `Planned workspace: \`${request.workspaceRelativePath}\``,
+    ].join("\n")
+    : [
+      `<@${config.operatorUserId}> Could not queue project start request for \`${request.displayName}\`.`,
+      result.message,
+      "Usage: `/startProject <project-name>`",
+    ].join("\n");
 
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",
@@ -280,22 +350,14 @@ async function fetchControlChannelMessages(
     afterId?: string | null;
     limit?: number;
   } = {},
-): Promise<Array<{
-  id: string;
-  content: string;
-  author?: { id?: string };
-}>> {
+): Promise<DiscordControlMessage[]> {
   const query = new URLSearchParams();
   query.set("limit", String(options.limit ?? 50));
   if (options.afterId && options.afterId.trim().length > 0) {
     query.set("after", options.afterId);
   }
 
-  return fetchDiscordJson<Array<{
-    id: string;
-    content: string;
-    author?: { id?: string };
-  }>>(config, `/channels/${config.controlChannelId}/messages?${query.toString()}`);
+  return fetchDiscordJson<DiscordControlMessage[]>(config, `/channels/${config.controlChannelId}/messages?${query.toString()}`);
 }
 
 async function initializeDiscordControlCursor(
@@ -369,6 +431,7 @@ export async function runDiscordOperatorControlStartupCheck(): Promise<void> {
 
 export async function pollDiscordGracefulShutdownCommand(
   workDir: string,
+  handlers: DiscordControlHandlers = {},
 ): Promise<GracefulShutdownRequest | null> {
   const config = getDiscordControlConfigFromEnv();
   if (!config) {
@@ -384,31 +447,96 @@ export async function pollDiscordGracefulShutdownCommand(
 
     await writeDiscordControlCursor(workDir, getHighestSnowflakeId(messages.map((message) => message.id)));
 
-    const quitMessage = messages.find((message) =>
-      message.author?.id === config.operatorUserId && isGracefulShutdownCommand(message.content)
-    );
-    if (!quitMessage) {
-      return null;
-    }
+    let gracefulShutdownRequest: GracefulShutdownRequest | null = null;
+    const orderedMessages = [...messages].sort((left, right) => {
+      if (left.id === right.id) {
+        return 0;
+      }
 
-    const recordedRequest = await recordGracefulShutdownRequest(workDir, {
-      messageId: quitMessage.id,
+      return BigInt(left.id) < BigInt(right.id) ? -1 : 1;
     });
-    if (!recordedRequest.created) {
-      return recordedRequest.request;
+
+    for (const message of orderedMessages) {
+      if (message.author?.id !== config.operatorUserId) {
+        continue;
+      }
+
+      if (isGracefulShutdownCommand(message.content)) {
+        const recordedRequest = await recordGracefulShutdownRequest(workDir, {
+          messageId: message.id,
+        });
+        gracefulShutdownRequest = recordedRequest.request;
+        if (recordedRequest.created) {
+          try {
+            await sendGracefulShutdownAcknowledgement(config);
+          } catch (error) {
+            const sendMessage = buildStepFailureMessage("send-quit-ack", error);
+            console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);
+            logDiscordMissingAccessHint(sendMessage);
+          }
+        }
+        continue;
+      }
+
+      const requestedProjectName = parseStartProjectName(message.content);
+      if (requestedProjectName === null || !handlers.onStartProject) {
+        continue;
+      }
+
+      const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
+        command: "start-project",
+        messageId: message.id,
+      });
+      if (!recordedReceipt) {
+        continue;
+      }
+
+      let startProjectRequest: StartProjectCommandRequest | null = null;
+      let commandResult: StartProjectCommandResult;
+
+      try {
+        const normalized = normalizeProjectNameInput(requestedProjectName);
+        startProjectRequest = {
+          messageId: message.id,
+          requestedAt: new Date().toISOString(),
+          requestedBy: `discord:${config.operatorUserId}`,
+          displayName: normalized.displayName,
+          slug: normalized.slug,
+          repositoryName: normalized.repositoryName,
+          issueLabel: normalized.issueLabel,
+          workspaceRelativePath: normalized.workspaceRelativePath,
+        };
+        commandResult = await handlers.onStartProject(startProjectRequest);
+      } catch (error) {
+        const fallbackDisplayName = requestedProjectName.trim() || "<missing project name>";
+        startProjectRequest = {
+          messageId: message.id,
+          requestedAt: new Date().toISOString(),
+          requestedBy: `discord:${config.operatorUserId}`,
+          displayName: fallbackDisplayName,
+          slug: "",
+          repositoryName: "",
+          issueLabel: "",
+          workspaceRelativePath: "",
+        };
+        commandResult = {
+          ok: false,
+          message: error instanceof Error ? error.message : "Unknown project start request error.",
+        };
+      }
+
+      try {
+        await sendStartProjectAcknowledgement(config, startProjectRequest, commandResult);
+      } catch (error) {
+        const sendMessage = buildStepFailureMessage("send-start-project-ack", error);
+        console.error(`Discord project start acknowledgement failed: ${sendMessage}`);
+        logDiscordMissingAccessHint(sendMessage);
+      }
     }
 
-    try {
-      await sendGracefulShutdownAcknowledgement(config);
-    } catch (error) {
-      const message = buildStepFailureMessage("send-quit-ack", error);
-      console.error(`Discord graceful shutdown acknowledgement failed: ${message}`);
-      logDiscordMissingAccessHint(message);
-    }
-
-    return recordedRequest.request;
+    return gracefulShutdownRequest;
   } catch (error) {
-    const message = buildStepFailureMessage("read-quit-commands", error);
+    const message = buildStepFailureMessage("read-control-commands", error);
     console.error(`Discord graceful shutdown polling failed: ${message}`);
     logDiscordMissingAccessHint(message);
     return null;
@@ -421,6 +549,7 @@ export type DiscordGracefulShutdownListener = {
 
 export async function startDiscordGracefulShutdownListener(
   workDir: string,
+  handlers: DiscordControlHandlers = {},
 ): Promise<DiscordGracefulShutdownListener | null> {
   const config = getDiscordControlConfigFromEnv();
   if (!config) {
@@ -430,7 +559,7 @@ export async function startDiscordGracefulShutdownListener(
   try {
     await initializeDiscordControlCursor(config, workDir);
   } catch (error) {
-    const message = buildStepFailureMessage("read-quit-commands", error);
+    const message = buildStepFailureMessage("read-control-commands", error);
     console.error(`Discord graceful shutdown listener bootstrap failed: ${message}`);
     logDiscordMissingAccessHint(message);
   }
@@ -445,7 +574,7 @@ export async function startDiscordGracefulShutdownListener(
     }
 
     timer = setTimeout(() => {
-      pendingPoll = pollDiscordGracefulShutdownCommand(workDir)
+      pendingPoll = pollDiscordGracefulShutdownCommand(workDir, handlers)
         .catch(() => undefined)
         .then(() => undefined)
         .finally(() => {


### PR DESCRIPTION
## Summary
- add managed-project provisioning primitives, including registry persistence, provisioning issue metadata, and GitHub admin label/repo helpers
- extend Discord operator control with authorized \/startProject handling, acknowledgements, and atomic message receipts to avoid duplicate provisioning requests
- execute provisioning request issues through the default Evolvo runtime path with success/failure lifecycle handling and focused regression coverage

## Testing
- pnpm vitest run src/github/githubClient.test.ts src/github/githubAdminClient.test.ts src/projects/projectNaming.test.ts src/projects/projectRegistry.test.ts src/issues/projectProvisioningIssue.test.ts src/projects/projectProvisioning.test.ts src/runtime/gracefulShutdown.test.ts src/runtime/operatorControl.test.ts src/main.test.ts src/main.replenishment.integration.test.ts
- pnpm typecheck

Closes #318