### PR TITLE
fix(challenges): avoid attempt artifact collisions

### DIFF
--- a/src/challenges/challengeAttemptArtifacts.test.ts
+++ b/src/challenges/challengeAttemptArtifacts.test.ts
@@ -1,7 +1,8 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { promises as nodeFs } from "node:fs";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { persistChallengeAttemptArtifact } from "./challengeAttemptArtifacts.js";
 
 async function createTempWorkDir(): Promise<string> {
@@ -14,6 +15,7 @@ describe("challengeAttemptArtifacts", () => {
   afterEach(async () => {
     await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
     tempDirs.length = 0;
+    vi.restoreAllMocks();
   });
 
   it("writes a deterministic failure artifact with runtime error fields", async () => {
@@ -128,5 +130,74 @@ describe("challengeAttemptArtifacts", () => {
       outcome: "failure",
     }));
     expect(parsed.runtimeError).toEqual(expect.objectContaining({ message: "second" }));
+  });
+
+  it("keeps concurrent attempt artifacts unique when writes overlap", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const originalWriteFile = nodeFs.writeFile.bind(nodeFs);
+    vi.spyOn(nodeFs, "writeFile").mockImplementation(async (...args) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return originalWriteFile(...args);
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, index) => persistChallengeAttemptArtifact(workDir, {
+        challengeIssueNumber: 144,
+        runResult: null,
+        runError: new Error(`failure-${index + 1}`),
+        nowMs: 1_700_000_000_100 + index,
+      })),
+    );
+
+    expect(results.map((result) => result.artifact.attempt).sort((left, right) => left - right)).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+    ]);
+    expect(new Set(results.map((result) => result.relativePath)).size).toBe(8);
+
+    const attemptDirectory = join(workDir, ".evolvo", "challenge-attempts", "144");
+    const persistedFiles = (await readdir(attemptDirectory)).sort();
+    expect(persistedFiles).toEqual([
+      "0001.json",
+      "0002.json",
+      "0003.json",
+      "0004.json",
+      "0005.json",
+      "0006.json",
+      "0007.json",
+      "0008.json",
+    ]);
+
+    const persistedMessages = await Promise.all(
+      persistedFiles.map(async (fileName) => {
+        const raw = await readFile(join(attemptDirectory, fileName), "utf8");
+        return (JSON.parse(raw) as {
+          attempt: number;
+          runtimeError: { message: string } | null;
+        });
+      }),
+    );
+
+    expect(persistedMessages.map((artifact) => artifact.attempt).sort((left, right) => left - right)).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+    ]);
+    expect(
+      new Set(persistedMessages.map((artifact) => artifact.runtimeError?.message ?? "missing")).size,
+    ).toBe(8);
   });
 });

--- a/src/challenges/challengeAttemptArtifacts.ts
+++ b/src/challenges/challengeAttemptArtifacts.ts
@@ -137,6 +137,29 @@ function getChallengeAttemptDirectory(workDir: string, challengeIssueNumber: num
   return join(workDir, EVOLVO_DIRECTORY_NAME, CHALLENGE_ATTEMPTS_DIRECTORY_NAME, String(challengeIssueNumber));
 }
 
+function buildChallengeAttemptArtifact(options: {
+  challengeIssueNumber: number;
+  attempt: number;
+  nowMs: number;
+  runResult: CodingAgentRunResult | null;
+  runError: unknown;
+}): ChallengeAttemptArtifact {
+  const success = options.runError === null &&
+    options.runResult !== null &&
+    options.runResult.summary.reviewOutcome === "accepted";
+
+  return {
+    schemaVersion: ARTIFACT_SCHEMA_VERSION,
+    challengeIssueNumber: options.challengeIssueNumber,
+    attempt: options.attempt,
+    attemptedAtMs: options.nowMs,
+    attemptedAtIso: new Date(options.nowMs).toISOString(),
+    outcome: success ? "success" : "failure",
+    executionSummary: buildExecutionSummary(options.runResult),
+    runtimeError: summarizeRuntimeError(options.runError),
+  };
+}
+
 async function getNextAttemptNumber(attemptDirectoryPath: string): Promise<number> {
   const entries = await fs.readdir(attemptDirectoryPath, { withFileTypes: true });
   const attempts = entries
@@ -166,22 +189,32 @@ export async function persistChallengeAttemptArtifact(
   const nowMs = toFiniteNonNegativeInteger(input.nowMs ?? Date.now());
   const attemptDirectoryPath = getChallengeAttemptDirectory(workDir, challengeIssueNumber);
   await fs.mkdir(attemptDirectoryPath, { recursive: true });
-  const attempt = await getNextAttemptNumber(attemptDirectoryPath);
-  const artifactFileName = formatAttemptFileName(attempt);
-  const relativePath = `${EVOLVO_DIRECTORY_NAME}/${CHALLENGE_ATTEMPTS_DIRECTORY_NAME}/${challengeIssueNumber}/${artifactFileName}`;
-  const absolutePath = join(attemptDirectoryPath, artifactFileName);
-  const success = input.runError === null && input.runResult !== null && input.runResult.summary.reviewOutcome === "accepted";
-  const artifact: ChallengeAttemptArtifact = {
-    schemaVersion: ARTIFACT_SCHEMA_VERSION,
-    challengeIssueNumber,
-    attempt,
-    attemptedAtMs: nowMs,
-    attemptedAtIso: new Date(nowMs).toISOString(),
-    outcome: success ? "success" : "failure",
-    executionSummary: buildExecutionSummary(input.runResult),
-    runtimeError: summarizeRuntimeError(input.runError),
-  };
+  let attempt = await getNextAttemptNumber(attemptDirectoryPath);
 
-  await fs.writeFile(absolutePath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
-  return { artifact, relativePath, absolutePath };
+  while (true) {
+    const artifactFileName = formatAttemptFileName(attempt);
+    const relativePath = `${EVOLVO_DIRECTORY_NAME}/${CHALLENGE_ATTEMPTS_DIRECTORY_NAME}/${challengeIssueNumber}/${artifactFileName}`;
+    const absolutePath = join(attemptDirectoryPath, artifactFileName);
+    const artifact = buildChallengeAttemptArtifact({
+      challengeIssueNumber,
+      attempt,
+      nowMs,
+      runResult: input.runResult,
+      runError: input.runError,
+    });
+
+    try {
+      await fs.writeFile(absolutePath, `${JSON.stringify(artifact, null, 2)}\n`, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      return { artifact, relativePath, absolutePath };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+
+      attempt += 1;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- make challenge attempt artifact writes exclusive with retry-on-collision numbering
- preserve the existing numbering scheme while preventing overlapping writes from overwriting earlier evidence
- add a concurrency regression that forces overlapping writes and proves every attempt file stays unique

## Testing
- pnpm vitest run src/challenges/challengeAttemptArtifacts.test.ts
- pnpm typecheck

Closes #338
