### PR TITLE
fix(state): archive invalid local payloads

### DIFF
--- a/src/challenges/challengeMetrics.test.ts
+++ b/src/challenges/challengeMetrics.test.ts
@@ -206,4 +206,59 @@ describe("challengeMetrics", () => {
       `Recovered malformed challenge metrics store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
     );
   });
+
+  it("archives parseable but invalid metrics payloads before normalizing them", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-08T00:40:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "challenge-metrics.json");
+    const corruptPath = join(evolvoDir, `challenge-metrics.corrupt-${recoveryAtMs}.json`);
+    const invalidPayload = {
+      total: -1,
+      success: 2,
+      failure: "oops",
+      attemptsToSuccess: {
+        total: 3,
+        samples: 0,
+        average: 99,
+      },
+      categoryCounts: {
+        "": 4,
+        kept: 2,
+      },
+      pendingAttemptsByChallenge: {
+        bad: -2,
+        101: 1,
+      },
+    };
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(statePath, JSON.stringify(invalidPayload), "utf8");
+
+    const metrics = await readChallengeMetrics(workDir);
+
+    expect(metrics).toEqual({
+      total: 0,
+      success: 2,
+      failure: 0,
+      attemptsToSuccess: {
+        total: 3,
+        samples: 0,
+        average: 0,
+      },
+      categoryCounts: {
+        kept: 2,
+      },
+      pendingAttemptsByChallenge: {
+        101: 1,
+      },
+    });
+    expect(await readFile(corruptPath, "utf8")).toBe(JSON.stringify(invalidPayload));
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered invalid challenge metrics store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
 });

--- a/src/challenges/challengeMetrics.ts
+++ b/src/challenges/challengeMetrics.ts
@@ -1,6 +1,9 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import { readRecoverableJsonState } from "../runtime/localStateFile.js";
+import {
+  readRecoverableJsonState,
+  type RecoverableJsonStateNormalizationResult,
+} from "../runtime/localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const CHALLENGE_METRICS_FILE_NAME = "challenge-metrics.json";
@@ -61,42 +64,95 @@ function sortNumericRecord(record: Record<string, number>): Record<string, numbe
   return Object.fromEntries(entries);
 }
 
-function normalizeMetricsShape(metrics: unknown): ChallengeMetrics {
+function normalizeMetricsShape(metrics: unknown): RecoverableJsonStateNormalizationResult<ChallengeMetrics> {
   if (typeof metrics !== "object" || metrics === null) {
-    return createDefaultMetrics();
+    return {
+      state: createDefaultMetrics(),
+      recoveredInvalid: true,
+    };
   }
 
   const candidate = metrics as Partial<ChallengeMetrics>;
+  let recoveredInvalid = false;
   const total = toFiniteNonNegativeInteger(candidate.total);
+  if (candidate.total !== undefined && total !== candidate.total) {
+    recoveredInvalid = true;
+  }
   const success = toFiniteNonNegativeInteger(candidate.success);
+  if (candidate.success !== undefined && success !== candidate.success) {
+    recoveredInvalid = true;
+  }
   const failure = toFiniteNonNegativeInteger(candidate.failure);
+  if (candidate.failure !== undefined && failure !== candidate.failure) {
+    recoveredInvalid = true;
+  }
   const attemptsToSuccessTotal = toFiniteNonNegativeInteger(candidate.attemptsToSuccess?.total);
+  if (candidate.attemptsToSuccess?.total !== undefined && attemptsToSuccessTotal !== candidate.attemptsToSuccess.total) {
+    recoveredInvalid = true;
+  }
   const attemptsToSuccessSamples = toFiniteNonNegativeInteger(candidate.attemptsToSuccess?.samples);
+  if (candidate.attemptsToSuccess?.samples !== undefined && attemptsToSuccessSamples !== candidate.attemptsToSuccess.samples) {
+    recoveredInvalid = true;
+  }
   const attemptsToSuccessAverage = attemptsToSuccessSamples === 0
     ? 0
     : Number((attemptsToSuccessTotal / attemptsToSuccessSamples).toFixed(2));
+  if (
+    candidate.attemptsToSuccess !== undefined &&
+    (
+      typeof candidate.attemptsToSuccess !== "object" ||
+      candidate.attemptsToSuccess === null ||
+      (
+        candidate.attemptsToSuccess.average !== undefined &&
+        candidate.attemptsToSuccess.average !== attemptsToSuccessAverage
+      )
+    )
+  ) {
+    recoveredInvalid = true;
+  }
+  if (candidate.categoryCounts !== undefined && (typeof candidate.categoryCounts !== "object" || candidate.categoryCounts === null)) {
+    recoveredInvalid = true;
+  }
   const categoryCounts = sortNumericRecord(
     Object.fromEntries(
-      Object.entries(candidate.categoryCounts ?? {}).map(([key, value]) => [key, toFiniteNonNegativeInteger(value)]),
+      Object.entries(candidate.categoryCounts ?? {}).map(([key, value]) => {
+        const normalizedValue = toFiniteNonNegativeInteger(value);
+        if (key.trim().length === 0 || normalizedValue !== value || normalizedValue <= 0) {
+          recoveredInvalid = true;
+        }
+        return [key, normalizedValue];
+      }),
     ),
   );
+  if (candidate.pendingAttemptsByChallenge !== undefined && (typeof candidate.pendingAttemptsByChallenge !== "object" || candidate.pendingAttemptsByChallenge === null)) {
+    recoveredInvalid = true;
+  }
   const pendingAttemptsByChallenge = sortNumericRecord(
     Object.fromEntries(
-      Object.entries(candidate.pendingAttemptsByChallenge ?? {}).map(([key, value]) => [key, toFiniteNonNegativeInteger(value)]),
+      Object.entries(candidate.pendingAttemptsByChallenge ?? {}).map(([key, value]) => {
+        const normalizedValue = toFiniteNonNegativeInteger(value);
+        if (key.trim().length === 0 || normalizedValue !== value || normalizedValue <= 0) {
+          recoveredInvalid = true;
+        }
+        return [key, normalizedValue];
+      }),
     ),
   );
 
   return {
-    total,
-    success,
-    failure,
-    attemptsToSuccess: {
-      total: attemptsToSuccessTotal,
-      samples: attemptsToSuccessSamples,
-      average: attemptsToSuccessAverage,
+    state: {
+      total,
+      success,
+      failure,
+      attemptsToSuccess: {
+        total: attemptsToSuccessTotal,
+        samples: attemptsToSuccessSamples,
+        average: attemptsToSuccessAverage,
+      },
+      categoryCounts,
+      pendingAttemptsByChallenge,
     },
-    categoryCounts,
-    pendingAttemptsByChallenge,
+    recoveredInvalid,
   };
 }
 
@@ -116,7 +172,7 @@ export async function readChallengeMetrics(workDir: string): Promise<ChallengeMe
 export async function writeChallengeMetrics(workDir: string, metrics: ChallengeMetrics): Promise<void> {
   const metricsPath = getMetricsPath(workDir);
   await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
-  await fs.writeFile(metricsPath, `${JSON.stringify(normalizeMetricsShape(metrics), null, 2)}\n`, "utf8");
+  await fs.writeFile(metricsPath, `${JSON.stringify(normalizeMetricsShape(metrics).state, null, 2)}\n`, "utf8");
 }
 
 export async function recordChallengeAttemptMetrics(
@@ -145,7 +201,7 @@ export async function recordChallengeAttemptMetrics(
     metrics.categoryCounts[category] = toFiniteNonNegativeInteger(metrics.categoryCounts[category]) + 1;
   }
 
-  const normalized = normalizeMetricsShape(metrics);
+  const normalized = normalizeMetricsShape(metrics).state;
   await writeChallengeMetrics(workDir, normalized);
   return normalized;
 }
@@ -159,7 +215,7 @@ function formatRate(numerator: number, denominator: number): string {
 }
 
 export function formatChallengeMetricsReport(metrics: ChallengeMetrics): string {
-  const normalized = normalizeMetricsShape(metrics);
+  const normalized = normalizeMetricsShape(metrics).state;
   const failureCategoryEntries = Object.entries(normalized.categoryCounts);
   const pendingChallenges = Object.keys(normalized.pendingAttemptsByChallenge).length;
   const failureCategoryLine = failureCategoryEntries.length === 0

--- a/src/challenges/retryGate.test.ts
+++ b/src/challenges/retryGate.test.ts
@@ -276,4 +276,45 @@ describe("retryGate", () => {
       `Recovered malformed challenge retry state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
     );
   });
+
+  it("archives parseable but invalid retry state payloads before normalizing them", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-08T00:50:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "challenge-retry-state.json");
+    const corruptPath = join(evolvoDir, `challenge-retry-state.corrupt-${recoveryAtMs}.json`);
+    const invalidPayload = {
+      failuresByChallenge: {
+        15: {
+          attempts: 2,
+          lastFailureAtMs: 1000,
+        },
+        99: {
+          attempts: -1,
+          lastFailureAtMs: "bad",
+        },
+      },
+    };
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(statePath, JSON.stringify(invalidPayload), "utf8");
+
+    const state = await readChallengeRetryState(workDir);
+
+    expect(state).toEqual({
+      failuresByChallenge: {
+        15: {
+          attempts: 2,
+          lastFailureAtMs: 1000,
+        },
+      },
+    });
+    expect(await readFile(corruptPath, "utf8")).toBe(JSON.stringify(invalidPayload));
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered invalid challenge retry state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
 });

--- a/src/challenges/retryGate.ts
+++ b/src/challenges/retryGate.ts
@@ -2,7 +2,10 @@ import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { hasIssueLabel, isChallengeIssue } from "../issues/challengeIssue.js";
 import type { IssueSummary } from "../issues/taskIssueManager.js";
-import { readRecoverableJsonState } from "../runtime/localStateFile.js";
+import {
+  readRecoverableJsonState,
+  type RecoverableJsonStateNormalizationResult,
+} from "../runtime/localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const CHALLENGE_RETRY_STATE_FILE_NAME = "challenge-retry-state.json";
@@ -63,23 +66,43 @@ function toFiniteNonNegativeInteger(value: unknown): number {
   return Math.floor(asNumber);
 }
 
-function normalizeRetryState(state: unknown): ChallengeRetryState {
+function normalizeRetryState(state: unknown): RecoverableJsonStateNormalizationResult<ChallengeRetryState> {
   if (typeof state !== "object" || state === null) {
-    return createDefaultRetryState();
+    return {
+      state: createDefaultRetryState(),
+      recoveredInvalid: true,
+    };
   }
 
+  let recoveredInvalid = false;
+  const candidate = state as Partial<ChallengeRetryState>;
+  if (candidate.failuresByChallenge !== undefined && (typeof candidate.failuresByChallenge !== "object" || candidate.failuresByChallenge === null)) {
+    recoveredInvalid = true;
+  }
   const failuresByChallenge = Object.fromEntries(
-    Object.entries((state as Partial<ChallengeRetryState>).failuresByChallenge ?? {})
+    Object.entries(candidate.failuresByChallenge ?? {})
       .map(([challengeNumber, value]) => {
         const attempts = toFiniteNonNegativeInteger(value?.attempts);
         const lastFailureAtMs = toFiniteNonNegativeInteger(value?.lastFailureAtMs);
+        if (
+          typeof value !== "object" ||
+          value === null ||
+          attempts <= 0 ||
+          attempts !== value.attempts ||
+          lastFailureAtMs !== value.lastFailureAtMs
+        ) {
+          recoveredInvalid = true;
+        }
         return [challengeNumber, { attempts, lastFailureAtMs }] as const;
       })
       .filter(([, value]) => value.attempts > 0)
       .sort(([left], [right]) => left.localeCompare(right)),
   );
 
-  return { failuresByChallenge };
+  return {
+    state: { failuresByChallenge },
+    recoveredInvalid,
+  };
 }
 
 function getRetryStatePath(workDir: string): string {
@@ -122,7 +145,7 @@ async function writeChallengeRetryState(workDir: string, state: ChallengeRetrySt
   await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
   await fs.writeFile(
     getRetryStatePath(workDir),
-    `${JSON.stringify(normalizeRetryState(state), null, 2)}\n`,
+    `${JSON.stringify(normalizeRetryState(state).state, null, 2)}\n`,
     "utf8",
   );
 }
@@ -145,7 +168,7 @@ export async function recordChallengeAttemptOutcome(
     };
   }
 
-  const normalized = normalizeRetryState(state);
+  const normalized = normalizeRetryState(state).state;
   await writeChallengeRetryState(workDir, normalized);
   return normalized;
 }

--- a/src/runtime/lifecycleState.test.ts
+++ b/src/runtime/lifecycleState.test.ts
@@ -183,12 +183,19 @@ describe("lifecycleState", () => {
     expect(state.issues["77"]?.state).toBe("completed");
   });
 
-  it("normalizes malformed persisted state", async () => {
+  it("archives parseable but invalid persisted state before normalizing it", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-08T00:30:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
-    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "runtime-lifecycle-state.json");
+    const corruptPath = join(evolvoDir, `runtime-lifecycle-state.corrupt-${recoveryAtMs}.json`);
+    await mkdir(evolvoDir, { recursive: true });
     await writeFile(
-      join(workDir, ".evolvo", "runtime-lifecycle-state.json"),
+      statePath,
       JSON.stringify({
         version: 0,
         issues: {
@@ -210,6 +217,25 @@ describe("lifecycleState", () => {
     expect(Object.keys(state.issues)).toEqual(["12"]);
     expect(state.issues["12"]?.state).toBe("blocked");
     expect(state.version).toBe(1);
+    expect(await readFile(corruptPath, "utf8")).toBe(
+      JSON.stringify({
+        version: 0,
+        issues: {
+          abc: { state: "unknown" },
+          12: {
+            issueNumber: 12,
+            kind: "challenge",
+            state: "blocked",
+            updatedAt: "2020-01-01T00:00:00.000Z",
+            transitionCount: 2,
+            history: [{ from: null, to: "blocked", at: "2020-01-01T00:00:00.000Z", reason: "x", runCycle: 1 }],
+          },
+        },
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered invalid lifecycle state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
   });
 
   it("preserves malformed lifecycle state JSON and resets to a default store", async () => {

--- a/src/runtime/lifecycleState.ts
+++ b/src/runtime/lifecycleState.ts
@@ -1,6 +1,9 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import { readRecoverableJsonState } from "./localStateFile.js";
+import {
+  readRecoverableJsonState,
+  type RecoverableJsonStateNormalizationResult,
+} from "./localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const LIFECYCLE_STATE_FILE_NAME = "runtime-lifecycle-state.json";
@@ -113,49 +116,83 @@ function createDefaultStateStore(): LifecycleStateStore {
   };
 }
 
-function normalizeStateStore(raw: unknown): LifecycleStateStore {
+function normalizeStateStore(raw: unknown): RecoverableJsonStateNormalizationResult<LifecycleStateStore> {
   if (typeof raw !== "object" || raw === null) {
-    return createDefaultStateStore();
+    return {
+      state: createDefaultStateStore(),
+      recoveredInvalid: true,
+    };
   }
 
   const candidate = raw as Partial<LifecycleStateStore>;
+  let recoveredInvalid = candidate.version !== LIFECYCLE_STATE_VERSION;
+  if (candidate.issues !== undefined && (typeof candidate.issues !== "object" || candidate.issues === null)) {
+    recoveredInvalid = true;
+  }
   const entries = Object.entries(candidate.issues ?? {});
   const issues = Object.fromEntries(
     entries.flatMap(([issueKey, value]) => {
       if (typeof value !== "object" || value === null) {
+        recoveredInvalid = true;
         return [];
       }
 
       const issueNumber = toFinitePositiveInteger((value as Partial<CanonicalLifecycleEntry>).issueNumber ?? issueKey);
       const state = (value as Partial<CanonicalLifecycleEntry>).state;
       if (issueNumber === null || !isCanonicalLifecycleState(state)) {
+        recoveredInvalid = true;
         return [];
       }
 
-      const kind = (value as Partial<CanonicalLifecycleEntry>).kind === "challenge" ? "challenge" : "issue";
+      const kindRaw = (value as Partial<CanonicalLifecycleEntry>).kind;
+      const kind = kindRaw === "challenge" ? "challenge" : "issue";
+      if (kindRaw !== undefined && kindRaw !== "challenge" && kindRaw !== "issue") {
+        recoveredInvalid = true;
+      }
       const transitionCountRaw = toFinitePositiveInteger((value as Partial<CanonicalLifecycleEntry>).transitionCount);
+      if ((value as Partial<CanonicalLifecycleEntry>).transitionCount !== undefined && transitionCountRaw === null) {
+        recoveredInvalid = true;
+      }
       const transitionCount = transitionCountRaw ?? 1;
       const updatedAtRaw = (value as Partial<CanonicalLifecycleEntry>).updatedAt;
       const updatedAt = typeof updatedAtRaw === "string" && updatedAtRaw.trim().length > 0
         ? updatedAtRaw
         : new Date(0).toISOString();
+      if (updatedAtRaw !== undefined && updatedAtRaw !== updatedAt) {
+        recoveredInvalid = true;
+      }
       const historyRaw = (value as Partial<CanonicalLifecycleEntry>).history;
       const history = Array.isArray(historyRaw)
         ? historyRaw.map((historyItem) => {
             if (typeof historyItem !== "object" || historyItem === null) {
+              recoveredInvalid = true;
               return null;
             }
 
             const fromRaw = (historyItem as { from?: unknown }).from;
             const from = fromRaw === null || isCanonicalLifecycleState(fromRaw) ? fromRaw : null;
+            if (fromRaw !== undefined && fromRaw !== null && !isCanonicalLifecycleState(fromRaw)) {
+              recoveredInvalid = true;
+            }
             const toRaw = (historyItem as { to?: unknown }).to;
             if (!isCanonicalLifecycleState(toRaw)) {
+              recoveredInvalid = true;
               return null;
             }
 
             const atRaw = (historyItem as { at?: unknown }).at;
             const reasonRaw = (historyItem as { reason?: unknown }).reason;
             const runCycleRaw = toFinitePositiveInteger((historyItem as { runCycle?: unknown }).runCycle);
+            const runCycleSource = (historyItem as { runCycle?: unknown }).runCycle;
+            if (runCycleSource !== undefined && runCycleSource !== null && runCycleRaw === null) {
+              recoveredInvalid = true;
+            }
+            if (atRaw !== undefined && (typeof atRaw !== "string" || atRaw.trim().length === 0)) {
+              recoveredInvalid = true;
+            }
+            if (reasonRaw !== undefined && reasonRaw !== null && (typeof reasonRaw !== "string" || reasonRaw.trim().length === 0)) {
+              recoveredInvalid = true;
+            }
             return {
               from,
               to: toRaw,
@@ -167,6 +204,9 @@ function normalizeStateStore(raw: unknown): LifecycleStateStore {
           .filter((item): item is CanonicalLifecycleEntry["history"][number] => item !== null)
           .slice(-MAX_HISTORY_ENTRIES)
         : [];
+      if (historyRaw !== undefined && !Array.isArray(historyRaw)) {
+        recoveredInvalid = true;
+      }
 
       return [[String(issueNumber), {
         issueNumber,
@@ -180,8 +220,11 @@ function normalizeStateStore(raw: unknown): LifecycleStateStore {
   );
 
   return {
-    version: LIFECYCLE_STATE_VERSION,
-    issues,
+    state: {
+      version: LIFECYCLE_STATE_VERSION,
+      issues,
+    },
+    recoveredInvalid,
   };
 }
 
@@ -196,7 +239,7 @@ export async function readCanonicalLifecycleState(workDir: string): Promise<Life
 
 async function writeCanonicalLifecycleState(workDir: string, state: LifecycleStateStore): Promise<void> {
   await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
-  await fs.writeFile(getStatePath(workDir), `${JSON.stringify(normalizeStateStore(state), null, 2)}\n`, "utf8");
+  await fs.writeFile(getStatePath(workDir), `${JSON.stringify(normalizeStateStore(state).state, null, 2)}\n`, "utf8");
 }
 
 export async function transitionCanonicalLifecycleState(

--- a/src/runtime/localStateFile.test.ts
+++ b/src/runtime/localStateFile.test.ts
@@ -25,7 +25,7 @@ describe("localStateFile", () => {
     const state = await readRecoverableJsonState({
       statePath: join(workDir, ".evolvo", "test-state.json"),
       createDefaultState: () => ({ value: 1 }),
-      normalizeState: (raw) => raw as { value: number },
+      normalizeState: (raw) => ({ state: raw as { value: number }, recoveredInvalid: false }),
       warningLabel: "test state store",
     });
 
@@ -48,7 +48,7 @@ describe("localStateFile", () => {
     const state = await readRecoverableJsonState({
       statePath,
       createDefaultState: () => ({ value: 0 }),
-      normalizeState: (raw) => raw as { value: number },
+      normalizeState: (raw) => ({ state: raw as { value: number }, recoveredInvalid: false }),
       warningLabel: "test state store",
     });
 
@@ -57,6 +57,46 @@ describe("localStateFile", () => {
     expect(JSON.parse(await readFile(statePath, "utf8"))).toEqual({ value: 0 });
     expect(warnSpy).toHaveBeenCalledWith(
       `Recovered malformed test state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
+
+  it("preserves parseable but invalid JSON, rewrites the normalized state, and warns", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-08T00:20:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    const statePath = join(evolvoDir, "test-state.json");
+    const corruptPath = join(evolvoDir, `test-state.corrupt-${recoveryAtMs}.json`);
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(statePath, JSON.stringify({ value: -5 }), "utf8");
+
+    const state = await readRecoverableJsonState({
+      statePath,
+      createDefaultState: () => ({ value: 0 }),
+      normalizeState: (raw) => {
+        if (typeof raw !== "object" || raw === null || typeof (raw as { value?: unknown }).value !== "number" || (raw as { value: number }).value < 0) {
+          return {
+            state: { value: 0 },
+            recoveredInvalid: true,
+          };
+        }
+
+        return {
+          state: raw as { value: number },
+          recoveredInvalid: false,
+        };
+      },
+      warningLabel: "test state store",
+    });
+
+    expect(state).toEqual({ value: 0 });
+    expect(await readFile(corruptPath, "utf8")).toBe(JSON.stringify({ value: -5 }));
+    expect(JSON.parse(await readFile(statePath, "utf8"))).toEqual({ value: 0 });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered invalid test state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
     );
   });
 });

--- a/src/runtime/localStateFile.ts
+++ b/src/runtime/localStateFile.ts
@@ -1,10 +1,15 @@
 import { promises as fs } from "node:fs";
 import { basename, dirname, extname, join } from "node:path";
 
+export type RecoverableJsonStateNormalizationResult<T> = {
+  state: T;
+  recoveredInvalid: boolean;
+};
+
 type ReadRecoverableJsonStateOptions<T> = {
   statePath: string;
   createDefaultState: () => T;
-  normalizeState: (raw: unknown) => T;
+  normalizeState: (raw: unknown) => RecoverableJsonStateNormalizationResult<T>;
   warningLabel: string;
 };
 
@@ -26,7 +31,12 @@ export async function readRecoverableJsonState<T>(
 ): Promise<T> {
   try {
     const raw = await fs.readFile(options.statePath, "utf8");
-    return options.normalizeState(JSON.parse(raw) as unknown);
+    const normalized = options.normalizeState(JSON.parse(raw) as unknown);
+    if (!normalized.recoveredInvalid) {
+      return normalized.state;
+    }
+
+    return recoverInvalidJsonState(options, normalized.state);
   } catch (error) {
     const errorCode = (error as NodeJS.ErrnoException).code;
     if (errorCode === "ENOENT") {
@@ -46,11 +56,25 @@ async function recoverMalformedJsonState<T>(
 ): Promise<T> {
   const corruptPath = buildCorruptStatePath(options.statePath);
   await fs.rename(options.statePath, corruptPath);
-  const defaultState = options.normalizeState(options.createDefaultState());
+  const defaultState = options.normalizeState(options.createDefaultState()).state;
   await fs.mkdir(dirname(options.statePath), { recursive: true });
   await fs.writeFile(options.statePath, `${JSON.stringify(defaultState, null, 2)}\n`, "utf8");
   console.warn(
     `Recovered malformed ${options.warningLabel} at ${options.statePath}; preserved corrupt file at ${corruptPath}.`,
   );
   return defaultState;
+}
+
+async function recoverInvalidJsonState<T>(
+  options: ReadRecoverableJsonStateOptions<T>,
+  normalizedState: T,
+): Promise<T> {
+  const corruptPath = buildCorruptStatePath(options.statePath);
+  await fs.rename(options.statePath, corruptPath);
+  await fs.mkdir(dirname(options.statePath), { recursive: true });
+  await fs.writeFile(options.statePath, `${JSON.stringify(normalizedState, null, 2)}\n`, "utf8");
+  console.warn(
+    `Recovered invalid ${options.warningLabel} at ${options.statePath}; preserved corrupt file at ${corruptPath}.`,
+  );
+  return normalizedState;
 }


### PR DESCRIPTION
## Summary
- archive parseable-but-invalid `.evolvo` state payloads before normalizing them away
- let lifecycle, challenge metrics, and retry-state normalizers explicitly report when they had to discard invalid content
- add regression coverage for the shared helper and each affected state store so operators keep corrupt-file evidence and warning logs

## Testing
- pnpm vitest run src/runtime/localStateFile.test.ts src/runtime/lifecycleState.test.ts src/challenges/challengeMetrics.test.ts src/challenges/retryGate.test.ts src/runtime/challengeLifecycle.test.ts
- pnpm typecheck

Closes #351
