### PR TITLE
fix: cap planner issue creation by queue deficit

### DIFF
--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -268,6 +268,32 @@ describe("TaskIssueManager", () => {
     );
   });
 
+  it("creates planned issues only up to the queue deficit when blocked open issues already exist", async () => {
+    const client = createClientMock();
+    client.get
+      .mockResolvedValueOnce([
+        createIssue({ number: 1, title: "Blocked issue", labels: [{ name: "blocked" }] }),
+        createIssue({ number: 2, title: "Another open issue", labels: [{ name: "in progress" }] }),
+      ])
+      .mockResolvedValueOnce([]);
+    client.post.mockResolvedValueOnce(createIssue({ number: 31, title: "Candidate A" }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.createPlannedIssues({
+      minimumIssueCount: 3,
+      maximumOpenIssues: 5,
+      issues: [
+        { title: "Candidate A", description: "Should fill the single missing queue slot." },
+        { title: "Candidate B", description: "Should not be created once the deficit is filled." },
+      ],
+    });
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]?.title).toBe("Candidate A");
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith("", expect.objectContaining({ title: "Candidate A" }));
+  });
+
   it("replenishes empty queue with provided repository-derived candidates", async () => {
     const client = createClientMock();
     client.get

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -379,6 +379,10 @@ export class TaskIssueManager {
     if (remainingOpenSlots <= 0) {
       return { created: [] };
     }
+    const queueDeficit = Math.max(0, minimumIssueCount - openIssues.length);
+    if (queueDeficit <= 0) {
+      return { created: [] };
+    }
 
     const recentClosed = await this.listRecentClosedIssues(PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT);
     const existingTitles = new Set(
@@ -388,7 +392,7 @@ export class TaskIssueManager {
     );
 
     const created: IssueSummary[] = [];
-    const toCreateCount = Math.min(remainingOpenSlots, minimumIssueCount);
+    const toCreateCount = Math.min(remainingOpenSlots, queueDeficit);
 
     for (const plannedIssue of plannedIssues) {
       if (created.length >= toCreateCount) {


### PR DESCRIPTION
Closes #307

## Summary
- compute the planned-issue queue deficit from `minimumIssueCount - openIssues.length` before creating planner issues
- stop planned issue creation when existing blocked/open items already satisfy most of the minimum queue target
- add a regression covering blocked/open issues already in the queue

## Validation
- pnpm vitest run src/issues/taskIssueManager.test.ts
- pnpm typecheck