### PR TITLE
feat(projects): resolve issue execution context

### DIFF
--- a/src/agents/codingAgent.test.ts
+++ b/src/agents/codingAgent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CODING_AGENT_THREAD_OPTIONS,
+  buildCodingAgentThreadOptions,
   buildCodingPrompt,
 } from "./codingAgent.js";
 
@@ -68,5 +69,14 @@ describe("buildCodingPrompt", () => {
   it("keeps Codex configured for workspace-write execution", () => {
     expect(CODING_AGENT_THREAD_OPTIONS.sandboxMode).toBe("workspace-write");
     expect(CODING_AGENT_THREAD_OPTIONS.approvalPolicy).toBe("never");
+  });
+
+  it("builds thread options for a resolved project working directory", () => {
+    const options = buildCodingAgentThreadOptions("/tmp/evolvo/projects/habit-cli");
+
+    expect(options).toEqual({
+      ...CODING_AGENT_THREAD_OPTIONS,
+      workingDirectory: "/tmp/evolvo/projects/habit-cli",
+    });
   });
 });

--- a/src/agents/codingAgent.ts
+++ b/src/agents/codingAgent.ts
@@ -383,6 +383,13 @@ export const CODING_AGENT_THREAD_OPTIONS: ThreadOptions = {
   approvalPolicy: "never",
 };
 
+export function buildCodingAgentThreadOptions(workDir: string): ThreadOptions {
+  return {
+    ...CODING_AGENT_THREAD_OPTIONS,
+    workingDirectory: workDir,
+  };
+}
+
 export function buildCodingPrompt(task: string): string {
   return `${CODING_AGENT_INSTRUCTIONS}\n\nTask:\n${task}`;
 }

--- a/src/agents/runCodingAgent.test.ts
+++ b/src/agents/runCodingAgent.test.ts
@@ -13,6 +13,7 @@ vi.mock("@openai/codex-sdk", () => ({
 
 vi.mock("./codingAgent.js", () => ({
   CODING_AGENT_THREAD_OPTIONS: { sandboxMode: "workspace-write" },
+  buildCodingAgentThreadOptions: (workDir: string) => ({ sandboxMode: "workspace-write", workingDirectory: workDir }),
   buildCodingPrompt: buildCodingPromptMock,
 }));
 
@@ -421,6 +422,49 @@ describe("runCodingAgent", () => {
     expect(result.mergedPullRequest).toBe(true);
     expect(result.summary.mergedExternalPullRequest).toBe(true);
     expect(result.summary.externalRepositories).toContain("https://github.com/other-org/other-repo");
+  });
+
+  it("uses the resolved project workdir and treats the active project repository as internal", async () => {
+    startThreadMock.mockReturnValue({ runStreamed: runStreamedMock });
+    runStreamedMock.mockResolvedValue(createEventStream([
+      {
+        type: "item.completed",
+        item: {
+          id: "1",
+          type: "command_execution",
+          command: "gh pr create --repo evolvo-auto/habit-cli --title \"project\" --body \"project\"",
+          exit_code: 0,
+          aggregated_output: "https://github.com/evolvo-auto/habit-cli/pull/7",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "2",
+          type: "file_change",
+          status: "completed",
+          changes: [{ kind: "add", path: "notes.md" }],
+        },
+      },
+    ]));
+
+    const { configureCodingAgentExecutionContext, runCodingAgent } = await import("./runCodingAgent.js");
+    configureCodingAgentExecutionContext({
+      workDir: "/tmp/evolvo/projects/habit-cli",
+      internalRepositoryUrls: [
+        "https://github.com/evolvo-auto/evolvo-ts",
+        "https://github.com/evolvo-auto/habit-cli",
+      ],
+    });
+    const result = await runCodingAgent("Create managed project pull request");
+
+    expect(startThreadMock).toHaveBeenCalledWith({
+      sandboxMode: "workspace-write",
+      workingDirectory: "/tmp/evolvo/projects/habit-cli",
+    });
+    expect(result.summary.externalRepositories).toEqual([]);
+    expect(result.summary.externalPullRequests).toEqual([]);
+    expect(result.summary.mergedExternalPullRequest).toBe(false);
   });
 
   it("does not treat arbitrary command text as validation execution", async () => {

--- a/src/agents/runCodingAgent.ts
+++ b/src/agents/runCodingAgent.ts
@@ -1,11 +1,12 @@
 import { Codex, Thread, type ThreadItem } from "@openai/codex-sdk";
 import {
-  CODING_AGENT_THREAD_OPTIONS,
+  buildCodingAgentThreadOptions,
   buildCodingPrompt,
 } from "./codingAgent.js";
+import { WORK_DIR } from "../constants/workDir.js";
 
 const codex = new Codex();
-let activeThread: Thread | null = null;
+const activeThreads = new Map<string, Thread>();
 const GITHUB_REPOSITORY_URL_PATTERN = /https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:\.git)?(?:\/)?/gi;
 const GITHUB_PULL_REQUEST_URL_PATTERN = /https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/\d+/gi;
 const INSPECTION_COMMAND_NAMES = new Set(["rg", "grep", "cat", "sed", "ls", "find", "fd", "tree"]);
@@ -63,12 +64,55 @@ type RuntimeFacts = {
   pullRequestCreated: boolean;
 };
 
-function getThread(): Thread {
-  if (!activeThread) {
-    activeThread = codex.startThread(CODING_AGENT_THREAD_OPTIONS);
+export type CodingAgentExecutionContext = {
+  workDir: string;
+  internalRepositoryUrls: string[];
+};
+
+let currentExecutionContext: CodingAgentExecutionContext | null = null;
+
+function normalizeInternalRepositoryUrls(urls: string[]): string[] {
+  const normalizedUrls = urls
+    .map((url) => normalizeRepositoryUrl(url))
+    .filter((url) => url.length > 0);
+  return [...new Set(normalizedUrls)];
+}
+
+function getDefaultExecutionContext(): CodingAgentExecutionContext {
+  const configuredRepositoryUrl = getConfiguredRepositoryUrl();
+  return {
+    workDir: WORK_DIR,
+    internalRepositoryUrls: configuredRepositoryUrl ? [configuredRepositoryUrl] : [],
+  };
+}
+
+export function configureCodingAgentExecutionContext(context: CodingAgentExecutionContext): void {
+  currentExecutionContext = {
+    workDir: context.workDir,
+    internalRepositoryUrls: normalizeInternalRepositoryUrls(context.internalRepositoryUrls),
+  };
+}
+
+function getExecutionContext(): CodingAgentExecutionContext {
+  if (currentExecutionContext === null) {
+    return getDefaultExecutionContext();
   }
 
-  return activeThread;
+  return {
+    workDir: currentExecutionContext.workDir,
+    internalRepositoryUrls: normalizeInternalRepositoryUrls(currentExecutionContext.internalRepositoryUrls),
+  };
+}
+
+function getThread(workDir: string): Thread {
+  const existingThread = activeThreads.get(workDir);
+  if (existingThread) {
+    return existingThread;
+  }
+
+  const nextThread = codex.startThread(buildCodingAgentThreadOptions(workDir));
+  activeThreads.set(workDir, nextThread);
+  return nextThread;
 }
 
 function isFileEditRequest(prompt: string): boolean {
@@ -312,12 +356,13 @@ function getConfiguredRepositoryUrl(): string | null {
   return `https://github.com/${owner}/${repo}`;
 }
 
-function isExternalRepositoryUrl(url: string, configuredRepositoryUrl: string | null): boolean {
-  if (!configuredRepositoryUrl) {
+function isExternalRepositoryUrl(url: string, internalRepositoryUrls: string[]): boolean {
+  if (internalRepositoryUrls.length === 0) {
     return true;
   }
 
-  return normalizeRepositoryUrl(url).toLowerCase() !== normalizeRepositoryUrl(configuredRepositoryUrl).toLowerCase();
+  const normalizedUrl = normalizeRepositoryUrl(url).toLowerCase();
+  return !internalRepositoryUrls.some((internalRepositoryUrl) => normalizeRepositoryUrl(internalRepositoryUrl).toLowerCase() === normalizedUrl);
 }
 
 function logCompletedItem(item: ThreadItem, details?: CommandExecutionLogDetails): void {
@@ -372,7 +417,8 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
   console.log("=== Run starting ===");
   console.log(`[user] ${prompt}\n`);
 
-  const thread = getThread();
+  const executionContext = getExecutionContext();
+  const thread = getThread(executionContext.workDir);
   const { events } = await thread.runStreamed(buildCodingPrompt(prompt));
 
   const startedItems = new Set<string>();
@@ -391,18 +437,18 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
     pullRequestCreated: false,
   };
   let finalResponse = "";
-  const configuredRepositoryUrl = getConfiguredRepositoryUrl();
+  const internalRepositoryUrls = executionContext.internalRepositoryUrls;
 
   function captureExternalReferences(text: string): void {
     for (const repositoryUrl of extractGitHubRepositoryUrls(text)) {
-      if (isExternalRepositoryUrl(repositoryUrl, configuredRepositoryUrl)) {
+      if (isExternalRepositoryUrl(repositoryUrl, internalRepositoryUrls)) {
         externalRepositories.add(repositoryUrl);
       }
     }
 
     for (const pullRequestUrl of extractGitHubPullRequestUrls(text)) {
       const pullRequestRepositoryUrl = pullRequestUrl.replace(/\/pull\/\d+$/, "");
-      if (isExternalRepositoryUrl(pullRequestRepositoryUrl, configuredRepositoryUrl)) {
+      if (isExternalRepositoryUrl(pullRequestRepositoryUrl, internalRepositoryUrls)) {
         externalPullRequests.add(pullRequestUrl);
         externalRepositories.add(pullRequestRepositoryUrl);
       }
@@ -453,7 +499,7 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
         captureExternalReferences(event.item.aggregated_output);
 
         for (const repositoryUrl of extractGhRepoFlagUrls(contract.parsedCommand.args)) {
-          if (isExternalRepositoryUrl(repositoryUrl, configuredRepositoryUrl)) {
+          if (isExternalRepositoryUrl(repositoryUrl, internalRepositoryUrls)) {
             externalRepositories.add(repositoryUrl);
           }
         }
@@ -468,7 +514,7 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
           const mergedPullRequestUrls = extractGitHubPullRequestUrls(mergeText);
           const mergedExternal = mergedPullRequestUrls.some((pullRequestUrl) => {
             const pullRequestRepositoryUrl = pullRequestUrl.replace(/\/pull\/\d+$/, "");
-            return isExternalRepositoryUrl(pullRequestRepositoryUrl, configuredRepositoryUrl);
+            return isExternalRepositoryUrl(pullRequestRepositoryUrl, internalRepositoryUrls);
           });
 
           const mergedRepositoryUrls = [
@@ -476,7 +522,7 @@ export async function runCodingAgent(prompt: string): Promise<CodingAgentRunResu
             ...extractGitHubRepositoryUrls(mergeText),
           ];
           const mergedExternalRepository = mergedRepositoryUrls.some((repositoryUrl) =>
-            isExternalRepositoryUrl(repositoryUrl, configuredRepositoryUrl)
+            isExternalRepositoryUrl(repositoryUrl, internalRepositoryUrls)
           );
 
           if (mergedExternal || mergedExternalRepository) {

--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const runCodingAgentMock = vi.fn();
+const configureCodingAgentExecutionContextMock = vi.fn();
 const runPlannerAgentMock = vi.fn();
 const generateStartupIssueTemplatesMock = vi.fn();
 const runIssueCommandMock = vi.fn();
@@ -15,6 +16,9 @@ const transitionCanonicalLifecycleStateMock = vi.fn();
 const buildLifecycleStateCommentMock = vi.fn();
 const writeRuntimeReadinessSignalMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
+const ensureProjectRegistryMock = vi.fn();
+const resolveProjectExecutionContextForIssueMock = vi.fn();
+const buildProjectRoutingBlockedCommentMock = vi.fn();
 
 type MockIssue = {
   number: number;
@@ -97,6 +101,7 @@ vi.mock("./constants/workDir.js", () => ({
 }));
 
 vi.mock("./agents/runCodingAgent.js", () => ({
+  configureCodingAgentExecutionContext: configureCodingAgentExecutionContextMock,
   runCodingAgent: runCodingAgentMock,
 }));
 
@@ -148,6 +153,27 @@ vi.mock("./runtime/lifecycleState.js", () => ({
 
 vi.mock("./runtime/runtimeReadiness.js", () => ({
   writeRuntimeReadinessSignal: writeRuntimeReadinessSignalMock,
+}));
+
+vi.mock("./projects/projectRegistry.js", () => ({
+  buildDefaultProjectContext: (context: {
+    owner: string;
+    repo: string;
+    workDir: string;
+    defaultBranch?: string | null;
+  }) => ({
+    owner: context.owner,
+    repo: context.repo,
+    workDir: context.workDir,
+    defaultBranch: context.defaultBranch ?? null,
+  }),
+  ensureProjectRegistry: ensureProjectRegistryMock,
+}));
+
+vi.mock("./projects/projectExecutionContext.js", () => ({
+  PROJECT_ROUTING_BLOCKED_LABEL: "blocked",
+  buildProjectRoutingBlockedComment: buildProjectRoutingBlockedCommentMock,
+  resolveProjectExecutionContextForIssue: resolveProjectExecutionContextForIssueMock,
 }));
 
 vi.mock("./github/githubConfig.js", () => ({
@@ -227,6 +253,8 @@ describe("main replenishment integration", () => {
     runIssueCommandMock.mockReset();
     runIssueCommandMock.mockResolvedValue(false);
     runCodingAgentMock.mockReset();
+    configureCodingAgentExecutionContextMock.mockReset();
+    configureCodingAgentExecutionContextMock.mockImplementation(() => undefined);
     runPlannerAgentMock.mockReset();
     generateStartupIssueTemplatesMock.mockReset();
     generateStartupIssueTemplatesMock.mockResolvedValue([]);
@@ -289,6 +317,78 @@ describe("main replenishment integration", () => {
     runPostMergeSelfRestartMock.mockResolvedValue(undefined);
     tryResolveRepositoryDefaultBranchMock.mockReset();
     tryResolveRepositoryDefaultBranchMock.mockResolvedValue("main");
+    ensureProjectRegistryMock.mockReset();
+    ensureProjectRegistryMock.mockResolvedValue({
+      version: 1,
+      projects: [
+        {
+          slug: "evolvo",
+          displayName: "Evolvo",
+          kind: "default",
+          issueLabel: "project:evolvo",
+          trackerRepo: {
+            owner: "owner",
+            repo: "repo",
+            url: "https://github.com/owner/repo",
+          },
+          executionRepo: {
+            owner: "owner",
+            repo: "repo",
+            url: "https://github.com/owner/repo",
+            defaultBranch: "main",
+          },
+          cwd: "/tmp/evolvo",
+          status: "active",
+          sourceIssueNumber: null,
+          createdAt: "2026-03-07T12:00:00.000Z",
+          updatedAt: "2026-03-07T12:00:00.000Z",
+          provisioning: {
+            labelCreated: false,
+            repoCreated: true,
+            workspacePrepared: true,
+            lastError: null,
+          },
+        },
+      ],
+    });
+    resolveProjectExecutionContextForIssueMock.mockReset();
+    resolveProjectExecutionContextForIssueMock.mockResolvedValue({
+      ok: true,
+      context: {
+        project: {
+          slug: "evolvo",
+          displayName: "Evolvo",
+          kind: "default",
+          issueLabel: "project:evolvo",
+          trackerRepo: {
+            owner: "owner",
+            repo: "repo",
+            url: "https://github.com/owner/repo",
+          },
+          executionRepo: {
+            owner: "owner",
+            repo: "repo",
+            url: "https://github.com/owner/repo",
+            defaultBranch: "main",
+          },
+          cwd: "/tmp/evolvo",
+          status: "active",
+          sourceIssueNumber: null,
+          createdAt: "2026-03-07T12:00:00.000Z",
+          updatedAt: "2026-03-07T12:00:00.000Z",
+          provisioning: {
+            labelCreated: false,
+            repoCreated: true,
+            workspacePrepared: true,
+            lastError: null,
+          },
+        },
+        trackerRepository: "owner/repo",
+        executionRepository: "owner/repo",
+      },
+    });
+    buildProjectRoutingBlockedCommentMock.mockReset();
+    buildProjectRoutingBlockedCommentMock.mockReturnValue("## Project Routing Blocked");
     getGitHubConfigMock.mockReset();
     getGitHubConfigMock.mockReturnValue({
       token: "token",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -32,6 +32,10 @@ const stopDiscordGracefulShutdownListenerMock = vi.fn();
 const readGracefulShutdownRequestMock = vi.fn();
 const clearGracefulShutdownRequestMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
+const configureCodingAgentExecutionContextMock = vi.fn();
+const ensureProjectRegistryMock = vi.fn();
+const resolveProjectExecutionContextForIssueMock = vi.fn();
+const buildProjectRoutingBlockedCommentMock = vi.fn();
 const createProjectProvisioningRequestIssueMock = vi.fn();
 const executeProjectProvisioningIssueMock = vi.fn();
 const isProjectProvisioningRequestIssueMock = vi.fn();
@@ -54,6 +58,39 @@ const DEFAULT_RUN_RESULT = {
   },
 };
 
+const DEFAULT_PROJECT_EXECUTION_CONTEXT = {
+  project: {
+    slug: "evolvo",
+    displayName: "Evolvo",
+    kind: "default" as const,
+    issueLabel: "project:evolvo",
+    trackerRepo: {
+      owner: "owner",
+      repo: "repo",
+      url: "https://github.com/owner/repo",
+    },
+    executionRepo: {
+      owner: "owner",
+      repo: "repo",
+      url: "https://github.com/owner/repo",
+      defaultBranch: "main",
+    },
+    cwd: "/tmp/evolvo",
+    status: "active" as const,
+    sourceIssueNumber: null,
+    createdAt: "2026-03-07T12:00:00.000Z",
+    updatedAt: "2026-03-07T12:00:00.000Z",
+    provisioning: {
+      labelCreated: false,
+      repoCreated: true,
+      workspacePrepared: true,
+      lastError: null,
+    },
+  },
+  trackerRepository: "owner/repo",
+  executionRepository: "owner/repo",
+};
+
 vi.mock("./environment.js", () => ({
   GITHUB_OWNER: "owner",
   GITHUB_REPO: "repo",
@@ -64,6 +101,7 @@ vi.mock("./constants/workDir.js", () => ({
 }));
 
 vi.mock("./agents/runCodingAgent.js", () => ({
+  configureCodingAgentExecutionContext: configureCodingAgentExecutionContextMock,
   runCodingAgent: runCodingAgentMock,
 }));
 
@@ -134,6 +172,27 @@ vi.mock("./projects/projectProvisioning.js", () => ({
   isProjectProvisioningRequestIssue: isProjectProvisioningRequestIssueMock,
 }));
 
+vi.mock("./projects/projectRegistry.js", () => ({
+  buildDefaultProjectContext: (context: {
+    owner: string;
+    repo: string;
+    workDir: string;
+    defaultBranch?: string | null;
+  }) => ({
+    owner: context.owner,
+    repo: context.repo,
+    workDir: context.workDir,
+    defaultBranch: context.defaultBranch ?? null,
+  }),
+  ensureProjectRegistry: ensureProjectRegistryMock,
+}));
+
+vi.mock("./projects/projectExecutionContext.js", () => ({
+  PROJECT_ROUTING_BLOCKED_LABEL: "blocked",
+  buildProjectRoutingBlockedComment: buildProjectRoutingBlockedCommentMock,
+  resolveProjectExecutionContextForIssue: resolveProjectExecutionContextForIssueMock,
+}));
+
 vi.mock("./issues/runIssueCommand.js", () => ({
   runIssueCommand: runIssueCommandMock,
 }));
@@ -174,6 +233,8 @@ describe("main", () => {
     delete process.env.EVOLVO_READINESS_FILE;
     runCodingAgentMock.mockReset();
     runCodingAgentMock.mockResolvedValue(DEFAULT_RUN_RESULT);
+    configureCodingAgentExecutionContextMock.mockReset();
+    configureCodingAgentExecutionContextMock.mockImplementation(() => undefined);
     runPlannerAgentMock.mockReset();
     generateStartupIssueTemplatesMock.mockReset();
     generateStartupIssueTemplatesMock.mockResolvedValue([]);
@@ -261,6 +322,15 @@ describe("main", () => {
     buildProjectProvisioningOutcomeCommentMock.mockReturnValue("## Project Provisioning");
     buildProjectProvisioningCompletionSummaryMock.mockReset();
     buildProjectProvisioningCompletionSummaryMock.mockReturnValue("Provisioning complete summary");
+    ensureProjectRegistryMock.mockReset();
+    ensureProjectRegistryMock.mockResolvedValue({ version: 1, projects: [DEFAULT_PROJECT_EXECUTION_CONTEXT.project] });
+    resolveProjectExecutionContextForIssueMock.mockReset();
+    resolveProjectExecutionContextForIssueMock.mockResolvedValue({
+      ok: true,
+      context: DEFAULT_PROJECT_EXECUTION_CONTEXT,
+    });
+    buildProjectRoutingBlockedCommentMock.mockReset();
+    buildProjectRoutingBlockedCommentMock.mockReturnValue("## Project Routing Blocked");
     runIssueCommandMock.mockReset();
     runIssueCommandMock.mockResolvedValue(false);
     getGitHubConfigMock.mockReset();
@@ -535,8 +605,17 @@ describe("main", () => {
       issueNumber: 12,
       issueTitle: "Fix login redirect",
       issueUrl: "https://github.com/owner/repo/issues/12",
-      repository: "owner/repo",
+      trackerRepository: "owner/repo",
+      executionProject: "Evolvo (`evolvo`)",
+      executionRepository: "owner/repo",
       lifecycleState: "selected -> executing",
+    });
+    expect(configureCodingAgentExecutionContextMock).toHaveBeenCalledWith({
+      workDir: "/tmp/evolvo",
+      internalRepositoryUrls: [
+        "https://github.com/owner/repo",
+        "https://github.com/owner/repo",
+      ],
     });
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #12: Fix login redirect\n\nHandle callback URL.");
     expect(console.log).toHaveBeenCalledWith("Cycle 1 queue health: open=1 selected=#12");
@@ -545,6 +624,109 @@ describe("main", () => {
     expect(replenishSelfImprovementIssuesMock).toHaveBeenCalledWith(
       expect.objectContaining({ minimumIssueCount: 3, maximumOpenIssues: 5 }),
     );
+  });
+
+  it("resolves managed-project execution context before running the coding agent", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 14, title: "Managed repo issue", description: "Use project context", state: "open", labels: ["project:habit-cli"] },
+      ])
+      .mockResolvedValueOnce([]);
+    resolveProjectExecutionContextForIssueMock.mockResolvedValueOnce({
+      ok: true,
+      context: {
+        project: {
+          slug: "habit-cli",
+          displayName: "Habit CLI",
+          kind: "managed",
+          issueLabel: "project:habit-cli",
+          trackerRepo: {
+            owner: "owner",
+            repo: "repo",
+            url: "https://github.com/owner/repo",
+          },
+          executionRepo: {
+            owner: "owner",
+            repo: "habit-cli",
+            url: "https://github.com/owner/habit-cli",
+            defaultBranch: "main",
+          },
+          cwd: "/tmp/evolvo/projects/habit-cli",
+          status: "active",
+          sourceIssueNumber: 318,
+          createdAt: "2026-03-07T12:00:00.000Z",
+          updatedAt: "2026-03-07T12:00:00.000Z",
+          provisioning: {
+            labelCreated: true,
+            repoCreated: true,
+            workspacePrepared: true,
+            lastError: null,
+          },
+        },
+        trackerRepository: "owner/repo",
+        executionRepository: "owner/habit-cli",
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(notifyIssueStartedInDiscordMock).toHaveBeenCalledWith({
+      issueNumber: 14,
+      issueTitle: "Managed repo issue",
+      issueUrl: "https://github.com/owner/repo/issues/14",
+      trackerRepository: "owner/repo",
+      executionProject: "Habit CLI (`habit-cli`)",
+      executionRepository: "owner/habit-cli",
+      lifecycleState: "selected -> executing",
+    });
+    expect(configureCodingAgentExecutionContextMock).toHaveBeenCalledWith({
+      workDir: "/tmp/evolvo/projects/habit-cli",
+      internalRepositoryUrls: [
+        "https://github.com/owner/repo",
+        "https://github.com/owner/habit-cli",
+      ],
+    });
+    expect(addProgressCommentMock).toHaveBeenCalledWith(
+      14,
+      expect.stringContaining("Execution repository: `owner/habit-cli`."),
+    );
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #14: Managed repo issue\n\nUse project context");
+  });
+
+  it("blocks issues with invalid project labels before execution", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 15, title: "Broken project labels", description: "bad", state: "open", labels: ["project:missing"] },
+        { number: 16, title: "Fallback issue", description: "good", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([
+        { number: 15, title: "Broken project labels", description: "bad", state: "open", labels: ["project:missing", "blocked"] },
+        { number: 16, title: "Fallback issue", description: "good", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    resolveProjectExecutionContextForIssueMock
+      .mockResolvedValueOnce({
+        ok: false,
+        code: "unknown-project",
+        message: "No project registry entry exists for label `project:missing`.",
+        projectLabels: ["project:missing"],
+      })
+      .mockResolvedValue({
+        ok: true,
+        context: DEFAULT_PROJECT_EXECUTION_CONTEXT,
+      });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #16: Fallback issue\n\ngood");
+    expect(addProgressCommentMock).toHaveBeenCalledWith(15, "## Project Routing Blocked");
+    expect(updateLabelsMock).toHaveBeenCalledWith(15, {
+      add: ["blocked"],
+      remove: ["in progress"],
+    });
   });
 
   it("logs validation command name, status, and elapsed time in lifecycle comments", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import { pathToFileURL } from "node:url";
 import type { CodingAgentRunResult } from "./agents/runCodingAgent.js";
-import { runCodingAgent } from "./agents/runCodingAgent.js";
+import { configureCodingAgentExecutionContext, runCodingAgent } from "./agents/runCodingAgent.js";
 import { runPlannerAgent } from "./agents/plannerAgent.js";
 import { WORK_DIR } from "./constants/workDir.js";
 import { GitHubAdminClient } from "./github/githubAdminClient.js";
@@ -67,6 +67,16 @@ import {
   executeProjectProvisioningIssue,
   isProjectProvisioningRequestIssue,
 } from "./projects/projectProvisioning.js";
+import {
+  PROJECT_ROUTING_BLOCKED_LABEL,
+  buildProjectRoutingBlockedComment,
+  resolveProjectExecutionContextForIssue,
+  type ProjectExecutionContext,
+} from "./projects/projectExecutionContext.js";
+import {
+  buildDefaultProjectContext,
+  ensureProjectRegistry,
+} from "./projects/projectRegistry.js";
 
 const MAX_ISSUE_CYCLES = 5;
 const MIN_REPLENISH_ISSUES = 3;
@@ -106,6 +116,10 @@ function mapReviewOutcomeToLifecycleState(reviewOutcome: string): "accepted" | "
   }
 
   return "rejected";
+}
+
+function buildExecutionProjectDisplay(context: ProjectExecutionContext): string {
+  return `${context.project.displayName} (\`${context.project.slug}\`)`;
 }
 
 async function transitionIssueLifecycleState(
@@ -230,6 +244,11 @@ export async function main(): Promise<void> {
   const issueManager = new TaskIssueManager(githubClient);
   const adminClient = new GitHubAdminClient(githubClient, githubConfig);
   const repositoryName = `${GITHUB_OWNER}/${GITHUB_REPO}`;
+  const defaultProjectContext = buildDefaultProjectContext({
+    owner: GITHUB_OWNER,
+    repo: GITHUB_REPO,
+    workDir: WORK_DIR,
+  });
   const discordHandlers: DiscordControlHandlers = {
     onStartProject: async (request) =>
       createProjectProvisioningRequestIssue({
@@ -245,6 +264,7 @@ export async function main(): Promise<void> {
 
   console.log(`Hello from ${GITHUB_OWNER}/${GITHUB_REPO}!`);
   console.log(`Working directory: ${WORK_DIR}`);
+  await ensureProjectRegistry(WORK_DIR, defaultProjectContext);
   await signalRestartReadinessIfRequested(WORK_DIR);
   await runDiscordOperatorControlStartupCheck();
   const gracefulShutdownListener = await startDiscordGracefulShutdownListener(WORK_DIR, discordHandlers);
@@ -382,6 +402,32 @@ export async function main(): Promise<void> {
             openCount: openIssues.length,
             selectedIssue,
           });
+          const projectResolution = await resolveProjectExecutionContextForIssue({
+            issue: selectedIssue,
+            workDir: WORK_DIR,
+            defaultProject: defaultProjectContext,
+          });
+          if (!projectResolution.ok) {
+            const routingComment = buildProjectRoutingBlockedComment(selectedIssue, projectResolution);
+            await addIssueLifecycleComment(issueManager, selectedIssue.number, routingComment);
+            await transitionIssueLifecycleState(issueManager, {
+              issue: selectedIssue,
+              nextState: "blocked",
+              reason: `project routing blocked: ${projectResolution.message}`,
+              cycle,
+            });
+            const blockLabelResult = await issueManager.updateLabels(selectedIssue.number, {
+              add: [PROJECT_ROUTING_BLOCKED_LABEL],
+              remove: ["in progress"],
+            });
+            if (!blockLabelResult.ok) {
+              console.error(`Could not block issue #${selectedIssue.number} for invalid project routing: ${blockLabelResult.message}`);
+              continue issueCycleLoop;
+            }
+            continue;
+          }
+
+          const executionContext = projectResolution.context;
           await transitionIssueLifecycleState(issueManager, {
             issue: selectedIssue,
             nextState: "selected",
@@ -400,12 +446,14 @@ export async function main(): Promise<void> {
           }
 
           if (startedThisCycle) {
-            await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue));
+            await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue, executionContext));
             await notifyIssueStartedInDiscord({
               issueNumber: selectedIssue.number,
               issueTitle: selectedIssue.title,
               issueUrl: `https://github.com/${repositoryName}/issues/${selectedIssue.number}`,
-              repository: repositoryName,
+              trackerRepository: repositoryName,
+              executionProject: buildExecutionProjectDisplay(executionContext),
+              executionRepository: executionContext.executionRepository,
               lifecycleState: "selected -> executing",
             });
           }
@@ -493,6 +541,13 @@ export async function main(): Promise<void> {
 
           const prompt = buildPromptFromIssue(selectedIssue);
           console.log(`Prompt: ${prompt}`);
+          configureCodingAgentExecutionContext({
+            workDir: executionContext.project.cwd,
+            internalRepositoryUrls: [
+              executionContext.project.trackerRepo.url,
+              executionContext.project.executionRepo.url,
+            ],
+          });
           let runError: unknown = null;
           const runResult = await runCodingAgent(prompt).catch((error) => {
             runError = error;
@@ -520,7 +575,7 @@ export async function main(): Promise<void> {
           let mergedDefaultBranch: string | null = null;
           if (runResult) {
             mergedDefaultBranch = runResult.mergedPullRequest
-              ? await tryResolveRepositoryDefaultBranch(WORK_DIR)
+              ? await tryResolveRepositoryDefaultBranch(executionContext.project.cwd)
               : null;
             await transitionIssueLifecycleState(issueManager, {
               issue: selectedIssue,
@@ -559,7 +614,7 @@ export async function main(): Promise<void> {
             await addIssueLifecycleComment(
               issueManager,
               selectedIssue.number,
-              buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence, mergedDefaultBranch),
+              buildIssueExecutionComment(selectedIssue, runResult, challengeEvidence, mergedDefaultBranch, executionContext),
             );
             const challengeCompleted = await finalizeChallengeSuccess(
               issueManager,
@@ -591,26 +646,30 @@ export async function main(): Promise<void> {
               selectedIssue.number,
               buildMergeOutcomeComment(selectedIssue, mergedDefaultBranch),
             );
-            console.log("Merged pull request detected. Running post-merge restart workflow.");
-            try {
-              await runPostMergeSelfRestart(WORK_DIR);
-              await transitionIssueLifecycleState(issueManager, {
-                issue: selectedIssue,
-                nextState: "restarted",
-                reason: "post-merge restart workflow completed successfully",
-                cycle,
-                runResult,
-              });
-              console.log("Post-merge restart workflow completed. Exiting current runtime.");
-            } catch (error) {
-              if (error instanceof Error) {
-                console.error(error.message);
-              } else {
-                console.error("Post-merge restart failed with an unknown error.");
+            if (executionContext.project.kind === "default") {
+              console.log("Merged pull request detected. Running post-merge restart workflow.");
+              try {
+                await runPostMergeSelfRestart(WORK_DIR);
+                await transitionIssueLifecycleState(issueManager, {
+                  issue: selectedIssue,
+                  nextState: "restarted",
+                  reason: "post-merge restart workflow completed successfully",
+                  cycle,
+                  runResult,
+                });
+                console.log("Post-merge restart workflow completed. Exiting current runtime.");
+              } catch (error) {
+                if (error instanceof Error) {
+                  console.error(error.message);
+                } else {
+                  console.error("Post-merge restart failed with an unknown error.");
+                }
               }
+
+              return;
             }
 
-            return;
+            console.log("Merged pull request detected for a managed project. Continuing without self-restart.");
           }
 
           if (

--- a/src/projects/projectExecutionContext.test.ts
+++ b/src/projects/projectExecutionContext.test.ts
@@ -1,0 +1,214 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { IssueSummary } from "../issues/taskIssueManager.js";
+import { DEFAULT_PROJECT_SLUG } from "./projectNaming.js";
+import {
+  buildProjectRoutingBlockedComment,
+  resolveProjectExecutionContextForIssue,
+  resolveProjectExecutionContextFromRegistry,
+} from "./projectExecutionContext.js";
+import {
+  readProjectRegistry,
+  upsertProjectRecord,
+  type ProjectRecord,
+} from "./projectRegistry.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "project-execution-context-"));
+}
+
+function createIssue(overrides: Partial<IssueSummary> = {}): IssueSummary {
+  return {
+    number: 42,
+    title: "Route this issue",
+    description: "context",
+    state: "open",
+    labels: [],
+    ...overrides,
+  };
+}
+
+function createManagedProject(workDir: string, overrides: Partial<ProjectRecord> = {}): ProjectRecord {
+  return {
+    slug: "habit-cli",
+    displayName: "Habit CLI",
+    kind: "managed",
+    issueLabel: "project:habit-cli",
+    trackerRepo: {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      url: "https://github.com/evolvo-auto/evolvo-ts",
+    },
+    executionRepo: {
+      owner: "evolvo-auto",
+      repo: "habit-cli",
+      url: "https://github.com/evolvo-auto/habit-cli",
+      defaultBranch: "main",
+    },
+    cwd: join(workDir, "projects", "habit-cli"),
+    status: "active",
+    sourceIssueNumber: 318,
+    createdAt: "2026-03-07T12:00:00.000Z",
+    updatedAt: "2026-03-07T12:00:00.000Z",
+    provisioning: {
+      labelCreated: true,
+      repoCreated: true,
+      workspacePrepared: true,
+      lastError: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("projectExecutionContext", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+  });
+
+  it("resolves unlabeled issues to the default Evolvo project", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const resolution = await resolveProjectExecutionContextForIssue({
+      issue: createIssue(),
+      workDir,
+      defaultProject: {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+        defaultBranch: "main",
+      },
+    });
+
+    expect(resolution).toEqual({
+      ok: true,
+      context: expect.objectContaining({
+        project: expect.objectContaining({
+          slug: DEFAULT_PROJECT_SLUG,
+          issueLabel: "project:evolvo",
+          cwd: workDir,
+        }),
+        trackerRepository: "evolvo-auto/evolvo-ts",
+        executionRepository: "evolvo-auto/evolvo-ts",
+      }),
+    });
+  });
+
+  it("treats project:evolvo as the default project alias", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const registry = await readProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    const resolution = resolveProjectExecutionContextFromRegistry(
+      createIssue({ labels: ["project:evolvo"] }),
+      registry,
+    );
+
+    expect(resolution).toEqual({
+      ok: true,
+      context: expect.objectContaining({
+        project: expect.objectContaining({
+          slug: DEFAULT_PROJECT_SLUG,
+        }),
+      }),
+    });
+  });
+
+  it("resolves project-labelled issues to the matching managed project", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await upsertProjectRecord(
+      workDir,
+      {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+        defaultBranch: "main",
+      },
+      createManagedProject(workDir),
+    );
+
+    const resolution = await resolveProjectExecutionContextForIssue({
+      issue: createIssue({ labels: ["project:habit-cli"] }),
+      workDir,
+      defaultProject: {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+        defaultBranch: "main",
+      },
+    });
+
+    expect(resolution).toEqual({
+      ok: true,
+      context: expect.objectContaining({
+        project: expect.objectContaining({
+          slug: "habit-cli",
+          cwd: join(workDir, "projects", "habit-cli"),
+        }),
+        trackerRepository: "evolvo-auto/evolvo-ts",
+        executionRepository: "evolvo-auto/habit-cli",
+      }),
+    });
+  });
+
+  it("blocks issues with unknown project labels and gives actionable guidance", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const registry = await readProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    const resolution = resolveProjectExecutionContextFromRegistry(
+      createIssue({ labels: ["project:missing-project"] }),
+      registry,
+    );
+
+    expect(resolution).toEqual({
+      ok: false,
+      code: "unknown-project",
+      message: "No project registry entry exists for label `project:missing-project`.",
+      projectLabels: ["project:missing-project"],
+    });
+    if (resolution.ok) {
+      throw new Error("Expected project resolution to be blocked for an unknown project label.");
+    }
+    expect(buildProjectRoutingBlockedComment(createIssue(), resolution)).toContain("remove the `blocked` label to retry execution");
+  });
+
+  it("blocks issues with multiple project labels", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const registry = await readProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    const resolution = resolveProjectExecutionContextFromRegistry(
+      createIssue({ labels: ["project:habit-cli", "project:other-project"] }),
+      registry,
+    );
+
+    expect(resolution).toEqual({
+      ok: false,
+      code: "multiple-project-labels",
+      message: "Issue has multiple project labels: project:habit-cli, project:other-project.",
+      projectLabels: ["project:habit-cli", "project:other-project"],
+    });
+  });
+});

--- a/src/projects/projectExecutionContext.ts
+++ b/src/projects/projectExecutionContext.ts
@@ -1,0 +1,141 @@
+import type { IssueSummary } from "../issues/taskIssueManager.js";
+import { DEFAULT_PROJECT_SLUG, PROJECT_LABEL_PREFIX } from "./projectNaming.js";
+import {
+  readProjectRegistry,
+  type DefaultProjectContext,
+  type ProjectRecord,
+} from "./projectRegistry.js";
+
+export const PROJECT_ROUTING_BLOCKED_LABEL = "blocked";
+
+export type ProjectExecutionContext = {
+  project: ProjectRecord;
+  trackerRepository: string;
+  executionRepository: string;
+};
+
+export type ProjectExecutionContextResolution =
+  | {
+    ok: true;
+    context: ProjectExecutionContext;
+  }
+  | {
+    ok: false;
+    code: "multiple-project-labels" | "unknown-project" | "inactive-project";
+    message: string;
+    projectLabels: string[];
+  };
+
+function normalizeProjectLabel(label: string): string | null {
+  const normalized = label.trim().toLowerCase();
+  if (!normalized.startsWith(PROJECT_LABEL_PREFIX)) {
+    return null;
+  }
+
+  const slug = normalized.slice(PROJECT_LABEL_PREFIX.length).trim();
+  if (!slug) {
+    return null;
+  }
+
+  return `${PROJECT_LABEL_PREFIX}${slug}`;
+}
+
+function getProjectLabels(labels: string[]): string[] {
+  const normalizedLabels = labels
+    .map(normalizeProjectLabel)
+    .filter((label): label is string => label !== null);
+  return [...new Set(normalizedLabels)];
+}
+
+function formatRepositoryReference(repository: { owner: string; repo: string }): string {
+  return `${repository.owner}/${repository.repo}`;
+}
+
+function buildExecutionContext(project: ProjectRecord): ProjectExecutionContext {
+  return {
+    project,
+    trackerRepository: formatRepositoryReference(project.trackerRepo),
+    executionRepository: formatRepositoryReference(project.executionRepo),
+  };
+}
+
+export function resolveProjectExecutionContextFromRegistry(
+  issue: IssueSummary,
+  registry: { projects: ProjectRecord[] },
+): ProjectExecutionContextResolution {
+  const projectLabels = getProjectLabels(issue.labels);
+  if (projectLabels.length > 1) {
+    return {
+      ok: false,
+      code: "multiple-project-labels",
+      message: `Issue has multiple project labels: ${projectLabels.join(", ")}.`,
+      projectLabels,
+    };
+  }
+
+  const requestedSlug = projectLabels[0]?.slice(PROJECT_LABEL_PREFIX.length) ?? DEFAULT_PROJECT_SLUG;
+  const project = registry.projects.find((candidate) => candidate.slug === requestedSlug) ?? null;
+  if (!project) {
+    return {
+      ok: false,
+      code: "unknown-project",
+      message: `No project registry entry exists for label \`${projectLabels[0]}\`.`,
+      projectLabels,
+    };
+  }
+
+  if (project.status !== "active") {
+    return {
+      ok: false,
+      code: "inactive-project",
+      message: `Project \`${project.slug}\` exists but is not ready for execution (status: \`${project.status}\`).`,
+      projectLabels,
+    };
+  }
+
+  if (requestedSlug === DEFAULT_PROJECT_SLUG && project.slug !== DEFAULT_PROJECT_SLUG) {
+    return {
+      ok: false,
+      code: "unknown-project",
+      message: `The default project label must resolve to \`${DEFAULT_PROJECT_SLUG}\`.`,
+      projectLabels,
+    };
+  }
+
+  return {
+    ok: true,
+    context: buildExecutionContext(project),
+  };
+}
+
+export async function resolveProjectExecutionContextForIssue(options: {
+  issue: IssueSummary;
+  workDir: string;
+  defaultProject: DefaultProjectContext;
+}): Promise<ProjectExecutionContextResolution> {
+  const registry = await readProjectRegistry(options.workDir, options.defaultProject);
+  return resolveProjectExecutionContextFromRegistry(options.issue, registry);
+}
+
+export function buildProjectRoutingBlockedComment(
+  issue: IssueSummary,
+  resolution: Extract<ProjectExecutionContextResolution, { ok: false }>,
+): string {
+  const projectLabelLine = resolution.projectLabels.length > 0
+    ? `- Project labels on the issue: ${resolution.projectLabels.map((label) => `\`${label}\``).join(", ")}`
+    : "- Project labels on the issue: none";
+
+  const actionLine = resolution.code === "multiple-project-labels"
+    ? "- Action: keep exactly one valid `project:<slug>` label, or remove all project labels to route this issue to the default Evolvo project, then remove the `blocked` label to retry execution."
+    : resolution.code === "inactive-project"
+      ? "- Action: finish or repair project provisioning so the registry status becomes `active`, then remove the `blocked` label to retry execution."
+      : "- Action: add a valid `project:<slug>` label from `.evolvo/projects.json`, or remove project labels to route this issue to the default Evolvo project, then remove the `blocked` label to retry execution.";
+
+  return [
+    "## Project Routing Blocked",
+    `- Issue #${issue.number} cannot start because its project routing is invalid.`,
+    projectLabelLine,
+    `- Diagnostic: ${resolution.message}`,
+    actionLine,
+  ].join("\n");
+}

--- a/src/projects/projectRegistry.test.ts
+++ b/src/projects/projectRegistry.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  ensureProjectRegistry,
   findProjectBySlug,
   getProjectRegistryPath,
   readProjectRegistry,
@@ -41,6 +42,31 @@ describe("projectRegistry", () => {
         cwd: workDir,
       }),
     );
+  });
+
+  it("persists the canonical registry file with the default Evolvo project", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const registry = await ensureProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    expect(registry.projects).toHaveLength(1);
+    const persisted = JSON.parse(await readFile(getProjectRegistryPath(workDir), "utf8")) as {
+      projects: Array<{ slug: string; executionRepo: { defaultBranch: string | null } }>;
+    };
+    expect(persisted.projects).toEqual([
+      expect.objectContaining({
+        slug: "evolvo",
+        executionRepo: expect.objectContaining({
+          defaultBranch: "main",
+        }),
+      }),
+    ]);
   });
 
   it("upserts a managed project record while preserving the default project", async () => {

--- a/src/projects/projectRegistry.ts
+++ b/src/projects/projectRegistry.ts
@@ -74,7 +74,17 @@ export function getProjectRegistryPath(workDir: string): string {
   return join(workDir, EVOLVO_DIRECTORY_NAME, PROJECT_REGISTRY_FILE_NAME);
 }
 
+export function buildDefaultProjectContext(context: DefaultProjectContext): DefaultProjectContext {
+  return {
+    owner: context.owner,
+    repo: context.repo,
+    workDir: context.workDir,
+    defaultBranch: context.defaultBranch?.trim() || null,
+  };
+}
+
 export function buildDefaultProjectRecord(context: DefaultProjectContext): ProjectRecord {
+  const normalizedContext = buildDefaultProjectContext(context);
   const createdAt = new Date().toISOString();
   return {
     slug: DEFAULT_PROJECT_SLUG,
@@ -82,17 +92,17 @@ export function buildDefaultProjectRecord(context: DefaultProjectContext): Proje
     kind: "default",
     issueLabel: buildProjectIssueLabel(DEFAULT_PROJECT_SLUG),
     trackerRepo: {
-      owner: context.owner,
-      repo: context.repo,
-      url: buildRepositoryUrl(context.owner, context.repo),
+      owner: normalizedContext.owner,
+      repo: normalizedContext.repo,
+      url: buildRepositoryUrl(normalizedContext.owner, normalizedContext.repo),
     },
     executionRepo: {
-      owner: context.owner,
-      repo: context.repo,
-      url: buildRepositoryUrl(context.owner, context.repo),
-      defaultBranch: context.defaultBranch?.trim() || null,
+      owner: normalizedContext.owner,
+      repo: normalizedContext.repo,
+      url: buildRepositoryUrl(normalizedContext.owner, normalizedContext.repo),
+      defaultBranch: normalizedContext.defaultBranch ?? null,
     },
-    cwd: context.workDir,
+    cwd: normalizedContext.workDir,
     status: "active",
     sourceIssueNumber: null,
     createdAt,
@@ -246,6 +256,15 @@ export async function writeProjectRegistry(workDir: string, registry: ProjectReg
     `${JSON.stringify({ version: PROJECT_REGISTRY_VERSION, projects: registry.projects }, null, 2)}\n`,
     "utf8",
   );
+}
+
+export async function ensureProjectRegistry(
+  workDir: string,
+  defaultProject: DefaultProjectContext,
+): Promise<ProjectRegistry> {
+  const registry = await readProjectRegistry(workDir, defaultProject);
+  await writeProjectRegistry(workDir, registry);
+  return registry;
 }
 
 export async function upsertProjectRecord(

--- a/src/runtime/issueLifecyclePresentation.test.ts
+++ b/src/runtime/issueLifecyclePresentation.test.ts
@@ -64,20 +64,85 @@ describe("issueLifecyclePresentation", () => {
   it("builds task start comment with issue context", () => {
     const issue = createIssue({ number: 88, title: "Add tests" });
 
-    const comment = buildIssueStartComment(issue);
+    const comment = buildIssueStartComment(issue, {
+      project: {
+        slug: "habit-cli",
+        displayName: "Habit CLI",
+        kind: "managed",
+        issueLabel: "project:habit-cli",
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "evolvo-ts",
+          url: "https://github.com/evolvo-auto/evolvo-ts",
+        },
+        executionRepo: {
+          owner: "evolvo-auto",
+          repo: "habit-cli",
+          url: "https://github.com/evolvo-auto/habit-cli",
+          defaultBranch: "main",
+        },
+        cwd: "/tmp/evolvo/projects/habit-cli",
+        status: "active",
+        sourceIssueNumber: 318,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: true,
+          lastError: null,
+        },
+      },
+      trackerRepository: "evolvo-auto/evolvo-ts",
+      executionRepository: "evolvo-auto/habit-cli",
+    });
 
     expect(comment).toContain("## Task Start");
     expect(comment).toContain("issue #88: Add tests");
     expect(comment).toContain("Planned lifecycle logging");
+    expect(comment).toContain("Project: Habit CLI (`habit-cli`).");
+    expect(comment).toContain("Execution repository: `evolvo-auto/habit-cli`.");
   });
 
   it("builds execution comment with validation and external evidence details", () => {
     const issue = createIssue();
     const runResult = createRunResult();
 
-    const comment = buildIssueExecutionComment(issue, runResult, null);
+    const comment = buildIssueExecutionComment(issue, runResult, null, null, {
+      project: {
+        slug: "evolvo",
+        displayName: "Evolvo",
+        kind: "default",
+        issueLabel: "project:evolvo",
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "evolvo-ts",
+          url: "https://github.com/evolvo-auto/evolvo-ts",
+        },
+        executionRepo: {
+          owner: "evolvo-auto",
+          repo: "evolvo-ts",
+          url: "https://github.com/evolvo-auto/evolvo-ts",
+          defaultBranch: "main",
+        },
+        cwd: "/tmp/evolvo",
+        status: "active",
+        sourceIssueNumber: null,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: false,
+          repoCreated: true,
+          workspacePrepared: true,
+          lastError: null,
+        },
+      },
+      trackerRepository: "evolvo-auto/evolvo-ts",
+      executionRepository: "evolvo-auto/evolvo-ts",
+    });
 
     expect(comment).toContain("## Task Execution Log");
+    expect(comment).toContain("Project: Evolvo (`evolvo`).");
     expect(comment).toContain("name=pnpm");
     expect(comment).toContain("status=0");
     expect(comment).toContain("elapsed=155ms");

--- a/src/runtime/issueLifecyclePresentation.ts
+++ b/src/runtime/issueLifecyclePresentation.ts
@@ -2,6 +2,7 @@ import type { CodingAgentRunResult, CommandExecutionSummary } from "../agents/ru
 import { persistChallengeAttemptArtifact } from "../challenges/challengeAttemptArtifacts.js";
 import { isChallengeIssue } from "../issues/challengeIssue.js";
 import type { TaskIssueManager, IssueSummary } from "../issues/taskIssueManager.js";
+import type { ProjectExecutionContext } from "../projects/projectExecutionContext.js";
 import { describeRepositoryDefaultBranch } from "./defaultBranch.js";
 
 export type ChallengeAttemptEvidence = {
@@ -11,6 +12,21 @@ export type ChallengeAttemptEvidence = {
   reviewOutcome: string | null;
   runtimeErrorMessage: string | null;
 };
+
+function buildProjectContextLines(executionContext: ProjectExecutionContext | null | undefined): string[] {
+  if (!executionContext) {
+    return [];
+  }
+
+  return [
+    "",
+    "### Project Context",
+    `- Project: ${executionContext.project.displayName} (\`${executionContext.project.slug}\`).`,
+    `- Tracker repository: \`${executionContext.trackerRepository}\`.`,
+    `- Execution repository: \`${executionContext.executionRepository}\`.`,
+    `- Working directory: \`${executionContext.project.cwd}\`.`,
+  ];
+}
 
 function formatDuration(durationMs: number | null): string {
   if (durationMs === null || !Number.isFinite(durationMs) || durationMs < 0) {
@@ -80,12 +96,16 @@ function formatFinalResponseExcerpt(response: string): string {
   return `${normalized.slice(0, maxLength - 3)}...`;
 }
 
-export function buildIssueStartComment(issue: IssueSummary): string {
+export function buildIssueStartComment(
+  issue: IssueSummary,
+  executionContext: ProjectExecutionContext | null = null,
+): string {
   return [
     "## Task Start",
     `- Started work on issue #${issue.number}: ${issue.title}.`,
     "- Initial assessment: inspect related files, apply a focused implementation, then validate and review.",
     "- Planned lifecycle logging: inspection, implementation decisions, validation steps/results, review outcome, PR/merge status, completion summary.",
+    ...buildProjectContextLines(executionContext),
   ].join("\n");
 }
 
@@ -155,6 +175,7 @@ export function buildIssueExecutionComment(
   result: CodingAgentRunResult,
   challengeEvidence: ChallengeAttemptEvidence | null,
   defaultBranch: string | null = null,
+  executionContext: ProjectExecutionContext | null = null,
 ): string {
   const inspectedAreas = result.summary.inspectedAreas.length > 0
     ? result.summary.inspectedAreas.map((area) => `- \`${area}\``)
@@ -177,9 +198,11 @@ export function buildIssueExecutionComment(
     : ["- No external pull request link captured."];
   const externalMergeLine = `- External pull request merged: ${result.summary.mergedExternalPullRequest ? "yes" : "no"}.`;
   const challengeEvidenceLines = isChallengeIssue(issue) ? buildChallengeEvidenceCommentLines(challengeEvidence) : [];
+  const projectContextLines = buildProjectContextLines(executionContext);
 
   return [
     "## Task Execution Log",
+    ...projectContextLines,
     "",
     "### Inspection",
     ...inspectedAreas,

--- a/src/runtime/loopUtils.test.ts
+++ b/src/runtime/loopUtils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GitHubApiError } from "../github/githubClient.js";
-import { getRunLoopRetryDelayMs, isTransientGitHubError, waitForRunLoopRetry } from "./loopUtils.js";
+import { getRunLoopRetryDelayMs, isTransientGitHubError, selectIssueForWork, waitForRunLoopRetry } from "./loopUtils.js";
 
 describe("loopUtils retry handling", () => {
   afterEach(() => {
@@ -61,5 +61,26 @@ describe("loopUtils retry handling", () => {
     await vi.advanceTimersByTimeAsync(1);
     await retryPromise;
     expect(resolved).toBe(true);
+  });
+
+  it("skips generically blocked issues when selecting work", () => {
+    const selected = selectIssueForWork([
+      {
+        number: 1,
+        title: "Blocked project issue",
+        description: "blocked",
+        state: "open",
+        labels: ["blocked"],
+      },
+      {
+        number: 2,
+        title: "Ready issue",
+        description: "ready",
+        state: "open",
+        labels: [],
+      },
+    ]);
+
+    expect(selected?.number).toBe(2);
   });
 });

--- a/src/runtime/loopUtils.ts
+++ b/src/runtime/loopUtils.ts
@@ -18,7 +18,7 @@ const RUN_LOOP_GITHUB_RETRY_MAX_DELAY_MS = 1_000;
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
 
 export function selectIssueForWork(issues: IssueSummary[]): IssueSummary | null {
-  const notCompleted = issues.filter((issue) => !hasIssueLabel(issue, "completed"));
+  const notCompleted = issues.filter((issue) => !hasIssueLabel(issue, "completed") && !hasIssueLabel(issue, "blocked"));
   if (notCompleted.length === 0) {
     return null;
   }

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -59,7 +59,9 @@ describe("operatorControl", () => {
       issueNumber: 298,
       issueTitle: "Send Discord start embed",
       issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
-      repository: "evolvo-auto/evolvo-ts",
+      trackerRepository: "evolvo-auto/evolvo-ts",
+      executionProject: "Evolvo (`evolvo`)",
+      executionRepository: "evolvo-auto/evolvo-ts",
       lifecycleState: "selected -> executing",
     });
 
@@ -170,7 +172,9 @@ describe("operatorControl", () => {
       issueNumber: 298,
       issueTitle: "Send a Discord embed notification with GitHub issue link when starting a new issue",
       issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
-      repository: "evolvo-auto/evolvo-ts",
+      trackerRepository: "evolvo-auto/evolvo-ts",
+      executionProject: "Evolvo (`evolvo`)",
+      executionRepository: "evolvo-auto/evolvo-ts",
       lifecycleState: "selected -> executing",
     });
 
@@ -203,7 +207,17 @@ describe("operatorControl", () => {
                   inline: true,
                 },
                 {
-                  name: "Repository",
+                  name: "Tracker Repository",
+                  value: "evolvo-auto/evolvo-ts",
+                  inline: true,
+                },
+                {
+                  name: "Execution Project",
+                  value: "Evolvo (`evolvo`)",
+                  inline: true,
+                },
+                {
+                  name: "Execution Repository",
                   value: "evolvo-auto/evolvo-ts",
                   inline: true,
                 },
@@ -251,7 +265,9 @@ describe("operatorControl", () => {
       issueNumber: 298,
       issueTitle: "Send Discord start embed",
       issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
-      repository: "evolvo-auto/evolvo-ts",
+      trackerRepository: "evolvo-auto/evolvo-ts",
+      executionProject: "Evolvo (`evolvo`)",
+      executionRepository: "evolvo-auto/evolvo-ts",
       lifecycleState: "selected -> executing",
     });
 

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -71,7 +71,9 @@ type DiscordIssueStartNotification = {
   issueNumber: number;
   issueTitle: string;
   issueUrl: string;
-  repository: string;
+  trackerRepository: string;
+  executionProject: string;
+  executionRepository: string;
   lifecycleState: string;
 };
 
@@ -243,8 +245,18 @@ async function sendIssueStartNotification(
               inline: true,
             },
             {
-              name: "Repository",
-              value: notification.repository,
+              name: "Tracker Repository",
+              value: notification.trackerRepository,
+              inline: true,
+            },
+            {
+              name: "Execution Project",
+              value: notification.executionProject,
+              inline: true,
+            },
+            {
+              name: "Execution Repository",
+              value: notification.executionRepository,
               inline: true,
             },
           ],


### PR DESCRIPTION
## Summary
- add a canonical project execution-context resolver on top of `.evolvo/projects.json`
- route issue execution through resolved project cwd/repository context and block invalid `project:*` label combinations
- surface tracker/execution project context in lifecycle comments and Discord start notifications while keeping planner/bootstrap on the default project

## Testing
- pnpm vitest run src/projects/projectRegistry.test.ts src/projects/projectExecutionContext.test.ts src/agents/codingAgent.test.ts src/agents/runCodingAgent.test.ts src/runtime/issueLifecyclePresentation.test.ts src/runtime/operatorControl.test.ts src/runtime/loopUtils.test.ts src/main.test.ts
- pnpm vitest run src/main.replenishment.integration.test.ts
- pnpm vitest run src/projects/projectExecutionContext.test.ts
- pnpm typecheck

Fixes #317
