### PR TITLE
fix(discord): use runtime context in issue-start cards

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -617,12 +617,18 @@ describe("main", () => {
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Start"));
     expect(addProgressCommentMock).toHaveBeenCalledWith(12, expect.stringContaining("## Task Execution Log"));
     expect(notifyIssueStartedInDiscordMock).toHaveBeenCalledWith({
-      issueNumber: 12,
-      issueTitle: "Fix login redirect",
-      issueUrl: "https://github.com/owner/repo/issues/12",
-      trackerRepository: "owner/repo",
-      executionProject: "Evolvo (`evolvo`)",
-      executionRepository: "owner/repo",
+      issue: {
+        number: 12,
+        title: "Fix login redirect",
+      },
+      executionContext: {
+        trackerRepository: "owner/repo",
+        executionRepository: "owner/repo",
+        project: {
+          displayName: "Evolvo",
+          slug: "evolvo",
+        },
+      },
       lifecycleState: "selected -> executing",
     });
     expect(configureCodingAgentExecutionContextMock).toHaveBeenCalledWith({
@@ -656,9 +662,9 @@ describe("main", () => {
           kind: "managed",
           issueLabel: "project:habit-cli",
           trackerRepo: {
-            owner: "owner",
-            repo: "repo",
-            url: "https://github.com/owner/repo",
+            owner: "tracker-org",
+            repo: "issue-tracker",
+            url: "https://github.com/tracker-org/issue-tracker",
           },
           executionRepo: {
             owner: "owner",
@@ -678,7 +684,7 @@ describe("main", () => {
             lastError: null,
           },
         },
-        trackerRepository: "owner/repo",
+        trackerRepository: "tracker-org/issue-tracker",
         executionRepository: "owner/habit-cli",
       },
     });
@@ -687,18 +693,24 @@ describe("main", () => {
     await main();
 
     expect(notifyIssueStartedInDiscordMock).toHaveBeenCalledWith({
-      issueNumber: 14,
-      issueTitle: "Managed repo issue",
-      issueUrl: "https://github.com/owner/repo/issues/14",
-      trackerRepository: "owner/repo",
-      executionProject: "Habit CLI (`habit-cli`)",
-      executionRepository: "owner/habit-cli",
+      issue: {
+        number: 14,
+        title: "Managed repo issue",
+      },
+      executionContext: {
+        trackerRepository: "tracker-org/issue-tracker",
+        executionRepository: "owner/habit-cli",
+        project: {
+          displayName: "Habit CLI",
+          slug: "habit-cli",
+        },
+      },
       lifecycleState: "selected -> executing",
     });
     expect(configureCodingAgentExecutionContextMock).toHaveBeenCalledWith({
       workDir: "/tmp/evolvo/projects/habit-cli",
       internalRepositoryUrls: [
-        "https://github.com/owner/repo",
+        "https://github.com/tracker-org/issue-tracker",
         "https://github.com/owner/habit-cli",
       ],
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,6 @@ import {
   PROJECT_ROUTING_BLOCKED_LABEL,
   buildProjectRoutingBlockedComment,
   resolveProjectExecutionContextForIssue,
-  type ProjectExecutionContext,
 } from "./projects/projectExecutionContext.js";
 import {
   buildDefaultProjectContext,
@@ -116,10 +115,6 @@ function mapReviewOutcomeToLifecycleState(reviewOutcome: string): "accepted" | "
   }
 
   return "rejected";
-}
-
-function buildExecutionProjectDisplay(context: ProjectExecutionContext): string {
-  return `${context.project.displayName} (\`${context.project.slug}\`)`;
 }
 
 async function transitionIssueLifecycleState(
@@ -243,7 +238,6 @@ export async function main(): Promise<void> {
   const githubClient = new GitHubClient(githubConfig);
   const issueManager = new TaskIssueManager(githubClient);
   const adminClient = new GitHubAdminClient(githubClient, githubConfig);
-  const repositoryName = `${GITHUB_OWNER}/${GITHUB_REPO}`;
   const defaultProjectContext = buildDefaultProjectContext({
     owner: GITHUB_OWNER,
     repo: GITHUB_REPO,
@@ -448,12 +442,18 @@ export async function main(): Promise<void> {
           if (startedThisCycle) {
             await addIssueLifecycleComment(issueManager, selectedIssue.number, buildIssueStartComment(selectedIssue, executionContext));
             await notifyIssueStartedInDiscord({
-              issueNumber: selectedIssue.number,
-              issueTitle: selectedIssue.title,
-              issueUrl: `https://github.com/${repositoryName}/issues/${selectedIssue.number}`,
-              trackerRepository: repositoryName,
-              executionProject: buildExecutionProjectDisplay(executionContext),
-              executionRepository: executionContext.executionRepository,
+              issue: {
+                number: selectedIssue.number,
+                title: selectedIssue.title,
+              },
+              executionContext: {
+                trackerRepository: executionContext.trackerRepository,
+                executionRepository: executionContext.executionRepository,
+                project: {
+                  displayName: executionContext.project.displayName,
+                  slug: executionContext.project.slug,
+                },
+              },
               lifecycleState: "selected -> executing",
             });
           }

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -69,12 +69,18 @@ describe("operatorControl", () => {
     vi.stubGlobal("fetch", fetchSpy);
 
     await notifyIssueStartedInDiscord({
-      issueNumber: 298,
-      issueTitle: "Send Discord start embed",
-      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
-      trackerRepository: "evolvo-auto/evolvo-ts",
-      executionProject: "Evolvo (`evolvo`)",
-      executionRepository: "evolvo-auto/evolvo-ts",
+      issue: {
+        number: 298,
+        title: "Send Discord start embed",
+      },
+      executionContext: {
+        trackerRepository: "evolvo-auto/evolvo-ts",
+        executionRepository: "evolvo-auto/evolvo-ts",
+        project: {
+          displayName: "Evolvo",
+          slug: "evolvo",
+        },
+      },
       lifecycleState: "selected -> executing",
     });
 
@@ -182,12 +188,18 @@ describe("operatorControl", () => {
     vi.stubGlobal("fetch", fetchSpy);
 
     await notifyIssueStartedInDiscord({
-      issueNumber: 298,
-      issueTitle: "Send a Discord embed notification with GitHub issue link when starting a new issue",
-      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
-      trackerRepository: "evolvo-auto/evolvo-ts",
-      executionProject: "Evolvo (`evolvo`)",
-      executionRepository: "evolvo-auto/evolvo-ts",
+      issue: {
+        number: 298,
+        title: "Send a Discord embed notification with GitHub issue link when starting a new issue",
+      },
+      executionContext: {
+        trackerRepository: "evolvo-auto/evolvo-ts",
+        executionRepository: "evolvo-auto/evolvo-ts",
+        project: {
+          displayName: "Evolvo",
+          slug: "evolvo",
+        },
+      },
       lifecycleState: "selected -> executing",
     });
 
@@ -255,6 +267,73 @@ describe("operatorControl", () => {
     );
   });
 
+  it("renders honest unavailable values and omits the GitHub button when tracker data is missing", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "channel-1", guild_id: "guild-1" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "message-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyIssueStartedInDiscord({
+      issue: {
+        number: 411,
+        title: "   ",
+      },
+      executionContext: {
+        trackerRepository: null,
+        executionRepository: " ",
+        project: null,
+      },
+      lifecycleState: null,
+    });
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1>",
+          embeds: [
+            {
+              title: "Started Issue #411",
+              description: "unavailable",
+              fields: [
+                {
+                  name: "State",
+                  value: "unknown",
+                  inline: true,
+                },
+                {
+                  name: "Tracker Repository",
+                  value: "unknown",
+                  inline: true,
+                },
+                {
+                  name: "Execution Project",
+                  value: "unavailable",
+                  inline: true,
+                },
+                {
+                  name: "Execution Repository",
+                  value: "unknown",
+                  inline: true,
+                },
+              ],
+            },
+          ],
+          components: [],
+        }),
+      }),
+    );
+  });
+
   it("logs and swallows issue-start notification failures", async () => {
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
     vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
@@ -275,12 +354,18 @@ describe("operatorControl", () => {
     vi.stubGlobal("fetch", fetchSpy);
 
     await notifyIssueStartedInDiscord({
-      issueNumber: 298,
-      issueTitle: "Send Discord start embed",
-      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
-      trackerRepository: "evolvo-auto/evolvo-ts",
-      executionProject: "Evolvo (`evolvo`)",
-      executionRepository: "evolvo-auto/evolvo-ts",
+      issue: {
+        number: 298,
+        title: "Send Discord start embed",
+      },
+      executionContext: {
+        trackerRepository: "evolvo-auto/evolvo-ts",
+        executionRepository: "evolvo-auto/evolvo-ts",
+        project: {
+          displayName: "Evolvo",
+          slug: "evolvo",
+        },
+      },
       lifecycleState: "selected -> executing",
     });
 

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -6,6 +6,8 @@ import {
   type GracefulShutdownRequest,
   writeDiscordControlCursor,
 } from "./gracefulShutdown.js";
+import type { IssueSummary } from "../issues/taskIssueManager.js";
+import type { ProjectExecutionContext } from "../projects/projectExecutionContext.js";
 import { normalizeProjectNameInput } from "../projects/projectNaming.js";
 
 type DiscordControlConfig = {
@@ -68,13 +70,16 @@ type DiscordOperatorStep =
   | "send-start-project-ack";
 
 type DiscordIssueStartNotification = {
-  issueNumber: number;
-  issueTitle: string;
-  issueUrl: string;
-  trackerRepository: string;
-  executionProject: string;
-  executionRepository: string;
-  lifecycleState: string;
+  issue: Pick<IssueSummary, "number" | "title">;
+  executionContext: {
+    trackerRepository: ProjectExecutionContext["trackerRepository"] | null;
+    executionRepository: ProjectExecutionContext["executionRepository"] | null;
+    project: {
+      displayName: ProjectExecutionContext["project"]["displayName"] | null;
+      slug: ProjectExecutionContext["project"]["slug"] | null;
+    } | null;
+  };
+  lifecycleState: string | null;
 };
 
 type DiscordControlMessage = {
@@ -176,6 +181,38 @@ function buildAuthHeaders(config: DiscordControlConfig): Record<string, string> 
   };
 }
 
+function normalizeInlineText(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function buildIssueStartProjectLabel(notification: DiscordIssueStartNotification): string {
+  const displayName = normalizeInlineText(notification.executionContext.project?.displayName);
+  const slug = normalizeInlineText(notification.executionContext.project?.slug);
+  if (displayName && slug) {
+    return `${displayName} (\`${slug}\`)`;
+  }
+
+  if (displayName) {
+    return displayName;
+  }
+
+  if (slug) {
+    return `\`${slug}\``;
+  }
+
+  return "unavailable";
+}
+
+function buildIssueStartIssueUrl(notification: DiscordIssueStartNotification): string | null {
+  const trackerRepository = normalizeInlineText(notification.executionContext.trackerRepository);
+  if (!trackerRepository || !/^[^/\s]+\/[^/\s]+$/.test(trackerRepository)) {
+    return null;
+  }
+
+  return `https://github.com/${trackerRepository}/issues/${notification.issue.number}`;
+}
+
 async function fetchDiscordJson<T>(
   config: DiscordControlConfig,
   path: string,
@@ -229,52 +266,60 @@ async function sendIssueStartNotification(
   config: DiscordControlConfig,
   notification: DiscordIssueStartNotification,
 ): Promise<void> {
+  const issueUrl = buildIssueStartIssueUrl(notification);
+  const issueTitle = normalizeInlineText(notification.issue.title) ?? "unavailable";
+  const lifecycleState = normalizeInlineText(notification.lifecycleState) ?? "unknown";
+  const trackerRepository = normalizeInlineText(notification.executionContext.trackerRepository) ?? "unknown";
+  const executionProject = buildIssueStartProjectLabel(notification);
+  const executionRepository = normalizeInlineText(notification.executionContext.executionRepository) ?? "unknown";
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",
     body: JSON.stringify({
       content: `<@${config.operatorUserId}>`,
       embeds: [
         {
-          title: `Started Issue #${notification.issueNumber}`,
-          description: notification.issueTitle,
-          url: notification.issueUrl,
+          title: `Started Issue #${notification.issue.number}`,
+          description: issueTitle,
+          ...(issueUrl ? { url: issueUrl } : {}),
           fields: [
             {
               name: "State",
-              value: notification.lifecycleState,
+              value: lifecycleState,
               inline: true,
             },
             {
               name: "Tracker Repository",
-              value: notification.trackerRepository,
+              value: trackerRepository,
               inline: true,
             },
             {
               name: "Execution Project",
-              value: notification.executionProject,
+              value: executionProject,
               inline: true,
             },
             {
               name: "Execution Repository",
-              value: notification.executionRepository,
+              value: executionRepository,
               inline: true,
             },
           ],
         },
       ],
-      components: [
-        {
-          type: 1,
-          components: [
+      components: issueUrl
+        ? [
             {
-              type: 2,
-              style: 5,
-              label: "Open GitHub Issue",
-              url: notification.issueUrl,
+              type: 1,
+              components: [
+                {
+                  type: 2,
+                  style: 5,
+                  label: "Open GitHub Issue",
+                  url: issueUrl,
+                },
+              ],
             },
-          ],
-        },
-      ],
+          ]
+        : [],
     }),
   });
 }


### PR DESCRIPTION
## Summary
- make Discord issue-start notifications consume structured issue and execution-context data instead of preformatted strings
- derive the issue URL from the resolved tracker repository and render honest unknown/unavailable values when data is missing
- add regression coverage for managed-project tracker repos and unavailable-field rendering

Closes #359