### PR TITLE
fix(state): write local stores atomically

### DIFF
--- a/src/challenges/challengeMetrics.test.ts
+++ b/src/challenges/challengeMetrics.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -260,5 +260,40 @@ describe("challengeMetrics", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       `Recovered invalid challenge metrics store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
     );
+  });
+
+  it("ignores interrupted temp files when persisting challenge metrics", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(join(evolvoDir, "challenge-metrics.tmp-interrupted.json"), "{\"total\":", "utf8");
+
+    const metrics = await recordChallengeAttemptMetrics(workDir, {
+      challengeIssueNumber: 55,
+      success: false,
+      failureCategory: "validation_failure",
+    });
+
+    expect(metrics).toEqual({
+      total: 1,
+      success: 0,
+      failure: 1,
+      attemptsToSuccess: {
+        total: 0,
+        samples: 0,
+        average: 0,
+      },
+      categoryCounts: {
+        validation_failure: 1,
+      },
+      pendingAttemptsByChallenge: {
+        55: 1,
+      },
+    });
+    expect((await readdir(evolvoDir)).sort()).toEqual([
+      "challenge-metrics.json",
+      "challenge-metrics.tmp-interrupted.json",
+    ]);
   });
 });

--- a/src/challenges/challengeMetrics.ts
+++ b/src/challenges/challengeMetrics.ts
@@ -1,8 +1,8 @@
-import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import {
   readRecoverableJsonState,
   type RecoverableJsonStateNormalizationResult,
+  writeAtomicJsonState,
 } from "../runtime/localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
@@ -171,8 +171,7 @@ export async function readChallengeMetrics(workDir: string): Promise<ChallengeMe
 
 export async function writeChallengeMetrics(workDir: string, metrics: ChallengeMetrics): Promise<void> {
   const metricsPath = getMetricsPath(workDir);
-  await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
-  await fs.writeFile(metricsPath, `${JSON.stringify(normalizeMetricsShape(metrics).state, null, 2)}\n`, "utf8");
+  await writeAtomicJsonState(metricsPath, normalizeMetricsShape(metrics).state);
 }
 
 export async function recordChallengeAttemptMetrics(

--- a/src/challenges/retryGate.test.ts
+++ b/src/challenges/retryGate.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -316,5 +316,32 @@ describe("retryGate", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       `Recovered invalid challenge retry state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
     );
+  });
+
+  it("ignores interrupted temp files when persisting challenge retry state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(join(evolvoDir, "challenge-retry-state.tmp-interrupted.json"), "{\"failuresByChallenge\":", "utf8");
+
+    const state = await recordChallengeAttemptOutcome(workDir, {
+      challengeIssueNumber: 42,
+      success: false,
+      nowMs: 5000,
+    });
+
+    expect(state).toEqual({
+      failuresByChallenge: {
+        42: {
+          attempts: 1,
+          lastFailureAtMs: 5000,
+        },
+      },
+    });
+    expect((await readdir(evolvoDir)).sort()).toEqual([
+      "challenge-retry-state.json",
+      "challenge-retry-state.tmp-interrupted.json",
+    ]);
   });
 });

--- a/src/challenges/retryGate.ts
+++ b/src/challenges/retryGate.ts
@@ -1,10 +1,10 @@
-import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { hasIssueLabel, isChallengeIssue } from "../issues/challengeIssue.js";
 import type { IssueSummary } from "../issues/taskIssueManager.js";
 import {
   readRecoverableJsonState,
   type RecoverableJsonStateNormalizationResult,
+  writeAtomicJsonState,
 } from "../runtime/localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
@@ -142,12 +142,7 @@ export async function readChallengeRetryState(workDir: string): Promise<Challeng
 }
 
 async function writeChallengeRetryState(workDir: string, state: ChallengeRetryState): Promise<void> {
-  await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
-  await fs.writeFile(
-    getRetryStatePath(workDir),
-    `${JSON.stringify(normalizeRetryState(state).state, null, 2)}\n`,
-    "utf8",
-  );
+  await writeAtomicJsonState(getRetryStatePath(workDir), normalizeRetryState(state).state);
 }
 
 export async function recordChallengeAttemptOutcome(

--- a/src/runtime/lifecycleState.test.ts
+++ b/src/runtime/lifecycleState.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -265,6 +265,48 @@ describe("lifecycleState", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       `Recovered malformed lifecycle state store at ${statePath}; preserved corrupt file at ${corruptPath}.`,
     );
+  });
+
+  it("ignores interrupted temp files when persisting lifecycle state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(join(evolvoDir, "runtime-lifecycle-state.tmp-interrupted.json"), "{\"issues\":", "utf8");
+
+    const result = await transitionCanonicalLifecycleState(workDir, {
+      issueNumber: 88,
+      kind: "issue",
+      nextState: "selected",
+      atMs: 2000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(JSON.parse(await readFile(join(evolvoDir, "runtime-lifecycle-state.json"), "utf8"))).toEqual({
+      version: 1,
+      issues: {
+        88: {
+          issueNumber: 88,
+          kind: "issue",
+          state: "selected",
+          updatedAt: new Date(2000).toISOString(),
+          transitionCount: 1,
+          history: [
+            {
+              from: null,
+              to: "selected",
+              at: new Date(2000).toISOString(),
+              reason: null,
+              runCycle: null,
+            },
+          ],
+        },
+      },
+    });
+    expect((await readdir(evolvoDir)).sort()).toEqual([
+      "runtime-lifecycle-state.json",
+      "runtime-lifecycle-state.tmp-interrupted.json",
+    ]);
   });
 
   it("formats canonical lifecycle comments with canonical and derived sections", () => {

--- a/src/runtime/lifecycleState.ts
+++ b/src/runtime/lifecycleState.ts
@@ -1,8 +1,8 @@
-import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import {
   readRecoverableJsonState,
   type RecoverableJsonStateNormalizationResult,
+  writeAtomicJsonState,
 } from "./localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
@@ -238,8 +238,7 @@ export async function readCanonicalLifecycleState(workDir: string): Promise<Life
 }
 
 async function writeCanonicalLifecycleState(workDir: string, state: LifecycleStateStore): Promise<void> {
-  await fs.mkdir(join(workDir, EVOLVO_DIRECTORY_NAME), { recursive: true });
-  await fs.writeFile(getStatePath(workDir), `${JSON.stringify(normalizeStateStore(state).state, null, 2)}\n`, "utf8");
+  await writeAtomicJsonState(getStatePath(workDir), normalizeStateStore(state).state);
 }
 
 export async function transitionCanonicalLifecycleState(

--- a/src/runtime/localStateFile.ts
+++ b/src/runtime/localStateFile.ts
@@ -26,6 +26,27 @@ function buildCorruptStatePath(statePath: string, atMs = Date.now()): string {
   );
 }
 
+function buildTempStatePath(statePath: string, atMs = Date.now()): string {
+  const extension = extname(statePath);
+  const fileName = basename(statePath, extension);
+  return join(
+    dirname(statePath),
+    `${fileName}.tmp-${Math.max(0, Math.floor(atMs))}-${process.pid}${extension}`,
+  );
+}
+
+export async function writeAtomicJsonState(statePath: string, state: unknown): Promise<void> {
+  await fs.mkdir(dirname(statePath), { recursive: true });
+  const tempPath = buildTempStatePath(statePath);
+  try {
+    await fs.writeFile(tempPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+    await fs.rename(tempPath, statePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
 export async function readRecoverableJsonState<T>(
   options: ReadRecoverableJsonStateOptions<T>,
 ): Promise<T> {
@@ -57,8 +78,7 @@ async function recoverMalformedJsonState<T>(
   const corruptPath = buildCorruptStatePath(options.statePath);
   await fs.rename(options.statePath, corruptPath);
   const defaultState = options.normalizeState(options.createDefaultState()).state;
-  await fs.mkdir(dirname(options.statePath), { recursive: true });
-  await fs.writeFile(options.statePath, `${JSON.stringify(defaultState, null, 2)}\n`, "utf8");
+  await writeAtomicJsonState(options.statePath, defaultState);
   console.warn(
     `Recovered malformed ${options.warningLabel} at ${options.statePath}; preserved corrupt file at ${corruptPath}.`,
   );
@@ -71,8 +91,7 @@ async function recoverInvalidJsonState<T>(
 ): Promise<T> {
   const corruptPath = buildCorruptStatePath(options.statePath);
   await fs.rename(options.statePath, corruptPath);
-  await fs.mkdir(dirname(options.statePath), { recursive: true });
-  await fs.writeFile(options.statePath, `${JSON.stringify(normalizedState, null, 2)}\n`, "utf8");
+  await writeAtomicJsonState(options.statePath, normalizedState);
   console.warn(
     `Recovered invalid ${options.warningLabel} at ${options.statePath}; preserved corrupt file at ${corruptPath}.`,
   );


### PR DESCRIPTION
## Summary
- add a shared atomic JSON-state writer to the local-state helper
- switch lifecycle, challenge metrics, and challenge retry state persistence to temp-file plus rename semantics
- add interrupted-temp regressions for each store to prove canonical state writes still succeed without consuming stale partial files

## Testing
- pnpm vitest run src/runtime/localStateFile.test.ts src/runtime/lifecycleState.test.ts src/challenges/challengeMetrics.test.ts src/challenges/retryGate.test.ts src/runtime/challengeLifecycle.test.ts
- pnpm typecheck

Closes #350
