### PR TITLE
fix: ignore closed PRs in replenishment history

### DIFF
--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -388,6 +388,36 @@ describe("TaskIssueManager", () => {
     );
   });
 
+  it("ignores closed pull request titles when replenishing issue history", async () => {
+    const client = createClientMock();
+    client.get
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        createIssue({
+          number: 4,
+          state: "closed",
+          title: "Candidate A",
+          pull_request: { url: "https://github.com/evolvo-auto/evolvo-ts/pull/4" },
+        }),
+      ]);
+    client.post.mockResolvedValueOnce(createIssue({ number: 31, title: "Candidate A" }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.replenishSelfImprovementIssues({
+      minimumIssueCount: 1,
+      maximumOpenIssues: 5,
+      templates: [
+        { title: "Candidate A", description: "Should not be blocked by a closed PR title." },
+        { title: "Candidate B", description: "Should stay unused because Candidate A is still valid." },
+      ],
+    });
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]?.title).toBe("Candidate A");
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith("", expect.objectContaining({ title: "Candidate A" }));
+  });
+
   it("supports startup-provided templates and creates follow-up titles when needed", async () => {
     const client = createClientMock();
     client.get

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -434,13 +434,14 @@ export class TaskIssueManager {
     const recentClosed = await this.client.get<GitHubIssue[]>(
       `?state=closed&sort=updated&direction=desc&per_page=${TaskIssueManager.ISSUES_PER_PAGE}&page=1`,
     );
+    const recentClosedIssues = recentClosed.filter((issue) => issue.pull_request === undefined);
     const existingTitles = new Set(
-      [...openIssues.map((issue) => issue.title), ...recentClosed.map((issue) => issue.title)].map((title) =>
+      [...openIssues.map((issue) => issue.title), ...recentClosedIssues.map((issue) => issue.title)].map((title) =>
         title.trim().toLowerCase(),
       ),
     );
 
-    const prioritizedTemplates = prioritizeTemplatesByFailureEvidence(baseTemplates, [...openIssues, ...recentClosed]);
+    const prioritizedTemplates = prioritizeTemplatesByFailureEvidence(baseTemplates, [...openIssues, ...recentClosedIssues]);
     const toCreateCount = Math.min(remainingOpenSlots, minimumIssueCount);
     const templates = selectTemplatesForCreation({
       baseTemplates: prioritizedTemplates,


### PR DESCRIPTION
Closes #306

## Summary
- filter closed pull requests out of replenishment history before title de-duplication
- exclude closed PRs from the failure-evidence inputs used for template prioritization
- add a regression proving a closed PR title no longer blocks a valid replenishment issue

## Validation
- pnpm vitest run src/issues/taskIssueManager.test.ts
- pnpm typecheck