### PR TITLE
fix: confirm Discord commands before quit

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -27,7 +27,9 @@ const buildLifecycleStateCommentMock = vi.fn();
 const writeRuntimeReadinessSignalMock = vi.fn();
 const requestCycleLimitDecisionFromOperatorMock = vi.fn();
 const runDiscordOperatorControlStartupCheckMock = vi.fn();
+const notifyCycleLimitDecisionAppliedInDiscordMock = vi.fn();
 const notifyIssueStartedInDiscordMock = vi.fn();
+const notifyRuntimeQuittingInDiscordMock = vi.fn();
 const pollDiscordGracefulShutdownCommandMock = vi.fn();
 const startDiscordGracefulShutdownListenerMock = vi.fn();
 const stopDiscordGracefulShutdownListenerMock = vi.fn();
@@ -161,7 +163,9 @@ vi.mock("./runtime/gracefulShutdown.js", () => ({
 }));
 
 vi.mock("./runtime/operatorControl.js", () => ({
+  notifyCycleLimitDecisionAppliedInDiscord: notifyCycleLimitDecisionAppliedInDiscordMock,
   notifyIssueStartedInDiscord: notifyIssueStartedInDiscordMock,
+  notifyRuntimeQuittingInDiscord: notifyRuntimeQuittingInDiscordMock,
   pollDiscordGracefulShutdownCommand: pollDiscordGracefulShutdownCommandMock,
   requestCycleLimitDecisionFromOperator: requestCycleLimitDecisionFromOperatorMock,
   runDiscordOperatorControlStartupCheck: runDiscordOperatorControlStartupCheckMock,
@@ -449,8 +453,12 @@ describe("main", () => {
     requestCycleLimitDecisionFromOperatorMock.mockResolvedValue(null);
     runDiscordOperatorControlStartupCheckMock.mockReset();
     runDiscordOperatorControlStartupCheckMock.mockResolvedValue(undefined);
+    notifyCycleLimitDecisionAppliedInDiscordMock.mockReset();
+    notifyCycleLimitDecisionAppliedInDiscordMock.mockResolvedValue(undefined);
     notifyIssueStartedInDiscordMock.mockReset();
     notifyIssueStartedInDiscordMock.mockResolvedValue(undefined);
+    notifyRuntimeQuittingInDiscordMock.mockReset();
+    notifyRuntimeQuittingInDiscordMock.mockResolvedValue(undefined);
     stopDiscordGracefulShutdownListenerMock.mockReset();
     stopDiscordGracefulShutdownListenerMock.mockResolvedValue(undefined);
     startDiscordGracefulShutdownListenerMock.mockReset();
@@ -974,6 +982,9 @@ describe("main", () => {
       }),
     );
     expect(runPostMergeSelfRestartMock).toHaveBeenCalledWith("/tmp/evolvo");
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Post-merge restart workflow completed. This runtime is quitting so the restarted runtime can take over.",
+    );
   });
 
   it("logs restart failures clearly and exits current runtime", async () => {
@@ -991,6 +1002,9 @@ describe("main", () => {
     await main();
 
     expect(console.error).toHaveBeenCalledWith("restart failed");
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Post-merge restart workflow failed, and this runtime is still quitting after the merged pull request.",
+    );
   });
 
   it("replenishes issues and continues when queue is empty", async () => {
@@ -1024,6 +1038,9 @@ describe("main", () => {
       ],
     });
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #19: Generated\n\ngenerated");
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "No actionable open issues remain and no new work was created, so Evolvo is shutting down.",
+    );
     expect(console.log).toHaveBeenCalledWith(
       "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=1 outcome=continue",
     );
@@ -1088,6 +1105,9 @@ describe("main", () => {
       "Cycle 1 queue health: open=0 selected=none queueAction=bootstrap created=0 outcome=stop",
     );
     expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "No open issues are available, so Evolvo is shutting down until more work is created.",
+    );
   });
 
   it("logs diagnostics and stops when startup repository analysis throws", async () => {
@@ -1577,6 +1597,12 @@ describe("main", () => {
     expect(console.log).toHaveBeenCalledWith(
       "Operator decision via Discord: continue (+2 cycles). New limit=7.",
     );
+    expect(notifyCycleLimitDecisionAppliedInDiscordMock).toHaveBeenCalledWith({
+      decision: "continue",
+      currentLimit: 5,
+      additionalCycles: 2,
+      newLimit: 7,
+    });
     expect(runCodingAgentMock).toHaveBeenCalledTimes(6);
   });
 
@@ -1596,6 +1622,25 @@ describe("main", () => {
     expect(requestCycleLimitDecisionFromOperatorMock).toHaveBeenCalledWith(5);
     expect(console.error).toHaveBeenCalledWith("Operator decision via Discord: quit.");
     expect(console.error).toHaveBeenCalledWith("Reached the maximum number of issue cycles (5).");
+    expect(notifyCycleLimitDecisionAppliedInDiscordMock).toHaveBeenCalledWith({
+      decision: "quit",
+      currentLimit: 5,
+    });
+  });
+
+  it("sends a pre-quit notification when the cycle limit is reached without a continue decision", async () => {
+    listOpenIssuesMock.mockResolvedValue([
+      { number: 203, title: "Long-running task", description: "still open", state: "open", labels: [] },
+    ]);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(requestCycleLimitDecisionFromOperatorMock).toHaveBeenCalledWith(5);
+    expect(console.error).toHaveBeenCalledWith("Reached the maximum number of issue cycles (5).");
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Cycle limit of 5 was reached and no continue decision was applied.",
+    );
   });
 
   it("stops before starting a new task when a graceful shutdown request is already pending", async () => {
@@ -1617,6 +1662,9 @@ describe("main", () => {
     expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
       "Graceful shutdown requested via Discord /quit. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
+    );
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Graceful shutdown via /quit is being enforced. Stopping before starting a new task.",
     );
   });
 
@@ -1653,6 +1701,9 @@ describe("main", () => {
     expect(console.log).toHaveBeenCalledWith(
       "Graceful shutdown requested via Discord /quit. Current task completed. Stopping before starting another issue. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Graceful shutdown via /quit is being enforced. Current task completed. Stopping before starting another issue.",
+    );
   });
 
   it("drains existing issues and suppresses planner replenishment after /quit after tasks", async () => {
@@ -1686,6 +1737,9 @@ describe("main", () => {
     expect(console.log).toHaveBeenCalledWith(
       "Graceful shutdown requested via Discord /quit after tasks. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Graceful shutdown via /quit after tasks is being enforced. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started.",
+    );
   });
 
   it("keeps honoring an already-enforced queue-drain shutdown request after restart", async () => {
@@ -1707,6 +1761,9 @@ describe("main", () => {
     expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
       "Graceful shutdown requested via Discord /quit after tasks. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
+    );
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Graceful shutdown via /quit after tasks is being enforced. Stopping before starting a new task.",
     );
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,9 @@ import {
   type GracefulShutdownRequest,
 } from "./runtime/gracefulShutdown.js";
 import {
+  notifyCycleLimitDecisionAppliedInDiscord,
   notifyIssueStartedInDiscord,
+  notifyRuntimeQuittingInDiscord,
   pollDiscordGracefulShutdownCommand,
   requestCycleLimitDecisionFromOperator,
   runDiscordOperatorControlStartupCheck,
@@ -181,6 +183,13 @@ function buildGracefulShutdownLogMessage(
   return `Graceful shutdown requested via Discord ${request.command}. ${reason} Shutdown intent remains persisted so later restarts do not resume work unexpectedly.`;
 }
 
+function buildGracefulShutdownQuitNotificationReason(
+  request: GracefulShutdownRequest,
+  reason: string,
+): string {
+  return `Graceful shutdown via ${request.command} is being enforced. ${reason}`;
+}
+
 function isQueueDrainGracefulShutdownRequest(request: GracefulShutdownRequest | null): boolean {
   return request?.mode === "after-tasks";
 }
@@ -212,7 +221,9 @@ async function stopIfSingleTaskGracefulShutdownRequested(
   }
 
   const enforced = await markGracefulShutdownRequestEnforced(workDir);
-  console.log(buildGracefulShutdownLogMessage(enforced?.request ?? request, reason));
+  const activeRequest = enforced?.request ?? request;
+  console.log(buildGracefulShutdownLogMessage(activeRequest, reason));
+  await notifyRuntimeQuittingInDiscord(buildGracefulShutdownQuitNotificationReason(activeRequest, reason));
   return true;
 }
 
@@ -230,7 +241,9 @@ async function stopIfGracefulShutdownPreventsNewWork(
   const shutdownReason = isQueueDrainGracefulShutdownRequest(request)
     ? "Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started."
     : reason;
-  console.log(buildGracefulShutdownLogMessage(enforced?.request ?? request, shutdownReason));
+  const activeRequest = enforced?.request ?? request;
+  console.log(buildGracefulShutdownLogMessage(activeRequest, shutdownReason));
+  await notifyRuntimeQuittingInDiscord(buildGracefulShutdownQuitNotificationReason(activeRequest, shutdownReason));
   return true;
 }
 
@@ -285,16 +298,32 @@ export async function main(): Promise<void> {
       if (cycle > cycleLimit) {
         const operatorDecision = await requestCycleLimitDecisionFromOperator(cycleLimit);
         if (operatorDecision?.decision === "continue" && operatorDecision.additionalCycles > 0) {
+          const currentLimit = cycleLimit;
           cycleLimit += operatorDecision.additionalCycles;
           console.log(
             `Operator decision via Discord: continue (+${operatorDecision.additionalCycles} cycles). New limit=${cycleLimit}.`,
           );
+          await notifyCycleLimitDecisionAppliedInDiscord({
+            decision: "continue",
+            currentLimit,
+            additionalCycles: operatorDecision.additionalCycles,
+            newLimit: cycleLimit,
+          });
           continue;
         }
         if (operatorDecision?.decision === "quit") {
           console.error("Operator decision via Discord: quit.");
+          await notifyCycleLimitDecisionAppliedInDiscord({
+            decision: "quit",
+            currentLimit: cycleLimit,
+          });
         }
         console.error(`Reached the maximum number of issue cycles (${cycleLimit}).`);
+        if (operatorDecision?.decision !== "quit") {
+          await notifyRuntimeQuittingInDiscord(
+            `Cycle limit of ${cycleLimit} was reached and no continue decision was applied.`,
+          );
+        }
         return;
       }
 
@@ -393,8 +422,14 @@ export async function main(): Promise<void> {
 
             if (cycle === 1) {
               console.log(DEFAULT_PROMPT);
+              await notifyRuntimeQuittingInDiscord(
+                "No open issues are available, so Evolvo is shutting down until more work is created.",
+              );
             } else {
               console.log("No actionable open issues remaining and no new issues were created. Issue loop stopped.");
+              await notifyRuntimeQuittingInDiscord(
+                "No actionable open issues remain and no new work was created, so Evolvo is shutting down.",
+              );
             }
             return;
           }
@@ -656,6 +691,8 @@ export async function main(): Promise<void> {
             );
             if (executionContext.project.kind === "default") {
               console.log("Merged pull request detected. Running post-merge restart workflow.");
+              let postMergeQuitReason =
+                "Post-merge restart workflow completed. This runtime is quitting so the restarted runtime can take over.";
               try {
                 await runPostMergeSelfRestart(WORK_DIR);
                 await transitionIssueLifecycleState(issueManager, {
@@ -667,6 +704,8 @@ export async function main(): Promise<void> {
                 });
                 console.log("Post-merge restart workflow completed. Exiting current runtime.");
               } catch (error) {
+                postMergeQuitReason =
+                  "Post-merge restart workflow failed, and this runtime is still quitting after the merged pull request.";
                 if (error instanceof Error) {
                   console.error(error.message);
                 } else {
@@ -674,6 +713,7 @@ export async function main(): Promise<void> {
                 }
               }
 
+              await notifyRuntimeQuittingInDiscord(postMergeQuitReason);
               return;
             }
 

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as gracefulShutdown from "./gracefulShutdown.js";
 import {
   getDiscordControlConfigFromEnv,
+  notifyCycleLimitDecisionAppliedInDiscord,
   notifyIssueStartedInDiscord,
+  notifyRuntimeQuittingInDiscord,
   pollDiscordGracefulShutdownCommand,
   requestCycleLimitDecisionFromOperator,
   runDiscordOperatorControlStartupCheck,
@@ -447,6 +449,105 @@ describe("operatorControl", () => {
     });
   });
 
+  it("sends a Discord confirmation when a cycle-limit continue decision is applied", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ id: "cycle-continue-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyCycleLimitDecisionAppliedInDiscord({
+      decision: "continue",
+      currentLimit: 5,
+      additionalCycles: 3,
+      newLimit: 8,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1> Confirmed: continue was applied at the cycle limit.\nAdded 3 cycles. New limit: 8. Evolvo remains online.",
+        }),
+      }),
+    );
+  });
+
+  it("sends a Discord confirmation when a cycle-limit quit decision is applied", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ id: "cycle-quit-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyCycleLimitDecisionAppliedInDiscord({
+      decision: "quit",
+      currentLimit: 5,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1> Confirmed: quit was applied at the cycle limit (5).\nEvolvo is about to quit intentionally.",
+        }),
+      }),
+    );
+  });
+
+  it("sends a pre-quit Discord notification before intentional shutdown", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ id: "quit-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyRuntimeQuittingInDiscord("Cycle limit of 5 was reached and no continue decision was applied.");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1> Evolvo is about to quit intentionally.\nReason: Cycle limit of 5 was reached and no continue decision was applied.\nRuntime shutdown is starting now.",
+        }),
+      }),
+    );
+  });
+
+  it("logs quit-notification failures clearly when Discord is unavailable", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ message: "Missing Access", code: 50001 }),
+        { status: 403 },
+      ),
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyRuntimeQuittingInDiscord("Post-merge restart workflow completed.");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Discord runtime quit notification failed: [send-quit-message] Discord API request failed (403)"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Discord bot is missing access to the configured control channel. Verify DISCORD_CONTROL_GUILD_ID, DISCORD_CONTROL_CHANNEL_ID, and bot channel permissions.",
+    );
+  });
+
   it("records and acknowledges an authorized /quit graceful shutdown command", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
@@ -486,7 +587,55 @@ describe("operatorControl", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          content: "<@operator-1> Graceful shutdown requested.\nEvolvo will finish the current task and then stop before starting another issue.",
+          content: "<@operator-1> Confirmed: `/quit` is now active.\nEvolvo will finish the current task and then stop before starting another issue.",
+        }),
+      }),
+    );
+  });
+
+  it("confirms the active shutdown plan when /quit is repeated after a queue-drain request already exists", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    await gracefulShutdown.recordGracefulShutdownRequest(workDir, {
+      messageId: "7999",
+      requestedAt: "2026-03-08T09:00:00.000Z",
+      mode: "after-tasks",
+    });
+    await gracefulShutdown.writeDiscordControlCursor(workDir, "7999");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "8000", content: "/quit", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-duplicate-quit" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir);
+
+    expect(request).toEqual({
+      version: 1,
+      source: "discord",
+      command: "/quit after tasks",
+      mode: "after-tasks",
+      messageId: "7999",
+      requestedAt: "2026-03-08T09:00:00.000Z",
+      enforcedAt: null,
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1> Confirmed: `/quit after tasks` was already active, so the new command did not change the shutdown plan.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
         }),
       }),
     );
@@ -531,7 +680,7 @@ describe("operatorControl", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          content: "<@operator-1> Queue-drain shutdown requested.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
+          content: "<@operator-1> Confirmed: `/quit after tasks` is now active.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
         }),
       }),
     );
@@ -702,7 +851,7 @@ describe("operatorControl", () => {
     });
     expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("9402");
     expect(onStartProject).toHaveBeenCalledTimes(1);
-    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
   });
 
   it("queues an authorized /startProject request and acknowledges the created tracker issue", async () => {

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -67,7 +67,21 @@ type DiscordOperatorStep =
   | "send-issue-start"
   | "read-control-commands"
   | "send-quit-ack"
-  | "send-start-project-ack";
+  | "send-start-project-ack"
+  | "send-cycle-decision-ack"
+  | "send-quit-message";
+
+export type CycleLimitDecisionConfirmation =
+  | {
+    decision: "continue";
+    currentLimit: number;
+    additionalCycles: number;
+    newLimit: number;
+  }
+  | {
+    decision: "quit";
+    currentLimit: number;
+  };
 
 type DiscordIssueStartNotification = {
   issue: Pick<IssueSummary, "number" | "title">;
@@ -324,19 +338,29 @@ async function sendIssueStartNotification(
   });
 }
 
+function buildGracefulShutdownBehaviorLine(request: GracefulShutdownRequest): string {
+  return request.mode === "after-tasks"
+    ? "Evolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained."
+    : "Evolvo will finish the current task and then stop before starting another issue.";
+}
+
 async function sendGracefulShutdownAcknowledgement(
   config: DiscordControlConfig,
   request: GracefulShutdownRequest,
+  options: {
+    created: boolean;
+    requestedCommand: GracefulShutdownRequest["command"];
+  },
 ): Promise<void> {
-  const content = request.mode === "after-tasks"
-    ? [
-      `<@${config.operatorUserId}> Queue-drain shutdown requested.`,
-      "Evolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
-    ].join("\n")
-    : [
-      `<@${config.operatorUserId}> Graceful shutdown requested.`,
-      "Evolvo will finish the current task and then stop before starting another issue.",
-    ].join("\n");
+  const confirmationLine = options.created
+    ? `<@${config.operatorUserId}> Confirmed: \`${request.command}\` is now active.`
+    : request.command === options.requestedCommand
+      ? `<@${config.operatorUserId}> Confirmed: \`${request.command}\` was already active.`
+      : `<@${config.operatorUserId}> Confirmed: \`${request.command}\` was already active, so the new command did not change the shutdown plan.`;
+  const content = [
+    confirmationLine,
+    buildGracefulShutdownBehaviorLine(request),
+  ].join("\n");
 
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",
@@ -362,6 +386,42 @@ async function sendStartProjectAcknowledgement(
       result.message,
       "Usage: `/startProject <project-name>`",
     ].join("\n");
+
+  await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ content }),
+  });
+}
+
+async function sendCycleLimitDecisionConfirmation(
+  config: DiscordControlConfig,
+  confirmation: CycleLimitDecisionConfirmation,
+): Promise<void> {
+  const content = confirmation.decision === "continue"
+    ? [
+      `<@${config.operatorUserId}> Confirmed: continue was applied at the cycle limit.`,
+      `Added ${confirmation.additionalCycles} cycles. New limit: ${confirmation.newLimit}. Evolvo remains online.`,
+    ].join("\n")
+    : [
+      `<@${config.operatorUserId}> Confirmed: quit was applied at the cycle limit (${confirmation.currentLimit}).`,
+      "Evolvo is about to quit intentionally.",
+    ].join("\n");
+
+  await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ content }),
+  });
+}
+
+async function sendRuntimeQuitNotification(
+  config: DiscordControlConfig,
+  reason: string,
+): Promise<void> {
+  const content = [
+    `<@${config.operatorUserId}> Evolvo is about to quit intentionally.`,
+    `Reason: ${reason}`,
+    "Runtime shutdown is starting now.",
+  ].join("\n");
 
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",
@@ -578,14 +638,15 @@ export async function pollDiscordGracefulShutdownCommand(
             mode: shutdownCommand.mode,
           });
           gracefulShutdownRequest = recordedRequest.request;
-          if (recordedRequest.created) {
-            try {
-              await sendGracefulShutdownAcknowledgement(config, recordedRequest.request);
-            } catch (error) {
-              const sendMessage = buildStepFailureMessage("send-quit-ack", error);
-              console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);
-              logDiscordMissingAccessHint(sendMessage);
-            }
+          try {
+            await sendGracefulShutdownAcknowledgement(config, recordedRequest.request, {
+              created: recordedRequest.created,
+              requestedCommand: shutdownCommand.command,
+            });
+          } catch (error) {
+            const sendMessage = buildStepFailureMessage("send-quit-ack", error);
+            console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);
+            logDiscordMissingAccessHint(sendMessage);
           }
         } else {
           const requestedProjectName = parseStartProjectName(message.content);
@@ -733,6 +794,38 @@ export async function notifyIssueStartedInDiscord(
   } catch (error) {
     const message = error instanceof Error ? error.message : "unknown error";
     console.error(`Discord issue start notification failed: ${message}`);
+    logDiscordMissingAccessHint(message);
+  }
+}
+
+export async function notifyCycleLimitDecisionAppliedInDiscord(
+  confirmation: CycleLimitDecisionConfirmation,
+): Promise<void> {
+  const config = getDiscordControlConfigFromEnv();
+  if (!config) {
+    return;
+  }
+
+  try {
+    await sendCycleLimitDecisionConfirmation(config, confirmation);
+  } catch (error) {
+    const message = buildStepFailureMessage("send-cycle-decision-ack", error);
+    console.error(`Discord cycle-limit confirmation failed: ${message}`);
+    logDiscordMissingAccessHint(message);
+  }
+}
+
+export async function notifyRuntimeQuittingInDiscord(reason: string): Promise<void> {
+  const config = getDiscordControlConfigFromEnv();
+  if (!config) {
+    return;
+  }
+
+  try {
+    await sendRuntimeQuitNotification(config, reason);
+  } catch (error) {
+    const message = buildStepFailureMessage("send-quit-message", error);
+    console.error(`Discord runtime quit notification failed: ${message}`);
     logDiscordMissingAccessHint(message);
   }
 }


### PR DESCRIPTION
## Summary
- send explicit Discord confirmations for cycle-limit decisions and repeated graceful-shutdown commands
- send a Discord pre-quit message on intentional shutdown paths, including graceful shutdown, queue exhaustion, cycle-limit exits, and post-merge restart handoff
- add focused regression coverage for confirmations, quit notifications, and restart-failure shutdown messaging

## Root cause
The operator-control surface acknowledged some commands, but not all applied actions. In particular, cycle-limit continue/quit replies had no confirmation, repeated /quit commands could be silently ignored once a shutdown plan already existed, and several intentional main-loop exits returned without attempting any pre-quit Discord message.

## Validation
- pnpm validate

Closes #358
