### PR TITLE
fix: restrict queue to authorized issue authors

### DIFF
--- a/src/issues/taskIssueManager.test.ts
+++ b/src/issues/taskIssueManager.test.ts
@@ -12,6 +12,7 @@ type MockIssue = {
   body: string;
   state: "open" | "closed";
   labels: Array<{ name: string }>;
+  user?: { login?: string | null };
   pull_request?: unknown;
 };
 
@@ -22,6 +23,7 @@ function createIssue(overrides: Partial<MockIssue> = {}): MockIssue {
     body: "Description",
     state: "open",
     labels: [],
+    user: { login: "evolvo-auto" },
     ...overrides,
   };
 }
@@ -100,6 +102,77 @@ describe("TaskIssueManager", () => {
       ...Array.from({ length: 3 }, (_, index) => index + 1),
       ...Array.from({ length: 96 }, (_, index) => index + 5),
       101,
+    ]);
+  });
+
+  it("returns only authorized open issues and closes unauthorized ones", async () => {
+    const client = createClientMock();
+    client.get.mockResolvedValue([
+      createIssue({ number: 1, title: "Allowed issue", user: { login: "evolvo-auto" } }),
+      createIssue({ number: 2, title: "Unauthorized issue", user: { login: "intruder-user" } }),
+    ]);
+    client.post.mockResolvedValue({});
+    client.patch.mockResolvedValue(createIssue({
+      number: 2,
+      title: "Unauthorized issue",
+      state: "closed",
+      user: { login: "intruder-user" },
+    }));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.listAuthorizedOpenIssues();
+
+    expect(result.issues).toEqual([
+      {
+        number: 1,
+        title: "Allowed issue",
+        description: "Description",
+        state: "open",
+        labels: [],
+      },
+    ]);
+    expect(result.unauthorizedClosures).toEqual([
+      {
+        issueNumber: 2,
+        issueTitle: "Unauthorized issue",
+        authorLogin: "intruder-user",
+        commentAdded: true,
+        closed: true,
+        closeMessage: "Issue #2 closed successfully.",
+        commentMessage: "Added unauthorized-author closure comment to issue #2.",
+      },
+    ]);
+    expect(client.post).toHaveBeenCalledWith(
+      "/2/comments",
+      expect.objectContaining({
+        body: expect.stringContaining("Evolvo only accepts work from approved issue authors"),
+      }),
+    );
+    expect(client.patch).toHaveBeenCalledWith("/2", { state: "closed" });
+  });
+
+  it("treats missing or uncloseable unauthorized authors as unauthorized and reports the failure", async () => {
+    const client = createClientMock();
+    client.get.mockResolvedValue([
+      createIssue({ number: 3, title: "Unknown author issue", user: { login: null } }),
+    ]);
+    client.post.mockRejectedValueOnce(new Error("comment denied"));
+    client.patch.mockRejectedValueOnce(new Error("close denied"));
+    const manager = new TaskIssueManager(client as never);
+
+    const result = await manager.listAuthorizedOpenIssues();
+
+    expect(result.issues).toEqual([]);
+    expect(result.unauthorizedClosures).toEqual([
+      {
+        issueNumber: 3,
+        issueTitle: "Unknown author issue",
+        authorLogin: null,
+        commentAdded: false,
+        closed: false,
+        closeMessage: "Failed to close issue #3: close denied",
+        commentMessage: "Failed to add unauthorized-author closure comment to issue #3: comment denied",
+      },
     ]);
   });
 

--- a/src/issues/taskIssueManager.ts
+++ b/src/issues/taskIssueManager.ts
@@ -4,9 +4,18 @@ const IN_PROGRESS_LABEL = "in progress";
 const COMPLETED_LABEL = "completed";
 const FOLLOW_UP_TITLE_SUFFIX_PATTERN = /\s*\(follow-up\s+\d+\)\s*$/i;
 export const PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT = 300;
+const AUTHORIZED_ISSUE_AUTHORS = new Set(["evolvo-auto", "ptekspy"]);
+const UNAUTHORIZED_ISSUE_CLOSURE_COMMENT = [
+  "Closing automatically because this issue was created by an unauthorized author.",
+  "Evolvo only accepts work from approved issue authors: `evolvo-auto` and `ptekspy`.",
+].join("\n\n");
 
 type GitHubLabel = {
   name: string;
+};
+
+type GitHubIssueUser = {
+  login?: string | null;
 };
 
 type GitHubIssue = {
@@ -15,6 +24,7 @@ type GitHubIssue = {
   body: string | null;
   state: "open" | "closed";
   labels: GitHubLabel[];
+  user?: GitHubIssueUser | null;
   pull_request?: unknown;
 };
 
@@ -40,6 +50,16 @@ export type ReplenishIssuesOptions = {
 
 export type ReplenishIssuesResult = {
   created: IssueSummary[];
+};
+
+export type UnauthorizedIssueClosureResult = {
+  issueNumber: number;
+  issueTitle: string;
+  authorLogin: string | null;
+  commentAdded: boolean;
+  closed: boolean;
+  closeMessage: string;
+  commentMessage: string | null;
 };
 
 export type PlannedIssueDraft = {
@@ -280,6 +300,15 @@ function hasLabel(issue: GitHubIssue, labelName: string): boolean {
   return issue.labels.some((label) => label.name.toLowerCase() === labelName.toLowerCase());
 }
 
+function normalizeIssueAuthorLogin(issue: GitHubIssue): string | null {
+  const login = issue.user?.login?.trim();
+  return login && login.length > 0 ? login : null;
+}
+
+function isAuthorizedIssueAuthor(authorLogin: string | null): boolean {
+  return authorLogin !== null && AUTHORIZED_ISSUE_AUTHORS.has(authorLogin.toLowerCase());
+}
+
 function buildLabels(issue: GitHubIssue, options: { inProgress: boolean; completed: boolean }): string[] {
   const names = issue.labels.map((label) => label.name);
   const withoutManaged = names.filter(
@@ -319,7 +348,7 @@ export class TaskIssueManager {
     };
   }
 
-  public async listOpenIssues(): Promise<IssueSummary[]> {
+  private async listRawOpenIssues(): Promise<GitHubIssue[]> {
     const issues: GitHubIssue[] = [];
     let page = 1;
 
@@ -336,7 +365,77 @@ export class TaskIssueManager {
       page += 1;
     }
 
-    return issues.filter((issue) => issue.pull_request === undefined).map(formatIssue);
+    return issues.filter((issue) => issue.pull_request === undefined);
+  }
+
+  private async closeUnauthorizedIssue(issue: GitHubIssue): Promise<UnauthorizedIssueClosureResult> {
+    let commentAdded = false;
+    let commentMessage: string | null = null;
+
+    try {
+      await this.client.post(`/${issue.number}/comments`, {
+        body: UNAUTHORIZED_ISSUE_CLOSURE_COMMENT,
+      });
+      commentAdded = true;
+      commentMessage = `Added unauthorized-author closure comment to issue #${issue.number}.`;
+    } catch (error) {
+      commentMessage = error instanceof Error
+        ? `Failed to add unauthorized-author closure comment to issue #${issue.number}: ${error.message}`
+        : `Failed to add unauthorized-author closure comment to issue #${issue.number}: unknown error`;
+    }
+
+    try {
+      await this.client.patch<GitHubIssue>(`/${issue.number}`, { state: "closed" });
+      return {
+        issueNumber: issue.number,
+        issueTitle: issue.title,
+        authorLogin: normalizeIssueAuthorLogin(issue),
+        commentAdded,
+        closed: true,
+        closeMessage: `Issue #${issue.number} closed successfully.`,
+        commentMessage,
+      };
+    } catch (error) {
+      return {
+        issueNumber: issue.number,
+        issueTitle: issue.title,
+        authorLogin: normalizeIssueAuthorLogin(issue),
+        commentAdded,
+        closed: false,
+        closeMessage: error instanceof Error
+          ? `Failed to close issue #${issue.number}: ${error.message}`
+          : `Failed to close issue #${issue.number}: unknown error`,
+        commentMessage,
+      };
+    }
+  }
+
+  public async listAuthorizedOpenIssues(): Promise<{
+    issues: IssueSummary[];
+    unauthorizedClosures: UnauthorizedIssueClosureResult[];
+  }> {
+    const issues = await this.listRawOpenIssues();
+    const authorizedIssues: IssueSummary[] = [];
+    const unauthorizedClosures: UnauthorizedIssueClosureResult[] = [];
+
+    for (const issue of issues) {
+      const authorLogin = normalizeIssueAuthorLogin(issue);
+      if (isAuthorizedIssueAuthor(authorLogin)) {
+        authorizedIssues.push(formatIssue(issue));
+        continue;
+      }
+
+      unauthorizedClosures.push(await this.closeUnauthorizedIssue(issue));
+    }
+
+    return {
+      issues: authorizedIssues,
+      unauthorizedClosures,
+    };
+  }
+
+  public async listOpenIssues(): Promise<IssueSummary[]> {
+    return (await this.listRawOpenIssues()).map(formatIssue);
   }
 
   public async listRecentClosedIssues(limit = TaskIssueManager.ISSUES_PER_PAGE): Promise<IssueSummary[]> {

--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -44,6 +44,7 @@ type MockIssue = {
   body: string;
   state: "open" | "closed";
   labels: Array<{ name: string }>;
+  user?: { login?: string | null };
   pull_request?: unknown;
 };
 
@@ -107,6 +108,15 @@ function parseIssueNumberFromPath(path: string): number {
   }
 
   return Number(match[1]);
+}
+
+function withApprovedAuthor<T extends MockIssue>(issue: T): T & { user: { login: string } } {
+  return {
+    ...issue,
+    user: {
+      login: issue.user?.login?.trim() || "evolvo-auto",
+    },
+  };
 }
 
 async function resetRuntimeState(): Promise<void> {
@@ -227,15 +237,19 @@ vi.mock("./github/githubClient.js", async () => {
   class FakeGitHubClient {
     public async get<T>(path: string): Promise<T> {
       if (path.startsWith("?state=open")) {
-        return mockApiState.issues.filter((issue) => issue.state === "open") as T;
+        return mockApiState.issues
+          .filter((issue) => issue.state === "open")
+          .map((issue) => withApprovedAuthor(issue)) as T;
       }
 
       if (path.startsWith("?state=closed")) {
-        return mockApiState.issues.filter((issue) => issue.state === "closed") as T;
+        return mockApiState.issues
+          .filter((issue) => issue.state === "closed")
+          .map((issue) => withApprovedAuthor(issue)) as T;
       }
 
       if (path.startsWith("/")) {
-        return findIssue(parseIssueNumberFromPath(path)) as T;
+        return withApprovedAuthor(findIssue(parseIssueNumberFromPath(path))) as T;
       }
 
       throw new Error(`Unsupported GET path in fake GitHub client: ${path}`);
@@ -249,6 +263,7 @@ vi.mock("./github/githubClient.js", async () => {
           body: body.body ?? "",
           state: "open",
           labels: [],
+          user: { login: "evolvo-auto" },
         };
         mockApiState.nextIssueNumber += 1;
         mockApiState.issues.push(issue);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,6 +8,7 @@ const replenishSelfImprovementIssuesMock = vi.fn();
 const runIssueCommandMock = vi.fn();
 const getGitHubConfigMock = vi.fn();
 const listOpenIssuesMock = vi.fn();
+const unauthorizedIssueClosuresMock = vi.fn();
 const markInProgressMock = vi.fn();
 const markCompletedMock = vi.fn();
 const addProgressCommentMock = vi.fn();
@@ -222,6 +223,10 @@ vi.mock("./github/githubClient.js", async () => {
 
 vi.mock("./issues/taskIssueManager.js", () => ({
   TaskIssueManager: class {
+    listAuthorizedOpenIssues = async () => ({
+      issues: await listOpenIssuesMock(),
+      unauthorizedClosures: await unauthorizedIssueClosuresMock(),
+    });
     listOpenIssues = listOpenIssuesMock;
     markInProgress = markInProgressMock;
     markCompleted = markCompletedMock;
@@ -350,6 +355,8 @@ describe("main", () => {
     });
     listOpenIssuesMock.mockReset();
     listOpenIssuesMock.mockResolvedValue([]);
+    unauthorizedIssueClosuresMock.mockReset();
+    unauthorizedIssueClosuresMock.mockResolvedValue([]);
     markInProgressMock.mockReset();
     markInProgressMock.mockResolvedValue({ ok: true, message: "ok" });
     markCompletedMock.mockReset();
@@ -516,6 +523,33 @@ describe("main", () => {
       }),
     );
     expect(stopDiscordGracefulShutdownListenerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and excludes unauthorized issues before normal selection", async () => {
+    listOpenIssuesMock.mockResolvedValueOnce([]);
+    unauthorizedIssueClosuresMock.mockResolvedValueOnce([
+      {
+        issueNumber: 91,
+        issueTitle: "Untrusted task",
+        authorLogin: "intruder-user",
+        commentAdded: true,
+        closed: true,
+        closeMessage: "Issue #91 closed successfully.",
+        commentMessage: "Added unauthorized-author closure comment to issue #91.",
+      },
+    ]);
+    const { DEFAULT_PROMPT, main } = await import("./main.js");
+
+    await main();
+
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      "Unauthorized issue #91 Untrusted task by intruder-user closed automatically.",
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      "Added unauthorized-author closure comment to issue #91.",
+    );
+    expect(console.log).toHaveBeenCalledWith(DEFAULT_PROMPT);
   });
 
   it("processes provisioning issues without invoking the coding agent", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,11 @@ import {
 } from "./runtime/challengeLifecycle.js";
 import { runIssueCommand } from "./issues/runIssueCommand.js";
 import { hasIssueLabel, isChallengeIssue } from "./issues/challengeIssue.js";
-import { TaskIssueManager, type IssueSummary } from "./issues/taskIssueManager.js";
+import {
+  TaskIssueManager,
+  type IssueSummary,
+  type UnauthorizedIssueClosureResult,
+} from "./issues/taskIssueManager.js";
 import {
   buildProjectProvisioningCompletionSummary,
   buildProjectProvisioningOutcomeComment,
@@ -117,6 +121,21 @@ function mapReviewOutcomeToLifecycleState(reviewOutcome: string): "accepted" | "
   }
 
   return "rejected";
+}
+
+function logUnauthorizedIssueClosure(result: UnauthorizedIssueClosureResult): void {
+  const authorLogin = result.authorLogin ?? "unknown";
+  const actionSummary = result.closed ? "closed automatically" : "could not be closed automatically";
+  console.log(`Unauthorized issue #${result.issueNumber} ${result.issueTitle} by ${authorLogin} ${actionSummary}.`);
+
+  if (result.commentMessage) {
+    const log = result.commentAdded ? console.log : console.error;
+    log(result.commentMessage);
+  }
+
+  if (!result.closed) {
+    console.error(result.closeMessage);
+  }
 }
 
 async function transitionIssueLifecycleState(
@@ -330,7 +349,11 @@ export async function main(): Promise<void> {
       let retryAttempt = 0;
       while (true) {
         try {
-          const openIssues = await issueManager.listOpenIssues();
+          const authorizedOpenIssueInventory = await issueManager.listAuthorizedOpenIssues();
+          const openIssues = authorizedOpenIssueInventory.issues;
+          for (const unauthorizedClosure of authorizedOpenIssueInventory.unauthorizedClosures) {
+            logUnauthorizedIssueClosure(unauthorizedClosure);
+          }
           const actionableIssues: IssueSummary[] = [];
 
           for (const issue of openIssues) {


### PR DESCRIPTION
## Summary
- enforce an explicit authorized-author trust boundary before issue selection by allowing only evolvo-auto and ptekspy
- automatically comment on and close unauthorized open issues, then log the outcome before normal queue handling continues
- add regression coverage for allowed authors, unauthorized closure, failure reporting, and the real-manager replenishment harness

## Root cause
The runtime consumed the raw open-issue queue without validating who created each issue. That meant any open issue could enter the normal work path, and there was no automatic cleanup for unauthorized issue authors.

## Validation
- pnpm validate

Closes #366
