### PR TITLE
fix(runtime): write readiness signals atomically

### DIFF
--- a/src/runtime/runtimeReadiness.test.ts
+++ b/src/runtime/runtimeReadiness.test.ts
@@ -1,7 +1,7 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getRuntimeReadinessSignalPath,
   waitForRuntimeReadinessSignal,
@@ -16,10 +16,13 @@ describe("runtimeReadiness", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
   });
 
   it("writes readiness signal with runtime metadata", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T23:55:00.000Z"));
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
 
@@ -39,6 +42,7 @@ describe("runtimeReadiness", () => {
     expect(raw.status).toBe("ready");
     expect(raw.pid).toBe(process.pid);
     expect(typeof raw.startedAt).toBe("string");
+    expect(await readdir(join(workDir, ".evolvo"))).toEqual(["runtime-readiness.json"]);
   });
 
   it("waits until matching readiness token appears", async () => {
@@ -87,6 +91,38 @@ describe("runtimeReadiness", () => {
         pollIntervalMs: 10,
       }),
     ).rejects.toThrow("Last observed token=other-token");
+  });
+
+  it("ignores truncated temp-file writes until the canonical readiness signal appears", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const signalPath = getRuntimeReadinessSignalPath(workDir);
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(join(evolvoDir, "runtime-readiness.tmp-interrupted.json"), "{\"token\":\"expected-token\"", "utf8");
+
+    const waitPromise = waitForRuntimeReadinessSignal({
+      workDir,
+      token: "expected-token",
+      timeoutMs: 400,
+      pollIntervalMs: 20,
+      signalPath,
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 60);
+    });
+    await writeRuntimeReadinessSignal({
+      workDir,
+      token: "expected-token",
+      signalPath,
+    });
+
+    await expect(waitPromise).resolves.toEqual(
+      expect.objectContaining({
+        token: "expected-token",
+        status: "ready",
+      }),
+    );
   });
 
   it("fails when readiness file payload is malformed", async () => {

--- a/src/runtime/runtimeReadiness.ts
+++ b/src/runtime/runtimeReadiness.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const RUNTIME_READINESS_FILE_NAME = "runtime-readiness.json";
@@ -38,6 +38,15 @@ function isRuntimeReadinessSignal(value: unknown): value is RuntimeReadinessSign
 
 export function getRuntimeReadinessSignalPath(workDir: string): string {
   return join(workDir, EVOLVO_DIRECTORY_NAME, RUNTIME_READINESS_FILE_NAME);
+}
+
+function buildRuntimeReadinessTempPath(signalPath: string, atMs = Date.now()): string {
+  const extension = extname(signalPath);
+  const fileName = basename(signalPath, extension);
+  return join(
+    dirname(signalPath),
+    `${fileName}.tmp-${Math.max(0, Math.floor(atMs))}-${process.pid}${extension}`,
+  );
 }
 
 async function readRuntimeReadinessSignal(signalPath: string): Promise<RuntimeReadinessSignal | null> {
@@ -81,7 +90,14 @@ export async function writeRuntimeReadinessSignal(options: {
     startedAt: new Date().toISOString(),
   };
   await fs.mkdir(dirname(signalPath), { recursive: true });
-  await fs.writeFile(signalPath, `${JSON.stringify(signal, null, 2)}\n`, "utf8");
+  const tempPath = buildRuntimeReadinessTempPath(signalPath);
+  try {
+    await fs.writeFile(tempPath, `${JSON.stringify(signal, null, 2)}\n`, "utf8");
+    await fs.rename(tempPath, signalPath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
   return signalPath;
 }
 


### PR DESCRIPTION
## Summary
- switch runtime readiness signal writes to a temp-file-and-rename flow
- ensure interrupted temp writes do not surface as malformed canonical readiness payloads during restart verification
- add readiness regressions for atomic writes and interrupted temp files

Closes #341

## Validation
- pnpm vitest run src/runtime/runtimeReadiness.test.ts src/runtime/selfRestart.test.ts
- pnpm typecheck