### PR TITLE
fix(challenges): roll back mixed state updates

### DIFF
--- a/src/challenges/challengeMetrics.ts
+++ b/src/challenges/challengeMetrics.ts
@@ -113,7 +113,7 @@ export async function readChallengeMetrics(workDir: string): Promise<ChallengeMe
   });
 }
 
-async function writeChallengeMetrics(workDir: string, metrics: ChallengeMetrics): Promise<void> {
+export async function writeChallengeMetrics(workDir: string, metrics: ChallengeMetrics): Promise<void> {
   const metricsPath = getMetricsPath(workDir);
   await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
   await fs.writeFile(metricsPath, `${JSON.stringify(normalizeMetricsShape(metrics), null, 2)}\n`, "utf8");

--- a/src/runtime/challengeLifecycle.test.ts
+++ b/src/runtime/challengeLifecycle.test.ts
@@ -21,7 +21,16 @@ vi.mock("../challenges/challengeFailureLearning.js", () => ({
 
 vi.mock("../challenges/challengeMetrics.js", () => ({
   formatChallengeMetricsReport: vi.fn(() => "metrics-report"),
+  readChallengeMetrics: vi.fn(async () => ({
+    total: 0,
+    success: 0,
+    failure: 0,
+    attemptsToSuccess: { total: 0, samples: 0, average: 0 },
+    categoryCounts: {},
+    pendingAttemptsByChallenge: {},
+  })),
   recordChallengeAttemptMetrics: vi.fn(async () => ({ totalAttempts: 1 })),
+  writeChallengeMetrics: vi.fn(async () => {}),
 }));
 
 vi.mock("../challenges/retryGate.js", () => ({
@@ -148,6 +157,41 @@ describe("challengeLifecycle", () => {
     await updateChallengeMetrics(issueManager, issue, new Error("boom"), null);
 
     expect(console.error).toHaveBeenCalledWith("Could not update challenge metrics for issue #33: write failed");
+    expect(issueManager.updateLabels).not.toHaveBeenCalled();
+  });
+
+  it("rolls back persisted metrics when retry-state persistence fails", async () => {
+    const issueManager = createIssueManager();
+    const issue = createIssue({ number: 34 });
+    const previousMetrics = {
+      total: 4,
+      success: 2,
+      failure: 2,
+      attemptsToSuccess: { total: 5, samples: 2, average: 2.5 },
+      categoryCounts: { execution_failure: 2 },
+      pendingAttemptsByChallenge: { "34": 1 },
+    };
+    const updatedMetrics = {
+      total: 5,
+      success: 2,
+      failure: 3,
+      attemptsToSuccess: { total: 5, samples: 2, average: 2.5 },
+      categoryCounts: { execution_failure: 3 },
+      pendingAttemptsByChallenge: { "34": 2 },
+    };
+    vi.mocked(challengeMetrics.readChallengeMetrics).mockResolvedValueOnce(previousMetrics);
+    vi.mocked(challengeMetrics.recordChallengeAttemptMetrics).mockResolvedValueOnce(updatedMetrics);
+    vi.mocked(retryGate.recordChallengeAttemptOutcome).mockRejectedValueOnce(new Error("retry write failed"));
+
+    await updateChallengeMetrics(issueManager, issue, new Error("boom"), null);
+
+    expect(challengeMetrics.recordChallengeAttemptMetrics).toHaveBeenCalledWith(expect.any(String), {
+      challengeIssueNumber: issue.number,
+      success: false,
+      failureCategory: "execution_failure",
+    });
+    expect(challengeMetrics.writeChallengeMetrics).toHaveBeenCalledWith(expect.any(String), previousMetrics);
+    expect(console.error).toHaveBeenCalledWith("Could not update challenge metrics for issue #34: retry write failed");
     expect(issueManager.updateLabels).not.toHaveBeenCalled();
   });
 

--- a/src/runtime/challengeLifecycle.ts
+++ b/src/runtime/challengeLifecycle.ts
@@ -8,7 +8,9 @@ import {
 } from "../challenges/challengeFailureLearning.js";
 import {
   formatChallengeMetricsReport,
+  readChallengeMetrics,
   recordChallengeAttemptMetrics,
+  writeChallengeMetrics,
 } from "../challenges/challengeMetrics.js";
 import {
   CHALLENGE_BLOCKED_LABEL,
@@ -26,6 +28,44 @@ import { describeRepositoryDefaultBranch } from "./defaultBranch.js";
 const CHALLENGE_MAX_ATTEMPTS = 3;
 const CHALLENGE_RETRY_COOLDOWN_MS = 60 * 60 * 1000;
 
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+async function recordChallengeAttemptState(options: {
+  issueNumber: number;
+  success: boolean;
+  failureCategory?: string;
+}): Promise<{
+  metrics: Awaited<ReturnType<typeof recordChallengeAttemptMetrics>>;
+  retryState: Awaited<ReturnType<typeof recordChallengeAttemptOutcome>>;
+}> {
+  const previousMetrics = await readChallengeMetrics(WORK_DIR);
+  const metrics = await recordChallengeAttemptMetrics(WORK_DIR, {
+    challengeIssueNumber: options.issueNumber,
+    success: options.success,
+    failureCategory: options.failureCategory,
+  });
+
+  try {
+    const retryState = await recordChallengeAttemptOutcome(WORK_DIR, {
+      challengeIssueNumber: options.issueNumber,
+      success: options.success,
+    });
+    return { metrics, retryState };
+  } catch (error) {
+    try {
+      await writeChallengeMetrics(WORK_DIR, previousMetrics);
+    } catch (rollbackError) {
+      throw new Error(
+        `Challenge retry state update failed after metrics persisted: ${describeError(error)}. Metrics rollback failed: ${describeError(rollbackError)}`,
+      );
+    }
+
+    throw error;
+  }
+}
+
 export async function updateChallengeMetrics(
   issueManager: TaskIssueManager,
   issue: IssueSummary,
@@ -40,15 +80,10 @@ export async function updateChallengeMetrics(
   const failureCategory = success ? undefined : classifyChallengeFailure(runError, runResult);
 
   try {
-    const metrics = await recordChallengeAttemptMetrics(WORK_DIR, {
-      challengeIssueNumber: issue.number,
+    const { metrics, retryState } = await recordChallengeAttemptState({
+      issueNumber: issue.number,
       success,
       failureCategory,
-    });
-
-    const retryState = await recordChallengeAttemptOutcome(WORK_DIR, {
-      challengeIssueNumber: issue.number,
-      success,
     });
     const failureAttempts = retryState.failuresByChallenge[String(issue.number)]?.attempts ?? 0;
     const labelUpdate = success


### PR DESCRIPTION
## Summary
- snapshot the existing challenge metrics before persisting a new attempt
- roll the metrics file back if retry-state persistence fails so the two stores do not diverge
- add a regression for the mixed-success failure case in challenge lifecycle tests

Closes #339

## Validation
- pnpm vitest run src/runtime/challengeLifecycle.test.ts src/challenges/challengeMetrics.test.ts src/challenges/retryGate.test.ts
- pnpm typecheck