### PR TITLE
fix: include lint in validate pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ pnpm validate
 Current validation pipeline:
 
 1. `pnpm typecheck`
-2. `pnpm build`
-3. `pnpm test`
+2. `pnpm lint`
+3. `pnpm build`
+4. `pnpm test`
 
-If full validation is too slow while narrowing failures, run targeted commands first (`pnpm test`, `pnpm typecheck`) then re-run `pnpm validate` before final acceptance.
+If full validation is too slow while narrowing failures, run targeted commands first (`pnpm test`, `pnpm typecheck`, `pnpm lint`) then re-run `pnpm validate` before final acceptance.
 
 ## Recovery Guide
 
@@ -182,8 +183,9 @@ pnpm dev -- issues close <issueNumber>
 
 ```bash
 pnpm dev        # run runtime in tsx
+pnpm lint       # compiler-backed unused-code/static analysis
 pnpm build      # compile to dist
 pnpm start      # run compiled runtime
 pnpm test       # run vitest
-pnpm validate   # typecheck + build + test
+pnpm validate   # typecheck + lint + build + test
 ```

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "validate": "pnpm typecheck && pnpm build && pnpm test",
+    "validate": "pnpm typecheck && pnpm lint && pnpm build && pnpm test",
     "dev": "tsx src/main.ts",
     "start": "node dist/main.js",
-    "lint": "eslint . --ext .ts",
+    "lint": "pnpm exec tsc --noEmit --noUnusedLocals --noUnusedParameters -p tsconfig.json",
     "test": "vitest run src"
   },
   "devDependencies": {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1108,7 +1108,7 @@ describe("main", () => {
     listOpenIssuesMock.mockResolvedValue([
       { number: 4, title: "Done", description: "Done", state: "open", labels: ["completed"] },
     ]);
-    const { DEFAULT_PROMPT, main } = await import("./main.js");
+    const { main } = await import("./main.js");
 
     await main();
 

--- a/src/validationPipeline.test.ts
+++ b/src/validationPipeline.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("validation pipeline", () => {
+  it("runs lint as part of pnpm validate", async () => {
+    const packageJson = JSON.parse(await readFile(join(REPO_ROOT, "package.json"), "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.lint).toBe(
+      "pnpm exec tsc --noEmit --noUnusedLocals --noUnusedParameters -p tsconfig.json",
+    );
+    expect(packageJson.scripts?.validate).toBe("pnpm typecheck && pnpm lint && pnpm build && pnpm test");
+  });
+
+  it("documents lint in the standard validation pipeline", async () => {
+    const readme = await readFile(join(REPO_ROOT, "README.md"), "utf8");
+
+    expect(readme).toContain("2. `pnpm lint`");
+    expect(readme).toContain("pnpm lint       # compiler-backed unused-code/static analysis");
+    expect(readme).toContain("pnpm validate   # typecheck + lint + build + test");
+    expect(readme).toContain("`pnpm test`, `pnpm typecheck`, `pnpm lint`");
+  });
+});


### PR DESCRIPTION
Closes #331

## Summary
- add `pnpm lint` to the standard `pnpm validate` pipeline and update README validation guidance
- replace the broken placeholder lint command with a working compiler-backed unused-code/static-analysis pass
- add a regression test that keeps the package script and README validation contract in sync

## Validation
- pnpm validate