### PR TITLE
fix(runtime): write discord control state atomically

### DIFF
--- a/src/runtime/gracefulShutdown.test.ts
+++ b/src/runtime/gracefulShutdown.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -170,6 +170,59 @@ describe("gracefulShutdown", () => {
       messageId: "9200",
       requestedAt: "2026-03-07T15:00:00.000Z",
     });
+  });
+
+  it("ignores interrupted temp files when persisting graceful shutdown requests", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(
+      join(evolvoDir, "graceful-shutdown-request.tmp-interrupted.json"),
+      "{\"messageId\":",
+      "utf8",
+    );
+
+    const result = await recordGracefulShutdownRequest(workDir, {
+      messageId: "9300",
+      requestedAt: "2026-03-07T17:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      created: true,
+      request: {
+        version: 1,
+        source: "discord",
+        command: "/quit",
+        mode: "after-current-task",
+        messageId: "9300",
+        requestedAt: "2026-03-07T17:00:00.000Z",
+      },
+    });
+    expect((await readdir(evolvoDir)).sort()).toEqual([
+      "graceful-shutdown-request.json",
+      "graceful-shutdown-request.tmp-interrupted.json",
+    ]);
+  });
+
+  it("ignores interrupted temp files when persisting Discord control cursors", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const evolvoDir = join(workDir, ".evolvo");
+    await mkdir(evolvoDir, { recursive: true });
+    await writeFile(
+      join(evolvoDir, "discord-control-cursor.tmp-interrupted.json"),
+      "{\"lastSeenMessageId\":",
+      "utf8",
+    );
+
+    await writeDiscordControlCursor(workDir, "9400");
+
+    await expect(readDiscordControlCursor(workDir)).resolves.toBe("9400");
+    expect((await readdir(evolvoDir)).sort()).toEqual([
+      "discord-control-cursor.json",
+      "discord-control-cursor.tmp-interrupted.json",
+    ]);
   });
 
   it("records Discord control receipts once per message id", async () => {

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { basename, dirname, extname, join } from "node:path";
+import { writeAtomicJsonState } from "./localStateFile.js";
 
 const EVOLVO_DIRECTORY_NAME = ".evolvo";
 const GRACEFUL_SHUTDOWN_REQUEST_FILE_NAME = "graceful-shutdown-request.json";
@@ -92,8 +93,7 @@ function normalizeDiscordControlCursorState(raw: unknown): DiscordControlCursorS
 }
 
 async function writeJsonFile(path: string, value: unknown): Promise<void> {
-  await fs.mkdir(dirname(path), { recursive: true });
-  await fs.writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await writeAtomicJsonState(path, value);
 }
 
 function buildCorruptStatePath(path: string, atMs = Date.now()): string {


### PR DESCRIPTION
## Summary\n- switch graceful shutdown and Discord control cursor persistence to the shared atomic JSON writer\n- keep malformed-state recovery behavior unchanged while removing direct canonical writes\n- add interrupted-write regressions for both shutdown request and cursor stores\n\n## Testing\n- pnpm vitest run src/runtime/gracefulShutdown.test.ts src/runtime/operatorControl.test.ts\n- pnpm typecheck\n- pnpm lint\n\nCloses #348