### PR TITLE
fix(runtime): preserve malformed discord control state

### DIFF
--- a/src/runtime/gracefulShutdown.test.ts
+++ b/src/runtime/gracefulShutdown.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   consumeGracefulShutdownRequest,
   getDiscordControlCursorPath,
@@ -22,6 +22,8 @@ describe("gracefulShutdown", () => {
 
   afterEach(async () => {
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("records a pending graceful shutdown request once and preserves the first request details", async () => {
@@ -99,23 +101,56 @@ describe("gracefulShutdown", () => {
     await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual(result.request);
   });
 
-  it("normalizes persisted cursor and malformed shutdown payloads", async () => {
+  it("preserves malformed Discord control cursor state and rewrites a recoverable default", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T15:00:00.000Z"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     await writeDiscordControlCursor(workDir, "  7777  ");
     expect(await readDiscordControlCursor(workDir)).toBe("7777");
 
-    await writeFile(getDiscordControlCursorPath(workDir), "{not-json", "utf8");
+    const cursorPath = getDiscordControlCursorPath(workDir);
+    const corruptCursorPath = cursorPath.replace(".json", ".corrupt-1772895600000.json");
+    await writeFile(cursorPath, "{not-json", "utf8");
+
     await expect(readDiscordControlCursor(workDir)).resolves.toBeNull();
-
-    await writeFile(
-      getGracefulShutdownRequestPath(workDir),
-      JSON.stringify({ version: 1, source: "discord", command: "/quit", messageId: "   " }),
-      "utf8",
+    await expect(readFile(cursorPath, "utf8")).resolves.toBe(
+      `${JSON.stringify({ lastSeenMessageId: null, recoveredMalformed: true }, null, 2)}\n`,
     );
-    await expect(readGracefulShutdownRequest(workDir)).resolves.toBeNull();
+    await expect(readFile(corruptCursorPath, "utf8")).resolves.toBe("{not-json");
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed discord control cursor state store at ${cursorPath}; preserved corrupt file at ${corruptCursorPath}.`,
+    );
+  });
 
+  it("preserves malformed graceful shutdown state and rewrites a clean default", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T16:00:00.000Z"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const requestPath = getGracefulShutdownRequestPath(workDir);
+    const corruptRequestPath = requestPath.replace(".json", ".corrupt-1772899200000.json");
+    await recordGracefulShutdownRequest(workDir, { messageId: "seed-request" });
+    await writeFile(requestPath, JSON.stringify({ version: 1, source: "discord", command: "/quit", messageId: "   " }), "utf8");
+
+    await expect(readGracefulShutdownRequest(workDir)).resolves.toBeNull();
+    await expect(readFile(requestPath, "utf8")).resolves.toBe("null\n");
+    await expect(readFile(corruptRequestPath, "utf8")).resolves.toBe(
+      `${JSON.stringify({ version: 1, source: "discord", command: "/quit", messageId: "   " })}`,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed graceful shutdown request store at ${requestPath}; preserved corrupt file at ${corruptRequestPath}.`,
+    );
+  });
+
+  it("normalizes persisted graceful shutdown payloads", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await recordGracefulShutdownRequest(workDir, { messageId: "seed-request" });
     await writeFile(
       getGracefulShutdownRequestPath(workDir),
       JSON.stringify({

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const GRACEFUL_SHUTDOWN_REQUEST_FILE_NAME = "graceful-shutdown-request.json";
@@ -20,6 +20,7 @@ export type GracefulShutdownRequest = {
 
 type DiscordControlCursorState = {
   lastSeenMessageId: string | null;
+  recoveredMalformed?: boolean;
 };
 
 function isNonEmptyString(value: unknown): value is string {
@@ -74,34 +75,41 @@ function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest
   };
 }
 
-function normalizeDiscordControlCursorState(raw: unknown): DiscordControlCursorState {
+function normalizeDiscordControlCursorState(raw: unknown): DiscordControlCursorState | null {
   if (typeof raw !== "object" || raw === null) {
-    return { lastSeenMessageId: null };
+    return null;
   }
 
   const candidate = raw as Partial<DiscordControlCursorState>;
+  if (!Object.hasOwn(candidate, "lastSeenMessageId")) {
+    return null;
+  }
+
   return {
     lastSeenMessageId: normalizeMessageId(candidate.lastSeenMessageId),
+    recoveredMalformed: candidate.recoveredMalformed === true,
   };
-}
-
-async function readJsonFile(path: string): Promise<unknown | null> {
-  try {
-    const raw = await fs.readFile(path, "utf8");
-    return JSON.parse(raw) as unknown;
-  } catch (error) {
-    const errorCode = (error as NodeJS.ErrnoException).code;
-    if (errorCode === "ENOENT" || error instanceof SyntaxError) {
-      return null;
-    }
-
-    throw error;
-  }
 }
 
 async function writeJsonFile(path: string, value: unknown): Promise<void> {
   await fs.mkdir(dirname(path), { recursive: true });
   await fs.writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function buildCorruptStatePath(path: string, atMs = Date.now()): string {
+  const extension = extname(path);
+  const fileName = basename(path, extension);
+  return join(
+    dirname(path),
+    `${fileName}.corrupt-${Math.max(0, Math.floor(atMs))}${extension}`,
+  );
+}
+
+async function recoverMalformedJsonFile(path: string, defaultValue: unknown, warningLabel: string): Promise<void> {
+  const corruptPath = buildCorruptStatePath(path);
+  await fs.rename(path, corruptPath);
+  await writeJsonFile(path, defaultValue);
+  console.warn(`Recovered malformed ${warningLabel} at ${path}; preserved corrupt file at ${corruptPath}.`);
 }
 
 export function getGracefulShutdownRequestPath(workDir: string): string {
@@ -121,9 +129,57 @@ function getDiscordControlReceiptPath(workDir: string, command: string, messageI
   );
 }
 
+async function readGracefulShutdownRequestState(workDir: string): Promise<{
+  request: GracefulShutdownRequest | null;
+  recoveredMalformed: boolean;
+}> {
+  const path = getGracefulShutdownRequestPath(workDir);
+  try {
+    const raw = await fs.readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null) {
+      return {
+        request: null,
+        recoveredMalformed: false,
+      };
+    }
+
+    const normalized = normalizeGracefulShutdownRequest(parsed);
+    if (normalized !== null) {
+      return {
+        request: normalized,
+        recoveredMalformed: false,
+      };
+    }
+
+    await recoverMalformedJsonFile(path, null, "graceful shutdown request store");
+    return {
+      request: null,
+      recoveredMalformed: true,
+    };
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return {
+        request: null,
+        recoveredMalformed: false,
+      };
+    }
+
+    if (error instanceof SyntaxError) {
+      await recoverMalformedJsonFile(path, null, "graceful shutdown request store");
+      return {
+        request: null,
+        recoveredMalformed: true,
+      };
+    }
+
+    throw error;
+  }
+}
+
 export async function readGracefulShutdownRequest(workDir: string): Promise<GracefulShutdownRequest | null> {
-  const raw = await readJsonFile(getGracefulShutdownRequestPath(workDir));
-  return normalizeGracefulShutdownRequest(raw);
+  return (await readGracefulShutdownRequestState(workDir)).request;
 }
 
 export async function recordGracefulShutdownRequest(
@@ -176,13 +232,61 @@ export async function consumeGracefulShutdownRequest(workDir: string): Promise<G
 }
 
 export async function readDiscordControlCursor(workDir: string): Promise<string | null> {
-  const raw = await readJsonFile(getDiscordControlCursorPath(workDir));
-  return normalizeDiscordControlCursorState(raw).lastSeenMessageId;
+  return (await readDiscordControlCursorState(workDir)).lastSeenMessageId;
+}
+
+export async function readDiscordControlCursorState(workDir: string): Promise<{
+  lastSeenMessageId: string | null;
+  recoveredMalformed: boolean;
+}> {
+  const path = getDiscordControlCursorPath(workDir);
+  try {
+    const raw = await fs.readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    const normalized = normalizeDiscordControlCursorState(parsed);
+    if (normalized !== null) {
+      return {
+        lastSeenMessageId: normalized.lastSeenMessageId,
+        recoveredMalformed: normalized.recoveredMalformed === true,
+      };
+    }
+
+    await recoverMalformedJsonFile(path, {
+      lastSeenMessageId: null,
+      recoveredMalformed: true,
+    } satisfies DiscordControlCursorState, "discord control cursor state store");
+    return {
+      lastSeenMessageId: null,
+      recoveredMalformed: true,
+    };
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return {
+        lastSeenMessageId: null,
+        recoveredMalformed: false,
+      };
+    }
+
+    if (error instanceof SyntaxError) {
+      await recoverMalformedJsonFile(path, {
+        lastSeenMessageId: null,
+        recoveredMalformed: true,
+      } satisfies DiscordControlCursorState, "discord control cursor state store");
+      return {
+        lastSeenMessageId: null,
+        recoveredMalformed: true,
+      };
+    }
+
+    throw error;
+  }
 }
 
 export async function writeDiscordControlCursor(workDir: string, lastSeenMessageId: string | null): Promise<void> {
   await writeJsonFile(getDiscordControlCursorPath(workDir), {
     lastSeenMessageId: normalizeMessageId(lastSeenMessageId),
+    recoveredMalformed: false,
   } satisfies DiscordControlCursorState);
 }
 

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -447,6 +447,56 @@ describe("operatorControl", () => {
           content: "<@operator-1> Queue-drain shutdown requested.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
         }),
       }),
+    );
+  });
+
+  it("replays unread control backlog when the persisted cursor file is malformed", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await gracefulShutdown.writeDiscordControlCursor(workDir, null);
+    await writeFile(gracefulShutdown.getDiscordControlCursorPath(workDir), "{not-json", "utf8");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            createDiscordControlMessage(7060, "noise"),
+            createDiscordControlMessage(7061, "/quit", "operator-1"),
+          ]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-recovered-cursor" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(request).toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit",
+      mode: "after-current-task",
+      messageId: "7061",
+      requestedAt: expect.any(String),
+    });
+    expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("7061");
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      "https://discord.com/api/v10/channels/channel-1/messages?limit=50",
+      expect.any(Object),
+    );
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/channel-1/messages?limit=1",
+      expect.anything(),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Recovered malformed discord control cursor state store"),
     );
   });
 

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -1,7 +1,7 @@
 import {
   recordDiscordControlCommandReceipt,
   recordGracefulShutdownRequest,
-  readDiscordControlCursor,
+  readDiscordControlCursorState,
   type GracefulShutdownMode,
   type GracefulShutdownRequest,
   writeDiscordControlCursor,
@@ -436,9 +436,9 @@ async function initializeDiscordControlCursor(
   config: DiscordControlConfig,
   workDir: string,
 ): Promise<string | null> {
-  const existingCursor = await readDiscordControlCursor(workDir);
-  if (existingCursor !== null) {
-    return existingCursor;
+  const existingCursor = await readDiscordControlCursorState(workDir);
+  if (existingCursor.lastSeenMessageId !== null || existingCursor.recoveredMalformed) {
+    return existingCursor.lastSeenMessageId;
   }
 
   const messages = await fetchControlChannelMessages(config, { limit: 1 });


### PR DESCRIPTION
## Summary
- preserve malformed Discord control cursor and shutdown state files as `.corrupt-<timestamp>.json` backups
- rewrite clean default state after recovery instead of silently treating malformed payloads as missing
- avoid reseeding the Discord control cursor to the newest message after malformed cursor recovery so unread backlog commands are still processed

## Testing
- pnpm vitest run src/runtime/gracefulShutdown.test.ts src/runtime/operatorControl.test.ts
- pnpm typecheck

## Notes
- An additional `pnpm vitest run src/main.test.ts` check still reports unrelated existing failures in the challenge metrics assertions.
- Closes #340
