### PR TITLE
fix: persist enforced Discord quit requests

### DIFF
--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const runCodingAgentMock = vi.fn();
@@ -19,6 +20,23 @@ const tryResolveRepositoryDefaultBranchMock = vi.fn();
 const ensureProjectRegistryMock = vi.fn();
 const resolveProjectExecutionContextForIssueMock = vi.fn();
 const buildProjectRoutingBlockedCommentMock = vi.fn();
+
+const TEST_WORK_DIR = "/tmp/evolvo";
+const TEST_STATE_DIR = `${TEST_WORK_DIR}/.evolvo`;
+const DISABLED_OPERATOR_ENV_KEYS = [
+  "DISCORD_BOT_TOKEN",
+  "DISCORD_CONTROL_GUILD_ID",
+  "DISCORD_CONTROL_CHANNEL_ID",
+  "DISCORD_OPERATOR_USER_ID",
+  "DISCORD_OPERATOR_TIMEOUT_MS",
+  "DISCORD_OPERATOR_POLL_INTERVAL_MS",
+  "DISCORD_CYCLE_EXTENSION",
+  "EVOLVO_RESTART_TOKEN",
+  "EVOLVO_READINESS_FILE",
+] as const;
+const originalOperatorEnv = new Map(
+  DISABLED_OPERATOR_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
 
 type MockIssue = {
   number: number;
@@ -89,6 +107,29 @@ function parseIssueNumberFromPath(path: string): number {
   }
 
   return Number(match[1]);
+}
+
+async function resetRuntimeState(): Promise<void> {
+  await fs.mkdir(TEST_WORK_DIR, { recursive: true });
+  await fs.rm(TEST_STATE_DIR, { recursive: true, force: true });
+}
+
+function disableOperatorEnv(): void {
+  for (const key of DISABLED_OPERATOR_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function restoreOperatorEnv(): void {
+  for (const key of DISABLED_OPERATOR_ENV_KEYS) {
+    const value = originalOperatorEnv.get(key);
+    if (typeof value === "string") {
+      process.env[key] = value;
+      continue;
+    }
+
+    delete process.env[key];
+  }
 }
 
 vi.mock("./environment.js", () => ({
@@ -247,8 +288,10 @@ vi.mock("./github/githubClient.js", async () => {
 describe("main replenishment integration", () => {
   const originalArgv = process.argv;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetModules();
+    await resetRuntimeState();
+    disableOperatorEnv();
     resetMockApiState();
     runIssueCommandMock.mockReset();
     runIssueCommandMock.mockResolvedValue(false);
@@ -449,9 +492,11 @@ describe("main replenishment integration", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     process.argv = originalArgv;
     vi.restoreAllMocks();
+    restoreOperatorEnv();
+    await resetRuntimeState();
   });
 
   it("replenishes a drained queue by creating issues and continues processing", async () => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -32,7 +32,7 @@ const pollDiscordGracefulShutdownCommandMock = vi.fn();
 const startDiscordGracefulShutdownListenerMock = vi.fn();
 const stopDiscordGracefulShutdownListenerMock = vi.fn();
 const readGracefulShutdownRequestMock = vi.fn();
-const clearGracefulShutdownRequestMock = vi.fn();
+const markGracefulShutdownRequestEnforcedMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
 const configureCodingAgentExecutionContextMock = vi.fn();
 const ensureProjectRegistryMock = vi.fn();
@@ -156,8 +156,8 @@ vi.mock("./runtime/runtimeReadiness.js", () => ({
 }));
 
 vi.mock("./runtime/gracefulShutdown.js", () => ({
+  markGracefulShutdownRequestEnforced: markGracefulShutdownRequestEnforcedMock,
   readGracefulShutdownRequest: readGracefulShutdownRequestMock,
-  clearGracefulShutdownRequest: clearGracefulShutdownRequestMock,
 }));
 
 vi.mock("./runtime/operatorControl.js", () => ({
@@ -430,8 +430,19 @@ describe("main", () => {
     writeRuntimeReadinessSignalMock.mockResolvedValue("/tmp/evolvo/.evolvo/runtime-readiness.json");
     readGracefulShutdownRequestMock.mockReset();
     readGracefulShutdownRequestMock.mockResolvedValue(null);
-    clearGracefulShutdownRequestMock.mockReset();
-    clearGracefulShutdownRequestMock.mockResolvedValue(undefined);
+    markGracefulShutdownRequestEnforcedMock.mockReset();
+    markGracefulShutdownRequestEnforcedMock.mockImplementation(async () => {
+      const request = await readGracefulShutdownRequestMock();
+      return request === null
+        ? null
+        : {
+            updated: request.enforcedAt === null,
+            request: {
+              ...request,
+              enforcedAt: request.enforcedAt ?? "2026-03-07T12:30:00.000Z",
+            },
+          };
+    });
     pollDiscordGracefulShutdownCommandMock.mockReset();
     pollDiscordGracefulShutdownCommandMock.mockResolvedValue(null);
     requestCycleLimitDecisionFromOperatorMock.mockReset();
@@ -1595,6 +1606,7 @@ describe("main", () => {
       mode: "after-current-task",
       messageId: "9001",
       requestedAt: "2026-03-07T12:00:00.000Z",
+      enforcedAt: null,
     });
     const { main } = await import("./main.js");
 
@@ -1602,9 +1614,9 @@ describe("main", () => {
 
     expect(listOpenIssuesMock).not.toHaveBeenCalled();
     expect(runCodingAgentMock).not.toHaveBeenCalled();
-    expect(clearGracefulShutdownRequestMock).toHaveBeenCalledTimes(1);
+    expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
-      "Graceful shutdown requested via Discord /quit. Stopping before starting a new task.",
+      "Graceful shutdown requested via Discord /quit. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
   });
 
@@ -1627,6 +1639,7 @@ describe("main", () => {
         mode: "after-current-task",
         messageId: "9002",
         requestedAt: "2026-03-07T12:05:00.000Z",
+        enforcedAt: null,
       });
     const { main } = await import("./main.js");
 
@@ -1636,9 +1649,9 @@ describe("main", () => {
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #301: Current task\n\nfinish this");
     expect(markInProgressMock).toHaveBeenCalledWith(301);
     expect(markInProgressMock).not.toHaveBeenCalledWith(302);
-    expect(clearGracefulShutdownRequestMock).toHaveBeenCalledTimes(1);
+    expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
-      "Graceful shutdown requested via Discord /quit. Current task completed. Stopping before starting another issue.",
+      "Graceful shutdown requested via Discord /quit. Current task completed. Stopping before starting another issue. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
   });
 
@@ -1659,6 +1672,7 @@ describe("main", () => {
       mode: "after-tasks",
       messageId: "9010",
       requestedAt: "2026-03-07T12:10:00.000Z",
+      enforcedAt: null,
     });
     const { main } = await import("./main.js");
 
@@ -1668,9 +1682,31 @@ describe("main", () => {
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(1, "Issue #401: First queued task\n\none");
     expect(runCodingAgentMock).toHaveBeenNthCalledWith(2, "Issue #402: Second queued task\n\ntwo");
     expect(runPlannerAgentMock).not.toHaveBeenCalled();
-    expect(clearGracefulShutdownRequestMock).toHaveBeenCalledTimes(1);
+    expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
-      "Graceful shutdown requested via Discord /quit after tasks. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started.",
+      "Graceful shutdown requested via Discord /quit after tasks. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
+    );
+  });
+
+  it("keeps honoring an already-enforced queue-drain shutdown request after restart", async () => {
+    readGracefulShutdownRequestMock.mockResolvedValue({
+      version: 1,
+      source: "discord",
+      command: "/quit after tasks",
+      mode: "after-tasks",
+      messageId: "9011",
+      requestedAt: "2026-03-07T12:15:00.000Z",
+      enforcedAt: "2026-03-07T12:20:00.000Z",
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(listOpenIssuesMock).not.toHaveBeenCalled();
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith(
+      "Graceful shutdown requested via Discord /quit after tasks. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import {
   waitForRunLoopRetry,
 } from "./runtime/loopUtils.js";
 import {
-  clearGracefulShutdownRequest,
+  markGracefulShutdownRequestEnforced,
   readGracefulShutdownRequest,
   type GracefulShutdownRequest,
 } from "./runtime/gracefulShutdown.js";
@@ -178,11 +178,15 @@ function buildGracefulShutdownLogMessage(
   request: GracefulShutdownRequest,
   reason: string,
 ): string {
-  return `Graceful shutdown requested via Discord ${request.command}. ${reason}`;
+  return `Graceful shutdown requested via Discord ${request.command}. ${reason} Shutdown intent remains persisted so later restarts do not resume work unexpectedly.`;
 }
 
 function isQueueDrainGracefulShutdownRequest(request: GracefulShutdownRequest | null): boolean {
   return request?.mode === "after-tasks";
+}
+
+function isEnforcedGracefulShutdownRequest(request: GracefulShutdownRequest | null): boolean {
+  return request?.enforcedAt !== null;
 }
 
 async function readPendingGracefulShutdownRequest(
@@ -199,12 +203,16 @@ async function stopIfSingleTaskGracefulShutdownRequested(
   discordHandlers: DiscordControlHandlers,
 ): Promise<boolean> {
   const request = await readPendingGracefulShutdownRequest(workDir, discordHandlers);
-  if (request === null || isQueueDrainGracefulShutdownRequest(request)) {
+  if (request === null) {
     return false;
   }
 
-  await clearGracefulShutdownRequest(workDir);
-  console.log(buildGracefulShutdownLogMessage(request, reason));
+  if (isQueueDrainGracefulShutdownRequest(request) && !isEnforcedGracefulShutdownRequest(request)) {
+    return false;
+  }
+
+  const enforced = await markGracefulShutdownRequestEnforced(workDir);
+  console.log(buildGracefulShutdownLogMessage(enforced?.request ?? request, reason));
   return true;
 }
 
@@ -218,11 +226,11 @@ async function stopIfGracefulShutdownPreventsNewWork(
     return false;
   }
 
-  await clearGracefulShutdownRequest(workDir);
+  const enforced = await markGracefulShutdownRequestEnforced(workDir);
   const shutdownReason = isQueueDrainGracefulShutdownRequest(request)
     ? "Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started."
     : reason;
-  console.log(buildGracefulShutdownLogMessage(request, shutdownReason));
+  console.log(buildGracefulShutdownLogMessage(enforced?.request ?? request, shutdownReason));
   return true;
 }
 

--- a/src/runtime/gracefulShutdown.test.ts
+++ b/src/runtime/gracefulShutdown.test.ts
@@ -6,6 +6,7 @@ import {
   consumeGracefulShutdownRequest,
   getDiscordControlCursorPath,
   getGracefulShutdownRequestPath,
+  markGracefulShutdownRequestEnforced,
   readDiscordControlCursor,
   readGracefulShutdownRequest,
   recordDiscordControlCommandReceipt,
@@ -48,6 +49,7 @@ describe("gracefulShutdown", () => {
         mode: "after-current-task",
         messageId: "9001",
         requestedAt: "2026-03-07T12:00:00.000Z",
+        enforcedAt: null,
       },
     });
     expect(second).toEqual({
@@ -73,6 +75,7 @@ describe("gracefulShutdown", () => {
       mode: "after-current-task",
       messageId: "9010",
       requestedAt: "2026-03-07T13:00:00.000Z",
+      enforcedAt: null,
     });
     await expect(consumeGracefulShutdownRequest(workDir)).resolves.toBeNull();
   });
@@ -96,9 +99,46 @@ describe("gracefulShutdown", () => {
         mode: "after-tasks",
         messageId: "9050",
         requestedAt: "2026-03-07T13:30:00.000Z",
+        enforcedAt: null,
       },
     });
     await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual(result.request);
+  });
+
+  it("marks graceful shutdown requests as enforced without clearing them", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await recordGracefulShutdownRequest(workDir, {
+      messageId: "9055",
+      requestedAt: "2026-03-07T13:35:00.000Z",
+    });
+
+    await expect(
+      markGracefulShutdownRequestEnforced(workDir, {
+        enforcedAt: "2026-03-07T13:40:00.000Z",
+      }),
+    ).resolves.toEqual({
+      updated: true,
+      request: {
+        version: 1,
+        source: "discord",
+        command: "/quit",
+        mode: "after-current-task",
+        messageId: "9055",
+        requestedAt: "2026-03-07T13:35:00.000Z",
+        enforcedAt: "2026-03-07T13:40:00.000Z",
+      },
+    });
+    await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit",
+      mode: "after-current-task",
+      messageId: "9055",
+      requestedAt: "2026-03-07T13:35:00.000Z",
+      enforcedAt: "2026-03-07T13:40:00.000Z",
+    });
   });
 
   it("preserves malformed Discord control cursor state and rewrites a recoverable default", async () => {
@@ -169,6 +209,7 @@ describe("gracefulShutdown", () => {
       mode: "after-current-task",
       messageId: "9200",
       requestedAt: "2026-03-07T15:00:00.000Z",
+      enforcedAt: null,
     });
   });
 
@@ -197,6 +238,7 @@ describe("gracefulShutdown", () => {
         mode: "after-current-task",
         messageId: "9300",
         requestedAt: "2026-03-07T17:00:00.000Z",
+        enforcedAt: null,
       },
     });
     expect((await readdir(evolvoDir)).sort()).toEqual([

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -17,6 +17,7 @@ export type GracefulShutdownRequest = {
   mode: GracefulShutdownMode;
   messageId: string;
   requestedAt: string;
+  enforcedAt: string | null;
 };
 
 type DiscordControlCursorState = {
@@ -65,6 +66,7 @@ function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest
   if (requestedAt === null) {
     return null;
   }
+  const enforcedAt = isNonEmptyString(candidate.enforcedAt) ? candidate.enforcedAt.trim() : null;
 
   return {
     version: GRACEFUL_SHUTDOWN_REQUEST_VERSION,
@@ -73,6 +75,7 @@ function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest
     mode,
     messageId,
     requestedAt,
+    enforcedAt,
   };
 }
 
@@ -212,9 +215,41 @@ export async function recordGracefulShutdownRequest(
     mode,
     messageId,
     requestedAt,
+    enforcedAt: null,
   };
   await writeJsonFile(getGracefulShutdownRequestPath(workDir), request);
   return { request, created: true };
+}
+
+export async function markGracefulShutdownRequestEnforced(
+  workDir: string,
+  input: {
+    enforcedAt?: string;
+  } = {},
+): Promise<{ request: GracefulShutdownRequest; updated: boolean } | null> {
+  const request = await readGracefulShutdownRequest(workDir);
+  if (request === null) {
+    return null;
+  }
+
+  if (request.enforcedAt !== null) {
+    return {
+      request,
+      updated: false,
+    };
+  }
+
+  const nextRequest: GracefulShutdownRequest = {
+    ...request,
+    enforcedAt: isNonEmptyString(input.enforcedAt)
+      ? input.enforcedAt.trim()
+      : new Date().toISOString(),
+  };
+  await writeJsonFile(getGracefulShutdownRequestPath(workDir), nextRequest);
+  return {
+    request: nextRequest,
+    updated: true,
+  };
 }
 
 export async function clearGracefulShutdownRequest(workDir: string): Promise<void> {

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -477,6 +477,7 @@ describe("operatorControl", () => {
       mode: "after-current-task",
       messageId: "7001",
       requestedAt: expect.any(String),
+      enforcedAt: null,
     });
     expect(fetchSpy).toHaveBeenCalledTimes(3);
     expect(fetchSpy).toHaveBeenNthCalledWith(
@@ -521,6 +522,7 @@ describe("operatorControl", () => {
       mode: "after-tasks",
       messageId: "7051",
       requestedAt: expect.any(String),
+      enforcedAt: null,
     });
     expect(fetchSpy).toHaveBeenCalledTimes(3);
     expect(fetchSpy).toHaveBeenNthCalledWith(
@@ -569,6 +571,7 @@ describe("operatorControl", () => {
       mode: "after-current-task",
       messageId: "7061",
       requestedAt: expect.any(String),
+      enforcedAt: null,
     });
     expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("7061");
     expect(fetchSpy).toHaveBeenNthCalledWith(
@@ -618,6 +621,7 @@ describe("operatorControl", () => {
       mode: "after-current-task",
       messageId: "9058",
       requestedAt: expect.any(String),
+      enforcedAt: null,
     });
     expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("9060");
     expect(fetchSpy).toHaveBeenNthCalledWith(
@@ -694,6 +698,7 @@ describe("operatorControl", () => {
       mode: "after-current-task",
       messageId: "9401",
       requestedAt: expect.any(String),
+      enforcedAt: null,
     });
     expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("9402");
     expect(onStartProject).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- persist graceful shutdown requests after they are enforced so later restarts still observe the operator quit intent
- add regression coverage for enforced shutdown handling and queue-drain restarts
- isolate replenishment integration tests from persisted .evolvo state and local Discord env

## Root cause
The main loop acknowledged /quit and /quit after tasks, but deleted the persisted shutdown request as soon as it enforced the stop. A later restart then had no canonical shutdown intent left to observe, so work could resume despite the earlier operator command.

## Validation
- pnpm validate

Closes #361
