### PR TITLE
fix(projects): recover malformed project registry

### DIFF
--- a/src/projects/projectProvisioning.test.ts
+++ b/src/projects/projectProvisioning.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -31,6 +31,7 @@ describe("projectProvisioning", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
     vi.restoreAllMocks();
   });
@@ -196,6 +197,61 @@ describe("projectProvisioning", () => {
       }),
     );
     expect(issueManager.createIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers a malformed registry before creating a provisioning request issue", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-07T23:30:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const registryPath = getProjectRegistryPath(workDir);
+    const corruptPath = join(workDir, ".evolvo", `projects.corrupt-${recoveryAtMs}.json`);
+    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    await writeFile(registryPath, "{\"projects\":", "utf8");
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([]),
+      createIssue: vi.fn().mockResolvedValue({
+        ok: true,
+        message: "Created issue #404.",
+        issue: {
+          number: 404,
+          title: "Start project Habit CLI",
+          description: "body",
+          state: "open",
+          labels: [],
+        },
+      }),
+    };
+
+    const result = await createProjectProvisioningRequestIssue({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        issueNumber: 404,
+      }),
+    );
+    expect(await readFile(corruptPath, "utf8")).toBe("{\"projects\":");
+    expect(JSON.parse(await readFile(registryPath, "utf8"))).toEqual({
+      version: 1,
+      projects: [
+        expect.objectContaining({
+          slug: "evolvo",
+        }),
+      ],
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed project registry at ${registryPath}; preserved corrupt file at ${corruptPath}.`,
+    );
   });
 
   it("provisions a managed project and records active registry state on success", async () => {

--- a/src/projects/projectRegistry.test.ts
+++ b/src/projects/projectRegistry.test.ts
@@ -1,13 +1,14 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensureProjectRegistry,
   findProjectBySlug,
   getProjectRegistryPath,
   readProjectRegistry,
   upsertProjectRecord,
+  writeProjectRegistry,
   type ProjectRecord,
 } from "./projectRegistry.js";
 
@@ -19,6 +20,8 @@ describe("projectRegistry", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
   });
 
@@ -67,6 +70,27 @@ describe("projectRegistry", () => {
         }),
       }),
     ]);
+  });
+
+  it("writes the registry atomically through a temp file rename", async () => {
+    vi.useFakeTimers();
+    const writeAtMs = new Date("2026-03-07T23:00:00.000Z").getTime();
+    vi.setSystemTime(writeAtMs);
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const registry = await readProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    await writeProjectRegistry(workDir, registry);
+
+    await expect(
+      access(join(workDir, ".evolvo", `projects.tmp-${writeAtMs}-${process.pid}.json`)),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readdir(join(workDir, ".evolvo"))).toEqual(["projects.json"]);
   });
 
   it("upserts a managed project record while preserving the default project", async () => {
@@ -120,5 +144,119 @@ describe("projectRegistry", () => {
       projects: Array<{ slug: string }>;
     };
     expect(persisted.projects.map((project) => project.slug)).toEqual(["evolvo", "habit-cli"]);
+  });
+
+  it("preserves malformed registry JSON, rewrites a safe default registry, and warns", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-07T23:10:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const registryPath = getProjectRegistryPath(workDir);
+    const corruptPath = join(evolvoDir, `projects.corrupt-${recoveryAtMs}.json`);
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(registryPath, "{\"projects\":", "utf8");
+
+    const registry = await readProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    expect(registry.projects.map((project) => project.slug)).toEqual(["evolvo"]);
+    expect(await readFile(corruptPath, "utf8")).toBe("{\"projects\":");
+    expect(JSON.parse(await readFile(registryPath, "utf8"))).toEqual({
+      version: 1,
+      projects: [
+        expect.objectContaining({
+          slug: "evolvo",
+          executionRepo: expect.objectContaining({
+            defaultBranch: "main",
+          }),
+        }),
+      ],
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed project registry at ${registryPath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
+
+  it("preserves valid existing projects when recovering malformed registry records", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-07T23:20:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const registryPath = getProjectRegistryPath(workDir);
+    const corruptPath = join(evolvoDir, `projects.corrupt-${recoveryAtMs}.json`);
+    const managedProject: ProjectRecord = {
+      slug: "habit-cli",
+      displayName: "Habit CLI",
+      kind: "managed",
+      issueLabel: "project:habit-cli",
+      trackerRepo: {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        url: "https://github.com/evolvo-auto/evolvo-ts",
+      },
+      executionRepo: {
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli",
+        defaultBranch: "main",
+      },
+      cwd: join(workDir, "projects", "habit-cli"),
+      status: "active",
+      sourceIssueNumber: 318,
+      createdAt: "2026-03-07T12:00:00.000Z",
+      updatedAt: "2026-03-07T12:00:00.000Z",
+      provisioning: {
+        labelCreated: true,
+        repoCreated: true,
+        workspacePrepared: true,
+        lastError: null,
+      },
+    };
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(
+      registryPath,
+      `${JSON.stringify({
+        version: 1,
+        projects: [
+          managedProject,
+          {
+            slug: "",
+            displayName: "Broken Project",
+          },
+        ],
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const registry = await readProjectRegistry(workDir, {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      workDir,
+      defaultBranch: "main",
+    });
+
+    expect(registry.projects.map((project) => project.slug)).toEqual(["evolvo", "habit-cli"]);
+    expect(findProjectBySlug(registry, "habit-cli")).toEqual(managedProject);
+    expect(await readFile(corruptPath, "utf8")).toContain("\"Broken Project\"");
+    expect(JSON.parse(await readFile(registryPath, "utf8"))).toEqual({
+      version: 1,
+      projects: [
+        expect.objectContaining({ slug: "evolvo" }),
+        expect.objectContaining({ slug: "habit-cli" }),
+      ],
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed project registry at ${registryPath}; preserved corrupt file at ${corruptPath}.`,
+    );
   });
 });

--- a/src/projects/projectRegistry.ts
+++ b/src/projects/projectRegistry.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
 import { buildProjectIssueLabel, DEFAULT_PROJECT_SLUG } from "./projectNaming.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
@@ -68,6 +68,31 @@ function normalizeNullableString(value: unknown): string | null {
 
 function buildRepositoryUrl(owner: string, repo: string): string {
   return `https://github.com/${owner}/${repo}`;
+}
+
+function buildProjectRegistry(defaultProject: DefaultProjectContext, projects: ProjectRecord[]): ProjectRegistry {
+  return {
+    version: PROJECT_REGISTRY_VERSION,
+    projects: ensureDefaultProject(projects, defaultProject),
+  };
+}
+
+function buildCorruptProjectRegistryPath(registryPath: string, atMs = Date.now()): string {
+  const extension = extname(registryPath);
+  const fileName = basename(registryPath, extension);
+  return join(
+    dirname(registryPath),
+    `${fileName}.corrupt-${Math.max(0, Math.floor(atMs))}${extension}`,
+  );
+}
+
+function buildProjectRegistryTempPath(registryPath: string, atMs = Date.now()): string {
+  const extension = extname(registryPath);
+  const fileName = basename(registryPath, extension);
+  return join(
+    dirname(registryPath),
+    `${fileName}.tmp-${Math.max(0, Math.floor(atMs))}-${process.pid}${extension}`,
+  );
 }
 
 export function getProjectRegistryPath(workDir: string): string {
@@ -213,49 +238,102 @@ function ensureDefaultProject(
   ];
 }
 
+type ParsedProjectRegistryResult =
+  | {
+    ok: true;
+    registry: ProjectRegistry;
+  }
+  | {
+    ok: false;
+    recoveryRegistry: ProjectRegistry;
+  };
+
+function parseProjectRegistry(
+  raw: string,
+  defaultProject: DefaultProjectContext,
+): ParsedProjectRegistryResult {
+  const parsed = JSON.parse(raw) as unknown;
+  const rawProjects = (parsed as { projects?: unknown }).projects;
+  if (!Array.isArray(rawProjects)) {
+    return {
+      ok: false,
+      recoveryRegistry: buildProjectRegistry(defaultProject, []),
+    };
+  }
+
+  const normalizedProjects = rawProjects.map(normalizeProjectRecord);
+  const validProjects = normalizedProjects.filter((project) => project !== null) as ProjectRecord[];
+  if (validProjects.length !== rawProjects.length) {
+    return {
+      ok: false,
+      recoveryRegistry: buildProjectRegistry(defaultProject, validProjects),
+    };
+  }
+
+  return {
+    ok: true,
+    registry: buildProjectRegistry(defaultProject, validProjects),
+  };
+}
+
+async function recoverMalformedProjectRegistry(
+  registryPath: string,
+  recoveryRegistry: ProjectRegistry,
+): Promise<ProjectRegistry> {
+  const corruptPath = buildCorruptProjectRegistryPath(registryPath);
+  await fs.rename(registryPath, corruptPath);
+  await writeProjectRegistryFile(registryPath, recoveryRegistry);
+  console.warn(
+    `Recovered malformed project registry at ${registryPath}; preserved corrupt file at ${corruptPath}.`,
+  );
+  return recoveryRegistry;
+}
+
 export async function readProjectRegistry(
   workDir: string,
   defaultProject: DefaultProjectContext,
 ): Promise<ProjectRegistry> {
+  const registryPath = getProjectRegistryPath(workDir);
   try {
-    const raw = await fs.readFile(getProjectRegistryPath(workDir), "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    const rawProjects = (parsed as { projects?: unknown }).projects;
-    if (!Array.isArray(rawProjects)) {
-      throw new Error("Project registry file is malformed: missing projects array.");
+    const raw = await fs.readFile(registryPath, "utf8");
+    const parsed = parseProjectRegistry(raw, defaultProject);
+    if (!parsed.ok) {
+      return recoverMalformedProjectRegistry(registryPath, parsed.recoveryRegistry);
     }
 
-    const normalizedProjects = rawProjects.map(normalizeProjectRecord);
-    if (normalizedProjects.some((project) => project === null)) {
-      throw new Error("Project registry file is malformed: invalid project record.");
-    }
-    const existingProjects = normalizedProjects as ProjectRecord[];
-
-    return {
-      version: PROJECT_REGISTRY_VERSION,
-      projects: ensureDefaultProject(existingProjects, defaultProject),
-    };
+    return parsed.registry;
   } catch (error) {
     const errorCode = (error as NodeJS.ErrnoException).code;
     if (errorCode === "ENOENT") {
-      return {
-        version: PROJECT_REGISTRY_VERSION,
-        projects: [buildDefaultProjectRecord(defaultProject)],
-      };
+      return buildProjectRegistry(defaultProject, []);
+    }
+
+    if (error instanceof SyntaxError) {
+      return recoverMalformedProjectRegistry(registryPath, buildProjectRegistry(defaultProject, []));
     }
 
     throw error;
   }
 }
 
-export async function writeProjectRegistry(workDir: string, registry: ProjectRegistry): Promise<void> {
-  const path = getProjectRegistryPath(workDir);
+async function writeProjectRegistryFile(path: string, registry: ProjectRegistry): Promise<void> {
   await fs.mkdir(dirname(path), { recursive: true });
-  await fs.writeFile(
-    path,
-    `${JSON.stringify({ version: PROJECT_REGISTRY_VERSION, projects: registry.projects }, null, 2)}\n`,
-    "utf8",
-  );
+  const tempPath = buildProjectRegistryTempPath(path);
+  try {
+    await fs.writeFile(
+      tempPath,
+      `${JSON.stringify({ version: PROJECT_REGISTRY_VERSION, projects: registry.projects }, null, 2)}\n`,
+      "utf8",
+    );
+    await fs.rename(tempPath, path);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function writeProjectRegistry(workDir: string, registry: ProjectRegistry): Promise<void> {
+  await writeProjectRegistryFile(getProjectRegistryPath(workDir), registry);
 }
 
 export async function ensureProjectRegistry(


### PR DESCRIPTION
## Summary
- write `.evolvo/projects.json` via a temp file + rename instead of direct overwrite
- recover malformed project registry files by preserving the corrupt file and rebuilding a safe registry
- add regression coverage for malformed-registry recovery and provisioning request recovery

Closes #328

## Validation
- pnpm vitest run src/projects/projectRegistry.test.ts src/projects/projectProvisioning.test.ts src/projects/projectExecutionContext.test.ts
- pnpm typecheck