### PR TITLE
fix(runtime): retry malformed readiness payloads

### DIFF
--- a/src/runtime/runtimeReadiness.test.ts
+++ b/src/runtime/runtimeReadiness.test.ts
@@ -125,7 +125,38 @@ describe("runtimeReadiness", () => {
     );
   });
 
-  it("fails when readiness file payload is malformed", async () => {
+  it("retries when the canonical readiness file is transiently malformed", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const signalPath = getRuntimeReadinessSignalPath(workDir);
+    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    await writeFile(signalPath, "{not-json", "utf8");
+
+    const waitPromise = waitForRuntimeReadinessSignal({
+      workDir,
+      token: "expected-token",
+      timeoutMs: 400,
+      pollIntervalMs: 20,
+      signalPath,
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 60);
+    });
+    await writeRuntimeReadinessSignal({
+      workDir,
+      token: "expected-token",
+      signalPath,
+    });
+
+    await expect(waitPromise).resolves.toEqual(
+      expect.objectContaining({
+        token: "expected-token",
+        status: "ready",
+      }),
+    );
+  });
+
+  it("times out with malformed payload diagnostics when readiness file never becomes valid", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     const signalPath = getRuntimeReadinessSignalPath(workDir);
@@ -140,6 +171,8 @@ describe("runtimeReadiness", () => {
         pollIntervalMs: 10,
         signalPath,
       }),
-    ).rejects.toThrow(`Could not read runtime readiness signal at ${signalPath}`);
+    ).rejects.toThrow(
+      `Timed out after 80ms waiting for runtime readiness token expected-token at ${signalPath}. Last observed payload was malformed.`,
+    );
   });
 });

--- a/src/runtime/runtimeReadiness.ts
+++ b/src/runtime/runtimeReadiness.ts
@@ -64,7 +64,7 @@ async function readRuntimeReadinessSignal(signalPath: string): Promise<RuntimeRe
     };
   } catch (error) {
     const errorCode = (error as NodeJS.ErrnoException).code;
-    if (errorCode === "ENOENT") {
+    if (errorCode === "ENOENT" || error instanceof SyntaxError) {
       return null;
     }
 


### PR DESCRIPTION
## Summary
- treat malformed canonical runtime readiness payloads as not-ready-yet during polling instead of aborting immediately
- preserve the existing timeout diagnostic that notes when the last observed payload was malformed
- add regression coverage for both transient malformed readiness files and the timeout path when the payload never becomes valid

## Testing
- pnpm vitest run src/runtime/runtimeReadiness.test.ts src/runtime/selfRestart.test.ts
- pnpm typecheck

Closes #337
