### PR TITLE
feat(runtime): add queue-drain quit mode

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -29,7 +29,8 @@ const notifyIssueStartedInDiscordMock = vi.fn();
 const pollDiscordGracefulShutdownCommandMock = vi.fn();
 const startDiscordGracefulShutdownListenerMock = vi.fn();
 const stopDiscordGracefulShutdownListenerMock = vi.fn();
-const consumeGracefulShutdownRequestMock = vi.fn();
+const readGracefulShutdownRequestMock = vi.fn();
+const clearGracefulShutdownRequestMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
 const createProjectProvisioningRequestIssueMock = vi.fn();
 const executeProjectProvisioningIssueMock = vi.fn();
@@ -113,7 +114,8 @@ vi.mock("./runtime/runtimeReadiness.js", () => ({
 }));
 
 vi.mock("./runtime/gracefulShutdown.js", () => ({
-  consumeGracefulShutdownRequest: consumeGracefulShutdownRequestMock,
+  readGracefulShutdownRequest: readGracefulShutdownRequestMock,
+  clearGracefulShutdownRequest: clearGracefulShutdownRequestMock,
 }));
 
 vi.mock("./runtime/operatorControl.js", () => ({
@@ -341,8 +343,10 @@ describe("main", () => {
     buildLifecycleStateCommentMock.mockReturnValue("## Canonical Lifecycle State");
     writeRuntimeReadinessSignalMock.mockReset();
     writeRuntimeReadinessSignalMock.mockResolvedValue("/tmp/evolvo/.evolvo/runtime-readiness.json");
-    consumeGracefulShutdownRequestMock.mockReset();
-    consumeGracefulShutdownRequestMock.mockResolvedValue(null);
+    readGracefulShutdownRequestMock.mockReset();
+    readGracefulShutdownRequestMock.mockResolvedValue(null);
+    clearGracefulShutdownRequestMock.mockReset();
+    clearGracefulShutdownRequestMock.mockResolvedValue(undefined);
     pollDiscordGracefulShutdownCommandMock.mockReset();
     pollDiscordGracefulShutdownCommandMock.mockResolvedValue(null);
     requestCycleLimitDecisionFromOperatorMock.mockReset();
@@ -1375,10 +1379,11 @@ describe("main", () => {
   });
 
   it("stops before starting a new task when a graceful shutdown request is already pending", async () => {
-    consumeGracefulShutdownRequestMock.mockResolvedValueOnce({
+    readGracefulShutdownRequestMock.mockResolvedValueOnce({
       version: 1,
       source: "discord",
       command: "/quit",
+      mode: "after-current-task",
       messageId: "9001",
       requestedAt: "2026-03-07T12:00:00.000Z",
     });
@@ -1388,6 +1393,7 @@ describe("main", () => {
 
     expect(listOpenIssuesMock).not.toHaveBeenCalled();
     expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(clearGracefulShutdownRequestMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
       "Graceful shutdown requested via Discord /quit. Stopping before starting a new task.",
     );
@@ -1401,7 +1407,7 @@ describe("main", () => {
       .mockResolvedValueOnce([
         { number: 302, title: "Next task", description: "should not start", state: "open", labels: [] },
       ]);
-    consumeGracefulShutdownRequestMock
+    readGracefulShutdownRequestMock
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
@@ -1409,6 +1415,7 @@ describe("main", () => {
         version: 1,
         source: "discord",
         command: "/quit",
+        mode: "after-current-task",
         messageId: "9002",
         requestedAt: "2026-03-07T12:05:00.000Z",
       });
@@ -1420,8 +1427,41 @@ describe("main", () => {
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #301: Current task\n\nfinish this");
     expect(markInProgressMock).toHaveBeenCalledWith(301);
     expect(markInProgressMock).not.toHaveBeenCalledWith(302);
+    expect(clearGracefulShutdownRequestMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
       "Graceful shutdown requested via Discord /quit. Current task completed. Stopping before starting another issue.",
+    );
+  });
+
+  it("drains existing issues and suppresses planner replenishment after /quit after tasks", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 401, title: "First queued task", description: "one", state: "open", labels: [] },
+        { number: 402, title: "Second queued task", description: "two", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([
+        { number: 402, title: "Second queued task", description: "two", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    readGracefulShutdownRequestMock.mockResolvedValue({
+      version: 1,
+      source: "discord",
+      command: "/quit after tasks",
+      mode: "after-tasks",
+      messageId: "9010",
+      requestedAt: "2026-03-07T12:10:00.000Z",
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).toHaveBeenCalledTimes(2);
+    expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #401: First queued task\n\none");
+    expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #402: Second queued task\n\ntwo");
+    expect(runPlannerAgentMock).not.toHaveBeenCalled();
+    expect(clearGracefulShutdownRequestMock).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith(
+      "Graceful shutdown requested via Discord /quit after tasks. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started.",
     );
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,8 @@ import {
   waitForRunLoopRetry,
 } from "./runtime/loopUtils.js";
 import {
-  consumeGracefulShutdownRequest,
+  clearGracefulShutdownRequest,
+  readGracefulShutdownRequest,
   type GracefulShutdownRequest,
 } from "./runtime/gracefulShutdown.js";
 import {
@@ -171,18 +172,48 @@ function buildGracefulShutdownLogMessage(
   return `Graceful shutdown requested via Discord ${request.command}. ${reason}`;
 }
 
-async function stopIfGracefulShutdownRequested(
+function isQueueDrainGracefulShutdownRequest(request: GracefulShutdownRequest | null): boolean {
+  return request?.mode === "after-tasks";
+}
+
+async function readPendingGracefulShutdownRequest(
+  workDir: string,
+  discordHandlers: DiscordControlHandlers,
+): Promise<GracefulShutdownRequest | null> {
+  await pollDiscordGracefulShutdownCommand(workDir, discordHandlers);
+  return readGracefulShutdownRequest(workDir);
+}
+
+async function stopIfSingleTaskGracefulShutdownRequested(
   workDir: string,
   reason: string,
   discordHandlers: DiscordControlHandlers,
 ): Promise<boolean> {
-  await pollDiscordGracefulShutdownCommand(workDir, discordHandlers);
-  const request = await consumeGracefulShutdownRequest(workDir);
+  const request = await readPendingGracefulShutdownRequest(workDir, discordHandlers);
+  if (request === null || isQueueDrainGracefulShutdownRequest(request)) {
+    return false;
+  }
+
+  await clearGracefulShutdownRequest(workDir);
+  console.log(buildGracefulShutdownLogMessage(request, reason));
+  return true;
+}
+
+async function stopIfGracefulShutdownPreventsNewWork(
+  workDir: string,
+  reason: string,
+  discordHandlers: DiscordControlHandlers,
+): Promise<boolean> {
+  const request = await readPendingGracefulShutdownRequest(workDir, discordHandlers);
   if (request === null) {
     return false;
   }
 
-  console.log(buildGracefulShutdownLogMessage(request, reason));
+  await clearGracefulShutdownRequest(workDir);
+  const shutdownReason = isQueueDrainGracefulShutdownRequest(request)
+    ? "Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started."
+    : reason;
+  console.log(buildGracefulShutdownLogMessage(request, shutdownReason));
   return true;
 }
 
@@ -219,13 +250,13 @@ export async function main(): Promise<void> {
   const gracefulShutdownListener = await startDiscordGracefulShutdownListener(WORK_DIR, discordHandlers);
 
   try {
-    if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
+    if (await stopIfSingleTaskGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
       return;
     }
 
     let cycleLimit = MAX_ISSUE_CYCLES;
     issueCycleLoop: for (let cycle = 1; ; cycle += 1) {
-      if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
+      if (await stopIfSingleTaskGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
         return;
       }
 
@@ -279,7 +310,7 @@ export async function main(): Promise<void> {
               });
             },
           });
-          if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
+          if (await stopIfSingleTaskGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
             return;
           }
 
@@ -287,7 +318,7 @@ export async function main(): Promise<void> {
 
           if (!selectedIssue) {
             if (
-              await stopIfGracefulShutdownRequested(
+              await stopIfGracefulShutdownPreventsNewWork(
                 WORK_DIR,
                 "Stopping before planner replenishment.",
                 discordHandlers,
@@ -318,7 +349,7 @@ export async function main(): Promise<void> {
 
             if (createdIssues.length > 0) {
               if (
-                await stopIfGracefulShutdownRequested(
+                await stopIfGracefulShutdownPreventsNewWork(
                   WORK_DIR,
                   "Stopping before starting a new task.",
                   discordHandlers,
@@ -334,7 +365,7 @@ export async function main(): Promise<void> {
               continue issueCycleLoop;
             }
 
-            if (await stopIfGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
+            if (await stopIfGracefulShutdownPreventsNewWork(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
               return;
             }
 
@@ -448,7 +479,7 @@ export async function main(): Promise<void> {
             }
 
             if (
-              await stopIfGracefulShutdownRequested(
+              await stopIfSingleTaskGracefulShutdownRequested(
                 WORK_DIR,
                 "Current task completed. Stopping before starting another issue.",
                 discordHandlers,
@@ -583,7 +614,7 @@ export async function main(): Promise<void> {
           }
 
           if (
-            await stopIfGracefulShutdownRequested(
+            await stopIfSingleTaskGracefulShutdownRequested(
               WORK_DIR,
               "Current task completed. Stopping before starting another issue.",
               discordHandlers,

--- a/src/runtime/gracefulShutdown.test.ts
+++ b/src/runtime/gracefulShutdown.test.ts
@@ -43,6 +43,7 @@ describe("gracefulShutdown", () => {
         version: 1,
         source: "discord",
         command: "/quit",
+        mode: "after-current-task",
         messageId: "9001",
         requestedAt: "2026-03-07T12:00:00.000Z",
       },
@@ -67,10 +68,35 @@ describe("gracefulShutdown", () => {
       version: 1,
       source: "discord",
       command: "/quit",
+      mode: "after-current-task",
       messageId: "9010",
       requestedAt: "2026-03-07T13:00:00.000Z",
     });
     await expect(consumeGracefulShutdownRequest(workDir)).resolves.toBeNull();
+  });
+
+  it("records queue-drain shutdown requests with the after-tasks mode", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const result = await recordGracefulShutdownRequest(workDir, {
+      messageId: "9050",
+      requestedAt: "2026-03-07T13:30:00.000Z",
+      mode: "after-tasks",
+    });
+
+    expect(result).toEqual({
+      created: true,
+      request: {
+        version: 1,
+        source: "discord",
+        command: "/quit after tasks",
+        mode: "after-tasks",
+        messageId: "9050",
+        requestedAt: "2026-03-07T13:30:00.000Z",
+      },
+    });
+    await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual(result.request);
   });
 
   it("normalizes persisted cursor and malformed shutdown payloads", async () => {
@@ -89,6 +115,26 @@ describe("gracefulShutdown", () => {
       "utf8",
     );
     await expect(readGracefulShutdownRequest(workDir)).resolves.toBeNull();
+
+    await writeFile(
+      getGracefulShutdownRequestPath(workDir),
+      JSON.stringify({
+        version: 1,
+        source: "discord",
+        command: "/quit",
+        messageId: "9200",
+        requestedAt: "2026-03-07T15:00:00.000Z",
+      }),
+      "utf8",
+    );
+    await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit",
+      mode: "after-current-task",
+      messageId: "9200",
+      requestedAt: "2026-03-07T15:00:00.000Z",
+    });
   });
 
   it("records Discord control receipts once per message id", async () => {

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -7,10 +7,13 @@ const DISCORD_CONTROL_CURSOR_FILE_NAME = "discord-control-cursor.json";
 const DISCORD_CONTROL_RECEIPTS_DIRECTORY_NAME = "discord-control-receipts";
 const GRACEFUL_SHUTDOWN_REQUEST_VERSION = 1;
 
+export type GracefulShutdownMode = "after-current-task" | "after-tasks";
+
 export type GracefulShutdownRequest = {
   version: typeof GRACEFUL_SHUTDOWN_REQUEST_VERSION;
   source: "discord";
-  command: "/quit";
+  command: "/quit" | "/quit after tasks";
+  mode: GracefulShutdownMode;
   messageId: string;
   requestedAt: string;
 };
@@ -38,7 +41,21 @@ function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest
 
   const candidate = raw as Partial<GracefulShutdownRequest>;
   const messageId = normalizeMessageId(candidate.messageId);
-  if (candidate.source !== "discord" || candidate.command !== "/quit" || messageId === null) {
+  if (candidate.source !== "discord" || messageId === null) {
+    return null;
+  }
+
+  let command: GracefulShutdownRequest["command"] | null = null;
+  let mode: GracefulShutdownMode | null = null;
+  if (candidate.command === "/quit after tasks") {
+    command = "/quit after tasks";
+    mode = "after-tasks";
+  } else if (candidate.command === "/quit") {
+    command = "/quit";
+    mode = candidate.mode === "after-tasks" ? "after-tasks" : "after-current-task";
+  }
+
+  if (command === null || mode === null) {
     return null;
   }
 
@@ -50,7 +67,8 @@ function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest
   return {
     version: GRACEFUL_SHUTDOWN_REQUEST_VERSION,
     source: "discord",
-    command: "/quit",
+    command,
+    mode,
     messageId,
     requestedAt,
   };
@@ -113,6 +131,7 @@ export async function recordGracefulShutdownRequest(
   input: {
     messageId: string;
     requestedAt?: string;
+    mode?: GracefulShutdownMode;
   },
 ): Promise<{ request: GracefulShutdownRequest; created: boolean }> {
   const existing = await readGracefulShutdownRequest(workDir);
@@ -128,16 +147,22 @@ export async function recordGracefulShutdownRequest(
   const requestedAt = isNonEmptyString(input.requestedAt)
     ? input.requestedAt.trim()
     : new Date().toISOString();
+  const mode = input.mode ?? "after-current-task";
 
   const request: GracefulShutdownRequest = {
     version: GRACEFUL_SHUTDOWN_REQUEST_VERSION,
     source: "discord",
-    command: "/quit",
+    command: mode === "after-tasks" ? "/quit after tasks" : "/quit",
+    mode,
     messageId,
     requestedAt,
   };
   await writeJsonFile(getGracefulShutdownRequestPath(workDir), request);
   return { request, created: true };
+}
+
+export async function clearGracefulShutdownRequest(workDir: string): Promise<void> {
+  await fs.rm(getGracefulShutdownRequestPath(workDir), { force: true });
 }
 
 export async function consumeGracefulShutdownRequest(workDir: string): Promise<GracefulShutdownRequest | null> {
@@ -146,7 +171,7 @@ export async function consumeGracefulShutdownRequest(workDir: string): Promise<G
     return null;
   }
 
-  await fs.rm(getGracefulShutdownRequestPath(workDir), { force: true });
+  await clearGracefulShutdownRequest(workDir);
   return request;
 }
 

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -360,6 +360,7 @@ describe("operatorControl", () => {
       version: 1,
       source: "discord",
       command: "/quit",
+      mode: "after-current-task",
       messageId: "7001",
       requestedAt: expect.any(String),
     });
@@ -371,6 +372,50 @@ describe("operatorControl", () => {
         method: "POST",
         body: JSON.stringify({
           content: "<@operator-1> Graceful shutdown requested.\nEvolvo will finish the current task and then stop before starting another issue.",
+        }),
+      }),
+    );
+  });
+
+  it("records and acknowledges an authorized /quit after tasks queue-drain command", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7050", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7051", content: "/quit   after   tasks", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-queue-drain" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(request).toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit after tasks",
+      mode: "after-tasks",
+      messageId: "7051",
+      requestedAt: expect.any(String),
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1> Queue-drain shutdown requested.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
         }),
       }),
     );
@@ -490,6 +535,32 @@ describe("operatorControl", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify([{ id: "8001", content: "/quit", author: { id: "intruder-1" } }]),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(request).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores /quit after tasks messages from unauthorized users", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "8010", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "8011", content: "/quit after tasks", author: { id: "intruder-1" } }]),
           { status: 200 },
         ),
       );

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -2,6 +2,7 @@ import {
   recordDiscordControlCommandReceipt,
   recordGracefulShutdownRequest,
   readDiscordControlCursor,
+  type GracefulShutdownMode,
   type GracefulShutdownRequest,
   writeDiscordControlCursor,
 } from "./gracefulShutdown.js";
@@ -137,8 +138,24 @@ function parseOperatorDecision(content: string): "continue" | "quit" | null {
   return null;
 }
 
-function isGracefulShutdownCommand(content: string): boolean {
-  return content.trim().toLowerCase() === "/quit";
+function parseGracefulShutdownCommand(
+  content: string,
+): { command: GracefulShutdownRequest["command"]; mode: GracefulShutdownMode } | null {
+  const normalized = content.trim().toLowerCase().replace(/\s+/g, " ");
+  if (normalized === "/quit after tasks") {
+    return {
+      command: "/quit after tasks",
+      mode: "after-tasks",
+    };
+  }
+  if (normalized === "/quit") {
+    return {
+      command: "/quit",
+      mode: "after-current-task",
+    };
+  }
+
+  return null;
 }
 
 function parseStartProjectName(content: string): string | null {
@@ -196,7 +213,7 @@ async function sendStartupBootMessage(config: DiscordControlConfig): Promise<voi
   const startedAt = new Date().toISOString();
   const content = [
     "🤖 Evolvo runtime booted.",
-    "Operator control is online for cycle-limit decisions, graceful shutdown, and `/startProject` requests.",
+    "Operator control is online for cycle-limit decisions, graceful shutdown (`/quit`, `/quit after tasks`), and `/startProject` requests.",
     `Started at: ${startedAt}`,
   ].join("\n");
 
@@ -250,11 +267,19 @@ async function sendIssueStartNotification(
   });
 }
 
-async function sendGracefulShutdownAcknowledgement(config: DiscordControlConfig): Promise<void> {
-  const content = [
-    `<@${config.operatorUserId}> Graceful shutdown requested.`,
-    "Evolvo will finish the current task and then stop before starting another issue.",
-  ].join("\n");
+async function sendGracefulShutdownAcknowledgement(
+  config: DiscordControlConfig,
+  request: GracefulShutdownRequest,
+): Promise<void> {
+  const content = request.mode === "after-tasks"
+    ? [
+      `<@${config.operatorUserId}> Queue-drain shutdown requested.`,
+      "Evolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
+    ].join("\n")
+    : [
+      `<@${config.operatorUserId}> Graceful shutdown requested.`,
+      "Evolvo will finish the current task and then stop before starting another issue.",
+    ].join("\n");
 
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",
@@ -461,14 +486,16 @@ export async function pollDiscordGracefulShutdownCommand(
         continue;
       }
 
-      if (isGracefulShutdownCommand(message.content)) {
+      const shutdownCommand = parseGracefulShutdownCommand(message.content);
+      if (shutdownCommand !== null) {
         const recordedRequest = await recordGracefulShutdownRequest(workDir, {
           messageId: message.id,
+          mode: shutdownCommand.mode,
         });
         gracefulShutdownRequest = recordedRequest.request;
         if (recordedRequest.created) {
           try {
-            await sendGracefulShutdownAcknowledgement(config);
+            await sendGracefulShutdownAcknowledgement(config, recordedRequest.request);
           } catch (error) {
             const sendMessage = buildStepFailureMessage("send-quit-ack", error);
             console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);


### PR DESCRIPTION
## Summary
- add explicit graceful shutdown modes so `/quit` and `/quit after tasks` persist distinctly
- teach Discord control to acknowledge and record `/quit after tasks`
- drain existing actionable issues while suppressing planner/bootstrap work once queue-drain shutdown is active

## Testing
- pnpm vitest run src/runtime/gracefulShutdown.test.ts src/runtime/operatorControl.test.ts src/main.test.ts
- pnpm vitest run src/main.replenishment.integration.test.ts
- pnpm typecheck

Fixes #320
