### PR TITLE
fix: advance Discord control cursor after handling

### DIFF
--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as gracefulShutdown from "./gracefulShutdown.js";
 import {
   getDiscordControlConfigFromEnv,
   notifyIssueStartedInDiscord,
@@ -435,6 +436,60 @@ describe("operatorControl", () => {
         }),
       }),
     );
+  });
+
+  it("does not advance the Discord control cursor past a command that fails before processing completes", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const recordRequestSpy = vi.spyOn(gracefulShutdown, "recordGracefulShutdownRequest")
+      .mockRejectedValueOnce(new Error("simulated cursor-ordering failure"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7400", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7401", content: "/quit", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7401", content: "/quit", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-replayed" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const firstRequest = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(firstRequest).toBeNull();
+    expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("7400");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Discord graceful shutdown polling failed: [read-control-commands] simulated cursor-ordering failure"),
+    );
+
+    recordRequestSpy.mockRestore();
+
+    const replayedRequest = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(replayedRequest).toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit",
+      mode: "after-current-task",
+      messageId: "7401",
+      requestedAt: expect.any(String),
+    });
+    expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("7401");
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
   });
 
   it("queues an authorized /startProject request and acknowledges the created tracker issue", async () => {

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -482,8 +482,6 @@ export async function pollDiscordGracefulShutdownCommand(
       return null;
     }
 
-    await writeDiscordControlCursor(workDir, getHighestSnowflakeId(messages.map((message) => message.id)));
-
     let gracefulShutdownRequest: GracefulShutdownRequest | null = null;
     const orderedMessages = [...messages].sort((left, right) => {
       if (left.id === right.id) {
@@ -498,79 +496,78 @@ export async function pollDiscordGracefulShutdownCommand(
         continue;
       }
 
-      const shutdownCommand = parseGracefulShutdownCommand(message.content);
-      if (shutdownCommand !== null) {
-        const recordedRequest = await recordGracefulShutdownRequest(workDir, {
-          messageId: message.id,
-          mode: shutdownCommand.mode,
-        });
-        gracefulShutdownRequest = recordedRequest.request;
-        if (recordedRequest.created) {
-          try {
-            await sendGracefulShutdownAcknowledgement(config, recordedRequest.request);
-          } catch (error) {
-            const sendMessage = buildStepFailureMessage("send-quit-ack", error);
-            console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);
-            logDiscordMissingAccessHint(sendMessage);
+      if (message.author?.id === config.operatorUserId) {
+        const shutdownCommand = parseGracefulShutdownCommand(message.content);
+        if (shutdownCommand !== null) {
+          const recordedRequest = await recordGracefulShutdownRequest(workDir, {
+            messageId: message.id,
+            mode: shutdownCommand.mode,
+          });
+          gracefulShutdownRequest = recordedRequest.request;
+          if (recordedRequest.created) {
+            try {
+              await sendGracefulShutdownAcknowledgement(config, recordedRequest.request);
+            } catch (error) {
+              const sendMessage = buildStepFailureMessage("send-quit-ack", error);
+              console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);
+              logDiscordMissingAccessHint(sendMessage);
+            }
+          }
+        } else {
+          const requestedProjectName = parseStartProjectName(message.content);
+          if (requestedProjectName !== null && handlers.onStartProject) {
+            const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
+              command: "start-project",
+              messageId: message.id,
+            });
+            if (recordedReceipt) {
+              let startProjectRequest: StartProjectCommandRequest | null = null;
+              let commandResult: StartProjectCommandResult;
+
+              try {
+                const normalized = normalizeProjectNameInput(requestedProjectName);
+                startProjectRequest = {
+                  messageId: message.id,
+                  requestedAt: new Date().toISOString(),
+                  requestedBy: `discord:${config.operatorUserId}`,
+                  displayName: normalized.displayName,
+                  slug: normalized.slug,
+                  repositoryName: normalized.repositoryName,
+                  issueLabel: normalized.issueLabel,
+                  workspaceRelativePath: normalized.workspaceRelativePath,
+                };
+                commandResult = await handlers.onStartProject(startProjectRequest);
+              } catch (error) {
+                const fallbackDisplayName = requestedProjectName.trim() || "<missing project name>";
+                startProjectRequest = {
+                  messageId: message.id,
+                  requestedAt: new Date().toISOString(),
+                  requestedBy: `discord:${config.operatorUserId}`,
+                  displayName: fallbackDisplayName,
+                  slug: "",
+                  repositoryName: "",
+                  issueLabel: "",
+                  workspaceRelativePath: "",
+                };
+                commandResult = {
+                  ok: false,
+                  message: error instanceof Error ? error.message : "Unknown project start request error.",
+                };
+              }
+
+              try {
+                await sendStartProjectAcknowledgement(config, startProjectRequest, commandResult);
+              } catch (error) {
+                const sendMessage = buildStepFailureMessage("send-start-project-ack", error);
+                console.error(`Discord project start acknowledgement failed: ${sendMessage}`);
+                logDiscordMissingAccessHint(sendMessage);
+              }
+            }
           }
         }
-        continue;
       }
 
-      const requestedProjectName = parseStartProjectName(message.content);
-      if (requestedProjectName === null || !handlers.onStartProject) {
-        continue;
-      }
-
-      const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
-        command: "start-project",
-        messageId: message.id,
-      });
-      if (!recordedReceipt) {
-        continue;
-      }
-
-      let startProjectRequest: StartProjectCommandRequest | null = null;
-      let commandResult: StartProjectCommandResult;
-
-      try {
-        const normalized = normalizeProjectNameInput(requestedProjectName);
-        startProjectRequest = {
-          messageId: message.id,
-          requestedAt: new Date().toISOString(),
-          requestedBy: `discord:${config.operatorUserId}`,
-          displayName: normalized.displayName,
-          slug: normalized.slug,
-          repositoryName: normalized.repositoryName,
-          issueLabel: normalized.issueLabel,
-          workspaceRelativePath: normalized.workspaceRelativePath,
-        };
-        commandResult = await handlers.onStartProject(startProjectRequest);
-      } catch (error) {
-        const fallbackDisplayName = requestedProjectName.trim() || "<missing project name>";
-        startProjectRequest = {
-          messageId: message.id,
-          requestedAt: new Date().toISOString(),
-          requestedBy: `discord:${config.operatorUserId}`,
-          displayName: fallbackDisplayName,
-          slug: "",
-          repositoryName: "",
-          issueLabel: "",
-          workspaceRelativePath: "",
-        };
-        commandResult = {
-          ok: false,
-          message: error instanceof Error ? error.message : "Unknown project start request error.",
-        };
-      }
-
-      try {
-        await sendStartProjectAcknowledgement(config, startProjectRequest, commandResult);
-      } catch (error) {
-        const sendMessage = buildStepFailureMessage("send-start-project-ack", error);
-        console.error(`Discord project start acknowledgement failed: ${sendMessage}`);
-        logDiscordMissingAccessHint(sendMessage);
-      }
+      await writeDiscordControlCursor(workDir, message.id);
     }
 
     return gracefulShutdownRequest;


### PR DESCRIPTION
Closes #330

## Summary
- stop advancing the Discord control cursor before processing fetched control messages
- write the cursor only after each message is successfully handled or deliberately ignored
- add a regression proving a handler failure replays the same `/quit` command on the next poll instead of skipping it forever

## Validation
- pnpm vitest run src/runtime/operatorControl.test.ts src/runtime/gracefulShutdown.test.ts
- pnpm typecheck