### PR TITLE
fix: recover malformed local state files

### DIFF
--- a/src/challenges/challengeMetrics.test.ts
+++ b/src/challenges/challengeMetrics.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatChallengeMetricsReport,
   readChallengeMetrics,
@@ -16,6 +16,8 @@ describe("challengeMetrics", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
     tempDirs.length = 0;
   });
@@ -159,5 +161,49 @@ describe("challengeMetrics", () => {
 
     expect(metrics.categoryCounts).toEqual({ unknown: 1 });
   });
-});
 
+  it("recovers malformed metrics JSON by preserving the corrupt file and resetting defaults", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-07T22:20:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "challenge-metrics.json");
+    const corruptPath = join(evolvoDir, `challenge-metrics.corrupt-${recoveryAtMs}.json`);
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(statePath, "{\"total\":", "utf8");
+
+    const metrics = await readChallengeMetrics(workDir);
+
+    expect(metrics).toEqual({
+      total: 0,
+      success: 0,
+      failure: 0,
+      attemptsToSuccess: {
+        total: 0,
+        samples: 0,
+        average: 0,
+      },
+      categoryCounts: {},
+      pendingAttemptsByChallenge: {},
+    });
+    expect(await readFile(corruptPath, "utf8")).toBe("{\"total\":");
+    expect(JSON.parse(await readFile(statePath, "utf8"))).toEqual({
+      total: 0,
+      success: 0,
+      failure: 0,
+      attemptsToSuccess: {
+        total: 0,
+        samples: 0,
+        average: 0,
+      },
+      categoryCounts: {},
+      pendingAttemptsByChallenge: {},
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed challenge metrics store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
+});

--- a/src/challenges/challengeMetrics.ts
+++ b/src/challenges/challengeMetrics.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
+import { readRecoverableJsonState } from "../runtime/localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const CHALLENGE_METRICS_FILE_NAME = "challenge-metrics.json";
@@ -104,20 +105,12 @@ function getMetricsPath(workDir: string): string {
 }
 
 export async function readChallengeMetrics(workDir: string): Promise<ChallengeMetrics> {
-  const metricsPath = getMetricsPath(workDir);
-
-  try {
-    const raw = await fs.readFile(metricsPath, "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    return normalizeMetricsShape(parsed);
-  } catch (error) {
-    const errorCode = (error as NodeJS.ErrnoException).code;
-    if (errorCode === "ENOENT") {
-      return createDefaultMetrics();
-    }
-
-    throw error;
-  }
+  return readRecoverableJsonState({
+    statePath: getMetricsPath(workDir),
+    createDefaultState: createDefaultMetrics,
+    normalizeState: normalizeMetricsShape,
+    warningLabel: "challenge metrics store",
+  });
 }
 
 async function writeChallengeMetrics(workDir: string, metrics: ChallengeMetrics): Promise<void> {
@@ -184,4 +177,3 @@ export function formatChallengeMetricsReport(metrics: ChallengeMetrics): string 
     `- active pending challenge attempts: ${pendingChallenges}`,
   ].join("\n");
 }
-

--- a/src/challenges/retryGate.test.ts
+++ b/src/challenges/retryGate.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IssueSummary } from "../issues/taskIssueManager.js";
 import {
   CHALLENGE_BLOCKED_LABEL,
@@ -31,6 +31,8 @@ describe("retryGate", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
     tempDirs.length = 0;
   });
@@ -250,5 +252,28 @@ describe("retryGate", () => {
     });
     const stateAfterSuccess = await readChallengeRetryState(workDir);
     expect(stateAfterSuccess.failuresByChallenge).toEqual({});
+  });
+
+  it("recovers malformed retry state JSON by preserving the corrupt file and resetting defaults", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-07T22:10:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "challenge-retry-state.json");
+    const corruptPath = join(evolvoDir, `challenge-retry-state.corrupt-${recoveryAtMs}.json`);
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(statePath, "{\"failuresByChallenge\":", "utf8");
+
+    const state = await readChallengeRetryState(workDir);
+
+    expect(state).toEqual({ failuresByChallenge: {} });
+    expect(await readFile(corruptPath, "utf8")).toBe("{\"failuresByChallenge\":");
+    expect(JSON.parse(await readFile(statePath, "utf8"))).toEqual({ failuresByChallenge: {} });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed challenge retry state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
   });
 });

--- a/src/challenges/retryGate.ts
+++ b/src/challenges/retryGate.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { hasIssueLabel, isChallengeIssue } from "../issues/challengeIssue.js";
 import type { IssueSummary } from "../issues/taskIssueManager.js";
+import { readRecoverableJsonState } from "../runtime/localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const CHALLENGE_RETRY_STATE_FILE_NAME = "challenge-retry-state.json";
@@ -109,19 +110,12 @@ function getManagedLabelChanges(issue: IssueSummary, addLabels: string[]): { add
 }
 
 export async function readChallengeRetryState(workDir: string): Promise<ChallengeRetryState> {
-  const retryStatePath = getRetryStatePath(workDir);
-
-  try {
-    const raw = await fs.readFile(retryStatePath, "utf8");
-    return normalizeRetryState(JSON.parse(raw) as unknown);
-  } catch (error) {
-    const errorCode = (error as NodeJS.ErrnoException).code;
-    if (errorCode === "ENOENT") {
-      return createDefaultRetryState();
-    }
-
-    throw error;
-  }
+  return readRecoverableJsonState({
+    statePath: getRetryStatePath(workDir),
+    createDefaultState: createDefaultRetryState,
+    normalizeState: normalizeRetryState,
+    warningLabel: "challenge retry state store",
+  });
 }
 
 async function writeChallengeRetryState(workDir: string, state: ChallengeRetryState): Promise<void> {

--- a/src/runtime/lifecycleState.ts
+++ b/src/runtime/lifecycleState.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
+import { readRecoverableJsonState } from "./localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const LIFECYCLE_STATE_FILE_NAME = "runtime-lifecycle-state.json";
@@ -105,23 +106,11 @@ function getStatePath(workDir: string): string {
   return join(workDir, EVOLVO_DIRECTORY_NAME, LIFECYCLE_STATE_FILE_NAME);
 }
 
-function getCorruptStatePath(workDir: string, atMs = Date.now()): string {
-  return join(
-    workDir,
-    EVOLVO_DIRECTORY_NAME,
-    `runtime-lifecycle-state.corrupt-${Math.max(0, Math.floor(atMs))}.json`,
-  );
-}
-
 function createDefaultStateStore(): LifecycleStateStore {
   return {
     version: LIFECYCLE_STATE_VERSION,
     issues: {},
   };
-}
-
-function isMalformedStateStoreError(error: unknown): boolean {
-  return error instanceof SyntaxError;
 }
 
 function normalizeStateStore(raw: unknown): LifecycleStateStore {
@@ -197,37 +186,17 @@ function normalizeStateStore(raw: unknown): LifecycleStateStore {
 }
 
 export async function readCanonicalLifecycleState(workDir: string): Promise<LifecycleStateStore> {
-  const statePath = getStatePath(workDir);
-  try {
-    const raw = await fs.readFile(statePath, "utf8");
-    return normalizeStateStore(JSON.parse(raw) as unknown);
-  } catch (error) {
-    const errorCode = (error as NodeJS.ErrnoException).code;
-    if (errorCode === "ENOENT") {
-      return createDefaultStateStore();
-    }
-    if (isMalformedStateStoreError(error)) {
-      return recoverMalformedLifecycleState(workDir, statePath);
-    }
-
-    throw error;
-  }
+  return readRecoverableJsonState({
+    statePath: getStatePath(workDir),
+    createDefaultState: createDefaultStateStore,
+    normalizeState: normalizeStateStore,
+    warningLabel: "lifecycle state store",
+  });
 }
 
 async function writeCanonicalLifecycleState(workDir: string, state: LifecycleStateStore): Promise<void> {
   await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
   await fs.writeFile(getStatePath(workDir), `${JSON.stringify(normalizeStateStore(state), null, 2)}\n`, "utf8");
-}
-
-async function recoverMalformedLifecycleState(workDir: string, statePath: string): Promise<LifecycleStateStore> {
-  const corruptPath = getCorruptStatePath(workDir);
-  await fs.rename(statePath, corruptPath);
-  const defaultStateStore = createDefaultStateStore();
-  await writeCanonicalLifecycleState(workDir, defaultStateStore);
-  console.warn(
-    `Recovered malformed lifecycle state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
-  );
-  return defaultStateStore;
 }
 
 export async function transitionCanonicalLifecycleState(

--- a/src/runtime/localStateFile.test.ts
+++ b/src/runtime/localStateFile.test.ts
@@ -1,0 +1,62 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readRecoverableJsonState } from "./localStateFile.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "local-state-file-"));
+}
+
+describe("localStateFile", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it("returns the default state when the file is missing", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const state = await readRecoverableJsonState({
+      statePath: join(workDir, ".evolvo", "test-state.json"),
+      createDefaultState: () => ({ value: 1 }),
+      normalizeState: (raw) => raw as { value: number },
+      warningLabel: "test state store",
+    });
+
+    expect(state).toEqual({ value: 1 });
+  });
+
+  it("preserves malformed JSON, rewrites the file with defaults, and warns", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-07T22:00:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "test-state.json");
+    const corruptPath = join(evolvoDir, `test-state.corrupt-${recoveryAtMs}.json`);
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(statePath, "{\"value\":", "utf8");
+
+    const state = await readRecoverableJsonState({
+      statePath,
+      createDefaultState: () => ({ value: 0 }),
+      normalizeState: (raw) => raw as { value: number },
+      warningLabel: "test state store",
+    });
+
+    expect(state).toEqual({ value: 0 });
+    expect(await readFile(corruptPath, "utf8")).toBe("{\"value\":");
+    expect(JSON.parse(await readFile(statePath, "utf8"))).toEqual({ value: 0 });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed test state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
+});

--- a/src/runtime/localStateFile.ts
+++ b/src/runtime/localStateFile.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from "node:fs";
+import { basename, dirname, extname, join } from "node:path";
+
+type ReadRecoverableJsonStateOptions<T> = {
+  statePath: string;
+  createDefaultState: () => T;
+  normalizeState: (raw: unknown) => T;
+  warningLabel: string;
+};
+
+function isMalformedJsonError(error: unknown): boolean {
+  return error instanceof SyntaxError;
+}
+
+function buildCorruptStatePath(statePath: string, atMs = Date.now()): string {
+  const extension = extname(statePath);
+  const fileName = basename(statePath, extension);
+  return join(
+    dirname(statePath),
+    `${fileName}.corrupt-${Math.max(0, Math.floor(atMs))}${extension}`,
+  );
+}
+
+export async function readRecoverableJsonState<T>(
+  options: ReadRecoverableJsonStateOptions<T>,
+): Promise<T> {
+  try {
+    const raw = await fs.readFile(options.statePath, "utf8");
+    return options.normalizeState(JSON.parse(raw) as unknown);
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return options.createDefaultState();
+    }
+
+    if (isMalformedJsonError(error)) {
+      return recoverMalformedJsonState(options);
+    }
+
+    throw error;
+  }
+}
+
+async function recoverMalformedJsonState<T>(
+  options: ReadRecoverableJsonStateOptions<T>,
+): Promise<T> {
+  const corruptPath = buildCorruptStatePath(options.statePath);
+  await fs.rename(options.statePath, corruptPath);
+  const defaultState = options.normalizeState(options.createDefaultState());
+  await fs.mkdir(dirname(options.statePath), { recursive: true });
+  await fs.writeFile(options.statePath, `${JSON.stringify(defaultState, null, 2)}\n`, "utf8");
+  console.warn(
+    `Recovered malformed ${options.warningLabel} at ${options.statePath}; preserved corrupt file at ${corruptPath}.`,
+  );
+  return defaultState;
+}


### PR DESCRIPTION
Closes #308

## Summary
- add shared recoverable `.evolvo` JSON state-file handling that preserves corrupt payloads and rewrites defaults
- use that recovery path for challenge retry state, challenge metrics, and lifecycle state
- add regression coverage for malformed retry, metrics, lifecycle, and helper state files

## Validation
- pnpm vitest run src/runtime/localStateFile.test.ts src/challenges/retryGate.test.ts src/challenges/challengeMetrics.test.ts src/runtime/lifecycleState.test.ts
- pnpm typecheck