### PR TITLE
fix(projects): resume existing startProject requests

### DIFF
--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -18,6 +18,7 @@ const buildLifecycleStateCommentMock = vi.fn();
 const writeRuntimeReadinessSignalMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
 const ensureProjectRegistryMock = vi.fn();
+const readActiveProjectStateMock = vi.fn();
 const resolveProjectExecutionContextForIssueMock = vi.fn();
 const buildProjectRoutingBlockedCommentMock = vi.fn();
 
@@ -221,6 +222,10 @@ vi.mock("./projects/projectRegistry.js", () => ({
   ensureProjectRegistry: ensureProjectRegistryMock,
 }));
 
+vi.mock("./projects/activeProjectState.js", () => ({
+  readActiveProjectState: readActiveProjectStateMock,
+}));
+
 vi.mock("./projects/projectExecutionContext.js", () => ({
   PROJECT_ROUTING_BLOCKED_LABEL: "blocked",
   buildProjectRoutingBlockedComment: buildProjectRoutingBlockedCommentMock,
@@ -409,6 +414,14 @@ describe("main replenishment integration", () => {
         },
       ],
     });
+    readActiveProjectStateMock.mockReset();
+    readActiveProjectStateMock.mockResolvedValue({
+      version: 1,
+      activeProjectSlug: null,
+      updatedAt: null,
+      requestedBy: null,
+      source: null,
+    });
     resolveProjectExecutionContextForIssueMock.mockReset();
     resolveProjectExecutionContextForIssueMock.mockResolvedValue({
       ok: true,
@@ -537,7 +550,7 @@ describe("main replenishment integration", () => {
       "No actionable open issues remaining and no new issues were created. Issue loop stopped.",
     );
     expect(runPostMergeSelfRestartMock).toHaveBeenCalledWith("/tmp/evolvo");
-  });
+  }, 10000);
 
   it("replenishes a completed-only open queue and continues processing without exiting", async () => {
     mockApiState.issues = [
@@ -632,7 +645,7 @@ describe("main replenishment integration", () => {
       "No actionable open issues remaining and no new issues were created. Issue loop stopped.",
     );
     expect(runPostMergeSelfRestartMock).toHaveBeenCalledWith("/tmp/evolvo");
-  });
+  }, 10000);
 
   it("bootstraps startup issues for an empty queue and proceeds into normal issue selection", async () => {
     resetMockApiStateToEmptyQueue();

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -39,9 +39,10 @@ const markGracefulShutdownRequestEnforcedMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
 const configureCodingAgentExecutionContextMock = vi.fn();
 const ensureProjectRegistryMock = vi.fn();
+const readActiveProjectStateMock = vi.fn();
 const resolveProjectExecutionContextForIssueMock = vi.fn();
 const buildProjectRoutingBlockedCommentMock = vi.fn();
-const createProjectProvisioningRequestIssueMock = vi.fn();
+const handleStartProjectCommandMock = vi.fn();
 const executeProjectProvisioningIssueMock = vi.fn();
 const isProjectProvisioningRequestIssueMock = vi.fn();
 const buildProjectProvisioningOutcomeCommentMock = vi.fn();
@@ -176,8 +177,8 @@ vi.mock("./runtime/operatorControl.js", () => ({
 vi.mock("./projects/projectProvisioning.js", () => ({
   buildProjectProvisioningCompletionSummary: buildProjectProvisioningCompletionSummaryMock,
   buildProjectProvisioningOutcomeComment: buildProjectProvisioningOutcomeCommentMock,
-  createProjectProvisioningRequestIssue: createProjectProvisioningRequestIssueMock,
   executeProjectProvisioningIssue: executeProjectProvisioningIssueMock,
+  handleStartProjectCommand: handleStartProjectCommandMock,
   isProjectProvisioningRequestIssue: isProjectProvisioningRequestIssueMock,
 }));
 
@@ -194,6 +195,10 @@ vi.mock("./projects/projectRegistry.js", () => ({
     defaultBranch: context.defaultBranch ?? null,
   }),
   ensureProjectRegistry: ensureProjectRegistryMock,
+}));
+
+vi.mock("./projects/activeProjectState.js", () => ({
+  readActiveProjectState: readActiveProjectStateMock,
 }));
 
 vi.mock("./projects/projectExecutionContext.js", () => ({
@@ -278,12 +283,23 @@ describe("main", () => {
     runPostMergeSelfRestartMock.mockResolvedValue(undefined);
     tryResolveRepositoryDefaultBranchMock.mockReset();
     tryResolveRepositoryDefaultBranchMock.mockResolvedValue("main");
-    createProjectProvisioningRequestIssueMock.mockReset();
-    createProjectProvisioningRequestIssueMock.mockResolvedValue({
+    handleStartProjectCommandMock.mockReset();
+    handleStartProjectCommandMock.mockResolvedValue({
       ok: true,
-      message: "Created issue #400.",
-      issueNumber: 400,
-      issueUrl: "https://github.com/owner/repo/issues/400",
+      action: "created",
+      message: "Created provisioning issue #400 for project `habit-cli`.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        workspacePath: "projects/habit-cli",
+        status: "provisioning",
+      },
+      trackerIssue: {
+        number: 400,
+        url: "https://github.com/owner/repo/issues/400",
+        alreadyOpen: false,
+      },
     });
     executeProjectProvisioningIssueMock.mockReset();
     executeProjectProvisioningIssueMock.mockResolvedValue({
@@ -337,6 +353,14 @@ describe("main", () => {
     buildProjectProvisioningCompletionSummaryMock.mockReturnValue("Provisioning complete summary");
     ensureProjectRegistryMock.mockReset();
     ensureProjectRegistryMock.mockResolvedValue({ version: 1, projects: [DEFAULT_PROJECT_EXECUTION_CONTEXT.project] });
+    readActiveProjectStateMock.mockReset();
+    readActiveProjectStateMock.mockResolvedValue({
+      version: 1,
+      activeProjectSlug: null,
+      updatedAt: null,
+      requestedBy: null,
+      source: null,
+    });
     resolveProjectExecutionContextForIssueMock.mockReset();
     resolveProjectExecutionContextForIssueMock.mockResolvedValue({
       ok: true,
@@ -523,6 +547,54 @@ describe("main", () => {
       }),
     );
     expect(stopDiscordGracefulShutdownListenerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes /startProject requests through the create-or-resume project handler", async () => {
+    const { main } = await import("./main.js");
+
+    await main();
+
+    const discordHandlers = startDiscordGracefulShutdownListenerMock.mock.calls[0]?.[1];
+    const result = await discordHandlers.onStartProject({
+      messageId: "7101",
+      requestedAt: "2026-03-08T09:00:00.000Z",
+      requestedBy: "discord:operator-1",
+      displayName: "Habit CLI",
+      slug: "habit-cli",
+      repositoryName: "habit-cli",
+      issueLabel: "project:habit-cli",
+      workspaceRelativePath: "projects/habit-cli",
+    });
+
+    expect(handleStartProjectCommandMock).toHaveBeenCalledWith({
+      issueManager: expect.any(Object),
+      workDir: "/tmp/evolvo",
+      trackerOwner: "owner",
+      trackerRepo: "repo",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-08T09:00:00.000Z",
+    });
+    expect(result).toEqual({
+      ok: true,
+      action: "created",
+      message: "Created provisioning issue #400 for project `habit-cli`.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        workspacePath: "projects/habit-cli",
+        status: "provisioning",
+      },
+      trackerIssue: {
+        number: 400,
+        url: "https://github.com/owner/repo/issues/400",
+        alreadyOpen: false,
+      },
+    });
+    expect(console.log).toHaveBeenCalledWith(
+      "[startProject] created new project flow for Habit CLI (habit-cli).",
+    );
   });
 
   it("logs and excludes unauthorized issues before normal selection", async () => {
@@ -772,6 +844,49 @@ describe("main", () => {
       expect.stringContaining("Execution repository: `owner/habit-cli`."),
     );
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #14: Managed repo issue\n\nUse project context");
+  });
+
+  it("prefers issues for the active project when one is selected", async () => {
+    readActiveProjectStateMock.mockResolvedValueOnce({
+      version: 1,
+      activeProjectSlug: "habit-cli",
+      updatedAt: "2026-03-08T09:10:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+    });
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 21, title: "Default issue", description: "general", state: "open", labels: [] },
+        { number: 22, title: "Managed issue", description: "project", state: "open", labels: ["project:habit-cli"] },
+      ])
+      .mockResolvedValueOnce([]);
+    resolveProjectExecutionContextForIssueMock.mockResolvedValueOnce({
+      ok: true,
+      context: {
+        project: {
+          ...DEFAULT_PROJECT_EXECUTION_CONTEXT.project,
+          slug: "habit-cli",
+          displayName: "Habit CLI",
+          kind: "managed",
+          issueLabel: "project:habit-cli",
+          executionRepo: {
+            owner: "owner",
+            repo: "habit-cli",
+            url: "https://github.com/owner/habit-cli",
+            defaultBranch: "main",
+          },
+          cwd: "/tmp/evolvo/projects/habit-cli",
+        },
+        trackerRepository: "owner/repo",
+        executionRepository: "owner/habit-cli",
+      },
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(markInProgressMock).toHaveBeenCalledWith(22);
+    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #22: Managed issue\n\nproject");
   });
 
   it("blocks issues with invalid project labels before execution", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,10 +69,11 @@ import {
 import {
   buildProjectProvisioningCompletionSummary,
   buildProjectProvisioningOutcomeComment,
-  createProjectProvisioningRequestIssue,
   executeProjectProvisioningIssue,
+  handleStartProjectCommand,
   isProjectProvisioningRequestIssue,
 } from "./projects/projectProvisioning.js";
+import { readActiveProjectState } from "./projects/activeProjectState.js";
 import {
   PROJECT_ROUTING_BLOCKED_LABEL,
   buildProjectRoutingBlockedComment,
@@ -283,9 +284,10 @@ export async function main(): Promise<void> {
     repo: GITHUB_REPO,
     workDir: WORK_DIR,
   });
+  let activeProjectSlug = (await readActiveProjectState(WORK_DIR)).activeProjectSlug;
   const discordHandlers: DiscordControlHandlers = {
-    onStartProject: async (request) =>
-      createProjectProvisioningRequestIssue({
+    onStartProject: async (request) => {
+      const result = await handleStartProjectCommand({
         issueManager,
         workDir: WORK_DIR,
         trackerOwner: GITHUB_OWNER,
@@ -293,7 +295,19 @@ export async function main(): Promise<void> {
         projectName: request.displayName,
         requestedBy: request.requestedBy,
         requestedAt: request.requestedAt,
-      }),
+      });
+      if (result.ok) {
+        activeProjectSlug = result.project.slug;
+        console.log(
+          result.action === "created"
+            ? `[startProject] created new project flow for ${result.project.displayName} (${result.project.slug}).`
+            : `[startProject] resumed existing project ${result.project.displayName} (${result.project.slug}) with status ${result.project.status}.`,
+        );
+      } else {
+        console.error(`[startProject] failed for ${request.displayName}: ${result.message}`);
+      }
+      return result;
+    },
   };
 
   console.log(`Hello from ${GITHUB_OWNER}/${GITHUB_REPO}!`);
@@ -388,7 +402,9 @@ export async function main(): Promise<void> {
             return;
           }
 
-          const selectedIssue = selectIssueForWork(retryEligibleIssues);
+          const selectedIssue = selectIssueForWork(retryEligibleIssues, {
+            activeProjectSlug,
+          });
 
           if (!selectedIssue) {
             if (
@@ -549,6 +565,7 @@ export async function main(): Promise<void> {
             );
 
             if (provisioningResult.ok) {
+              activeProjectSlug = provisioningResult.record.slug;
               await transitionIssueLifecycleState(issueManager, {
                 issue: selectedIssue,
                 nextState: "accepted",

--- a/src/projects/activeProjectState.test.ts
+++ b/src/projects/activeProjectState.test.ts
@@ -1,0 +1,121 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getActiveProjectStatePath,
+  readActiveProjectState,
+  setActiveProjectState,
+} from "./activeProjectState.js";
+
+async function createTempWorkDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "active-project-state-"));
+}
+
+describe("activeProjectState", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.map((directory) => rm(directory, { recursive: true, force: true })));
+  });
+
+  it("returns an empty active-project state when the file is missing", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await expect(readActiveProjectState(workDir)).resolves.toEqual({
+      version: 1,
+      activeProjectSlug: null,
+      updatedAt: null,
+      requestedBy: null,
+      source: null,
+    });
+  });
+
+  it("writes the active project state atomically", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    const state = await setActiveProjectState({
+      workDir,
+      slug: "habit-cli",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+      updatedAt: "2026-03-08T12:00:00.000Z",
+    });
+
+    expect(state).toEqual({
+      version: 1,
+      activeProjectSlug: "habit-cli",
+      updatedAt: "2026-03-08T12:00:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+    });
+    await expect(readFile(getActiveProjectStatePath(workDir), "utf8")).resolves.toBe(
+      `${JSON.stringify(state, null, 2)}\n`,
+    );
+    await expect(readActiveProjectState(workDir)).resolves.toEqual(state);
+  });
+
+  it("recovers malformed state files with a safe empty state", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-08T13:00:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const statePath = getActiveProjectStatePath(workDir);
+    const corruptPath = join(workDir, ".evolvo", `active-project.corrupt-${recoveryAtMs}.json`);
+    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    await writeFile(statePath, "{\"activeProjectSlug\":", "utf8");
+
+    await expect(readActiveProjectState(workDir)).resolves.toEqual({
+      version: 1,
+      activeProjectSlug: null,
+      updatedAt: null,
+      requestedBy: null,
+      source: null,
+    });
+    await expect(readFile(corruptPath, "utf8")).resolves.toBe("{\"activeProjectSlug\":");
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered malformed active project state at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
+
+  it("recovers invalid state files with a safe empty state", async () => {
+    vi.useFakeTimers();
+    const recoveryAtMs = new Date("2026-03-08T13:05:00.000Z").getTime();
+    vi.setSystemTime(recoveryAtMs);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const statePath = getActiveProjectStatePath(workDir);
+    const corruptPath = join(workDir, ".evolvo", `active-project.corrupt-${recoveryAtMs}.json`);
+    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        version: 99,
+        activeProjectSlug: 7,
+        updatedAt: false,
+        requestedBy: "discord:operator-1",
+        source: "unknown",
+      }),
+      "utf8",
+    );
+
+    await expect(readActiveProjectState(workDir)).resolves.toEqual({
+      version: 1,
+      activeProjectSlug: null,
+      updatedAt: null,
+      requestedBy: null,
+      source: null,
+    });
+    await expect(readFile(corruptPath, "utf8")).resolves.toContain("\"version\":99");
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Recovered invalid active project state at ${statePath}; preserved corrupt file at ${corruptPath}.`,
+    );
+  });
+});

--- a/src/projects/activeProjectState.ts
+++ b/src/projects/activeProjectState.ts
@@ -1,0 +1,117 @@
+import { join } from "node:path";
+import {
+  readRecoverableJsonState,
+  writeAtomicJsonState,
+  type RecoverableJsonStateNormalizationResult,
+} from "../runtime/localStateFile.js";
+
+const ACTIVE_PROJECT_STATE_FILE_NAME = "active-project.json";
+const ACTIVE_PROJECT_STATE_VERSION = 1;
+
+export type ActiveProjectStateSource = "start-project-command" | "project-provisioning";
+
+export type ActiveProjectState = {
+  version: typeof ACTIVE_PROJECT_STATE_VERSION;
+  activeProjectSlug: string | null;
+  updatedAt: string | null;
+  requestedBy: string | null;
+  source: ActiveProjectStateSource | null;
+};
+
+function normalizeNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeSource(value: unknown): ActiveProjectStateSource | null {
+  if (value === "start-project-command" || value === "project-provisioning") {
+    return value;
+  }
+
+  return null;
+}
+
+function createDefaultActiveProjectState(): ActiveProjectState {
+  return {
+    version: ACTIVE_PROJECT_STATE_VERSION,
+    activeProjectSlug: null,
+    updatedAt: null,
+    requestedBy: null,
+    source: null,
+  };
+}
+
+function normalizeActiveProjectState(raw: unknown): RecoverableJsonStateNormalizationResult<ActiveProjectState> {
+  if (typeof raw !== "object" || raw === null) {
+    return {
+      state: createDefaultActiveProjectState(),
+      recoveredInvalid: true,
+    };
+  }
+
+  const candidate = raw as Partial<ActiveProjectState>;
+  const activeProjectSlug = normalizeNonEmptyString(candidate.activeProjectSlug);
+  const updatedAt = normalizeNonEmptyString(candidate.updatedAt);
+  const requestedBy = normalizeNonEmptyString(candidate.requestedBy);
+  const source = normalizeSource(candidate.source);
+  const version = candidate.version === ACTIVE_PROJECT_STATE_VERSION ? ACTIVE_PROJECT_STATE_VERSION : null;
+
+  if (
+    version === null ||
+    ("activeProjectSlug" in candidate && candidate.activeProjectSlug !== null && activeProjectSlug === null) ||
+    ("updatedAt" in candidate && candidate.updatedAt !== null && updatedAt === null) ||
+    ("requestedBy" in candidate && candidate.requestedBy !== null && requestedBy === null) ||
+    ("source" in candidate && candidate.source !== null && source === null)
+  ) {
+    return {
+      state: createDefaultActiveProjectState(),
+      recoveredInvalid: true,
+    };
+  }
+
+  return {
+    state: {
+      version: ACTIVE_PROJECT_STATE_VERSION,
+      activeProjectSlug,
+      updatedAt,
+      requestedBy,
+      source,
+    },
+    recoveredInvalid: false,
+  };
+}
+
+export function getActiveProjectStatePath(workDir: string): string {
+  return join(workDir, ".evolvo", ACTIVE_PROJECT_STATE_FILE_NAME);
+}
+
+export async function readActiveProjectState(workDir: string): Promise<ActiveProjectState> {
+  return readRecoverableJsonState({
+    statePath: getActiveProjectStatePath(workDir),
+    createDefaultState: createDefaultActiveProjectState,
+    normalizeState: normalizeActiveProjectState,
+    warningLabel: "active project state",
+  });
+}
+
+export async function setActiveProjectState(options: {
+  workDir: string;
+  slug: string;
+  requestedBy: string;
+  source: ActiveProjectStateSource;
+  updatedAt?: string;
+}): Promise<ActiveProjectState> {
+  const state: ActiveProjectState = {
+    version: ACTIVE_PROJECT_STATE_VERSION,
+    activeProjectSlug: options.slug.trim(),
+    updatedAt: options.updatedAt?.trim() || new Date().toISOString(),
+    requestedBy: options.requestedBy.trim(),
+    source: options.source,
+  };
+  await writeAtomicJsonState(getActiveProjectStatePath(options.workDir), state);
+  return state;
+}

--- a/src/projects/projectProvisioning.test.ts
+++ b/src/projects/projectProvisioning.test.ts
@@ -9,9 +9,11 @@ import {
   buildProjectProvisioningOutcomeComment,
   createProjectProvisioningRequestIssue,
   executeProjectProvisioningIssue,
+  handleStartProjectCommand,
   isProjectProvisioningRequestIssue,
 } from "./projectProvisioning.js";
 import { getProjectRegistryPath, upsertProjectRecord } from "./projectRegistry.js";
+import { getActiveProjectStatePath } from "./activeProjectState.js";
 
 async function createTempWorkDir(): Promise<string> {
   return mkdtemp(join(tmpdir(), "project-provisioning-"));
@@ -254,6 +256,320 @@ describe("projectProvisioning", () => {
     );
   });
 
+  it("creates a missing project start flow and stores the requested project as active", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([]),
+      createIssue: vi.fn().mockResolvedValue({
+        ok: true,
+        message: "Created issue #405.",
+        issue: {
+          number: 405,
+          title: "Start project Habit CLI",
+          description: "body",
+          state: "open",
+          labels: [],
+        },
+      }),
+    };
+
+    const result = await handleStartProjectCommand({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-08T08:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      action: "created",
+      message: "Created provisioning issue #405 for project `habit-cli`.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        workspacePath: "projects/habit-cli",
+        status: "provisioning",
+      },
+      trackerIssue: {
+        number: 405,
+        url: "https://github.com/evolvo-auto/evolvo-ts/issues/405",
+        alreadyOpen: false,
+      },
+    });
+    expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
+      version: 1,
+      activeProjectSlug: "habit-cli",
+      updatedAt: "2026-03-08T08:00:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+    });
+  });
+
+  it("resumes an existing active project without creating a new provisioning issue", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await upsertProjectRecord(
+      workDir,
+      {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+      },
+      {
+        slug: "habit-cli",
+        displayName: "Habit CLI",
+        kind: "managed",
+        issueLabel: "project:habit-cli",
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "evolvo-ts",
+          url: "https://github.com/evolvo-auto/evolvo-ts",
+        },
+        executionRepo: {
+          owner: "evolvo-auto",
+          repo: "habit-cli",
+          url: "https://github.com/evolvo-auto/habit-cli",
+          defaultBranch: "main",
+        },
+        cwd: resolve(workDir, "projects", "habit-cli"),
+        status: "active",
+        sourceIssueNumber: 318,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: true,
+          lastError: null,
+        },
+      },
+    );
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([]),
+      createIssue: vi.fn(),
+    };
+
+    const result = await handleStartProjectCommand({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-08T08:05:00.000Z",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      action: "resumed",
+      message: "Resumed existing project `habit-cli`.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
+        workspacePath: resolve(workDir, "projects", "habit-cli"),
+        status: "active",
+      },
+    });
+    expect(issueManager.createIssue).not.toHaveBeenCalled();
+    expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
+      version: 1,
+      activeProjectSlug: "habit-cli",
+      updatedAt: "2026-03-08T08:05:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+    });
+  });
+
+  it("resumes a failed project by reusing its existing recovery issue", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await upsertProjectRecord(
+      workDir,
+      {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+      },
+      {
+        slug: "habit-cli",
+        displayName: "Habit CLI",
+        kind: "managed",
+        issueLabel: "project:habit-cli",
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "evolvo-ts",
+          url: "https://github.com/evolvo-auto/evolvo-ts",
+        },
+        executionRepo: {
+          owner: "evolvo-auto",
+          repo: "habit-cli",
+          url: "https://github.com/evolvo-auto/habit-cli",
+          defaultBranch: "main",
+        },
+        cwd: resolve(workDir, "projects", "habit-cli"),
+        status: "failed",
+        sourceIssueNumber: 318,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: false,
+          lastError: "workspace failed",
+        },
+      },
+    );
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          number: 406,
+          title: "Start project Habit CLI",
+          description: buildProjectProvisioningIssueBody({
+            owner: "evolvo-auto",
+            displayName: "Habit CLI",
+            slug: "habit-cli",
+            repositoryName: "habit-cli",
+            issueLabel: "project:habit-cli",
+            workspaceRelativePath: "projects/habit-cli",
+            requestedBy: "discord:operator-1",
+            requestedAt: "2026-03-08T07:50:00.000Z",
+          }),
+          state: "open",
+          labels: [],
+        },
+      ]),
+      createIssue: vi.fn(),
+    };
+
+    const result = await handleStartProjectCommand({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-08T08:10:00.000Z",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      action: "resumed",
+      message: "Resumed existing project `habit-cli` and kept recovery issue #406 active.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
+        workspacePath: resolve(workDir, "projects", "habit-cli"),
+        status: "failed",
+      },
+      trackerIssue: {
+        number: 406,
+        url: "https://github.com/evolvo-auto/evolvo-ts/issues/406",
+        alreadyOpen: true,
+      },
+    });
+    expect(issueManager.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("resumes a failed project by queuing a recovery issue when none is open", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await upsertProjectRecord(
+      workDir,
+      {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir,
+      },
+      {
+        slug: "habit-cli",
+        displayName: "Habit CLI",
+        kind: "managed",
+        issueLabel: "project:habit-cli",
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "evolvo-ts",
+          url: "https://github.com/evolvo-auto/evolvo-ts",
+        },
+        executionRepo: {
+          owner: "evolvo-auto",
+          repo: "habit-cli",
+          url: "https://github.com/evolvo-auto/habit-cli",
+          defaultBranch: "main",
+        },
+        cwd: resolve(workDir, "projects", "habit-cli"),
+        status: "failed",
+        sourceIssueNumber: 318,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+        provisioning: {
+          labelCreated: true,
+          repoCreated: true,
+          workspacePrepared: false,
+          lastError: "workspace failed",
+        },
+      },
+    );
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([]),
+      createIssue: vi.fn().mockResolvedValue({
+        ok: true,
+        message: "Created issue #407.",
+        issue: {
+          number: 407,
+          title: "Start project Habit CLI",
+          description: "body",
+          state: "open",
+          labels: [],
+        },
+      }),
+    };
+
+    const result = await handleStartProjectCommand({
+      issueManager,
+      workDir,
+      trackerOwner: "evolvo-auto",
+      trackerRepo: "evolvo-ts",
+      projectName: "Habit CLI",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-08T08:15:00.000Z",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      action: "resumed",
+      message: "Resumed existing project `habit-cli` and queued recovery issue #407.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
+        workspacePath: resolve(workDir, "projects", "habit-cli"),
+        status: "failed",
+      },
+      trackerIssue: {
+        number: 407,
+        url: "https://github.com/evolvo-auto/evolvo-ts/issues/407",
+        alreadyOpen: false,
+      },
+    });
+    expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
+      version: 1,
+      activeProjectSlug: "habit-cli",
+      updatedAt: "2026-03-08T08:15:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+    });
+  });
+
   it("provisions a managed project and records active registry state on success", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
@@ -314,6 +630,13 @@ describe("projectProvisioning", () => {
       }),
     );
     expect(resolve(workDir, "projects", "habit-cli")).toBe(result.record.cwd);
+    expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
+      version: 1,
+      activeProjectSlug: "habit-cli",
+      updatedAt: expect.any(String),
+      requestedBy: "discord:operator-1",
+      source: "project-provisioning",
+    });
   });
 
   it("preserves partial success in failed registry state when workspace preparation fails", async () => {

--- a/src/projects/projectProvisioning.ts
+++ b/src/projects/projectProvisioning.ts
@@ -8,6 +8,7 @@ import {
   type ProjectProvisioningIssueMetadata,
 } from "../issues/projectProvisioningIssue.js";
 import type { IssueSummary, TaskIssueManager } from "../issues/taskIssueManager.js";
+import { setActiveProjectState } from "./activeProjectState.js";
 import { normalizeProjectNameInput } from "./projectNaming.js";
 import {
   findProjectBySlug,
@@ -52,16 +53,61 @@ export type CreateProjectProvisioningRequestResult =
     message: string;
   };
 
+export type StartProjectCommandHandlingResult =
+  | {
+    ok: true;
+    action: "created";
+    message: string;
+    project: {
+      displayName: string;
+      slug: string;
+      repositoryName: string;
+      workspacePath: string;
+      status: "provisioning";
+    };
+    trackerIssue: {
+      number: number;
+      url: string;
+      alreadyOpen: boolean;
+    };
+  }
+  | {
+    ok: true;
+    action: "resumed";
+    message: string;
+    project: {
+      displayName: string;
+      slug: string;
+      repositoryName: string;
+      repositoryUrl: string;
+      workspacePath: string;
+      status: ProjectRecord["status"];
+    };
+    trackerIssue?: {
+      number: number;
+      url: string;
+      alreadyOpen: boolean;
+    };
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
 export type ProjectProvisioningExecutionResult = {
   ok: boolean;
   metadata: ProjectProvisioningIssueMetadata;
   record: ProjectRecord;
-  failureStep: "registry" | "label" | "repository" | "workspace" | null;
+  failureStep: "registry" | "label" | "repository" | "workspace" | "active-project" | null;
   message: string;
 };
 
 function buildRepositoryUrl(owner: string, repo: string): string {
   return `https://github.com/${owner}/${repo}`;
+}
+
+function buildProjectProvisioningIssueUrl(owner: string, repo: string, issueNumber: number): string {
+  return `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
 }
 
 function buildDefaultProjectContext(workDir: string, owner: string, repo: string): DefaultProjectContext {
@@ -116,6 +162,89 @@ function buildManagedProjectRecord(
   };
 }
 
+async function findOpenProvisioningIssueForSlug(
+  issueManager: ProjectProvisioningIssueManager,
+  slug: string,
+): Promise<IssueSummary | null> {
+  const openIssues = await issueManager.listOpenIssues();
+  return openIssues.find((issue) => {
+    const metadata = parseProjectProvisioningIssueMetadata(issue.description);
+    return metadata?.slug === slug;
+  }) ?? null;
+}
+
+function buildProjectProvisioningMetadata(options: {
+  trackerOwner: string;
+  normalizedProject: ReturnType<typeof normalizeProjectNameInput>;
+  requestedBy: string;
+  requestedAt?: string;
+}): ProjectProvisioningIssueMetadata {
+  return {
+    owner: options.trackerOwner,
+    displayName: options.normalizedProject.displayName,
+    slug: options.normalizedProject.slug,
+    repositoryName: options.normalizedProject.repositoryName,
+    issueLabel: options.normalizedProject.issueLabel,
+    workspaceRelativePath: options.normalizedProject.workspaceRelativePath,
+    requestedBy: options.requestedBy,
+    requestedAt: options.requestedAt?.trim() || new Date().toISOString(),
+  };
+}
+
+function buildCreatedStartProjectResult(options: {
+  metadata: ProjectProvisioningIssueMetadata;
+  trackerOwner: string;
+  trackerRepo: string;
+  issueNumber: number;
+  alreadyOpen: boolean;
+}): StartProjectCommandHandlingResult {
+  const issueUrl = buildProjectProvisioningIssueUrl(options.trackerOwner, options.trackerRepo, options.issueNumber);
+  return {
+    ok: true,
+    action: "created",
+    message: options.alreadyOpen
+      ? `Project \`${options.metadata.slug}\` is already queued for provisioning in issue #${options.issueNumber}.`
+      : `Created provisioning issue #${options.issueNumber} for project \`${options.metadata.slug}\`.`,
+    project: {
+      displayName: options.metadata.displayName,
+      slug: options.metadata.slug,
+      repositoryName: options.metadata.repositoryName,
+      workspacePath: options.metadata.workspaceRelativePath,
+      status: "provisioning",
+    },
+    trackerIssue: {
+      number: options.issueNumber,
+      url: issueUrl,
+      alreadyOpen: options.alreadyOpen,
+    },
+  };
+}
+
+function buildResumedStartProjectResult(
+  record: ProjectRecord,
+  message: string,
+  trackerIssue?: {
+    number: number;
+    url: string;
+    alreadyOpen: boolean;
+  },
+): StartProjectCommandHandlingResult {
+  return {
+    ok: true,
+    action: "resumed",
+    message,
+    project: {
+      displayName: record.displayName,
+      slug: record.slug,
+      repositoryName: record.executionRepo.repo,
+      repositoryUrl: record.executionRepo.url,
+      workspacePath: record.cwd,
+      status: record.status,
+    },
+    ...(trackerIssue ? { trackerIssue } : {}),
+  };
+}
+
 export async function createProjectProvisioningRequestIssue(options: {
   issueManager: ProjectProvisioningIssueManager;
   workDir: string;
@@ -137,11 +266,7 @@ export async function createProjectProvisioningRequestIssue(options: {
       };
     }
 
-    const openIssues = await options.issueManager.listOpenIssues();
-    const duplicateIssue = openIssues.find((issue) => {
-      const metadata = parseProjectProvisioningIssueMetadata(issue.description);
-      return metadata?.slug === normalized.slug;
-    });
+    const duplicateIssue = await findOpenProvisioningIssueForSlug(options.issueManager, normalized.slug);
     if (duplicateIssue) {
       return {
         ok: false,
@@ -149,16 +274,12 @@ export async function createProjectProvisioningRequestIssue(options: {
       };
     }
 
-    const metadata: ProjectProvisioningIssueMetadata = {
-      owner: options.trackerOwner,
-      displayName: normalized.displayName,
-      slug: normalized.slug,
-      repositoryName: normalized.repositoryName,
-      issueLabel: normalized.issueLabel,
-      workspaceRelativePath: normalized.workspaceRelativePath,
+    const metadata = buildProjectProvisioningMetadata({
+      trackerOwner: options.trackerOwner,
+      normalizedProject: normalized,
       requestedBy: options.requestedBy,
-      requestedAt: options.requestedAt?.trim() || new Date().toISOString(),
-    };
+      requestedAt: options.requestedAt,
+    });
     const created = await options.issueManager.createIssue(
       buildProjectProvisioningIssueTitle(metadata.displayName),
       buildProjectProvisioningIssueBody(metadata),
@@ -171,13 +292,154 @@ export async function createProjectProvisioningRequestIssue(options: {
       ok: true,
       message: created.message,
       issueNumber: created.issue.number,
-      issueUrl: `https://github.com/${options.trackerOwner}/${options.trackerRepo}/issues/${created.issue.number}`,
+      issueUrl: buildProjectProvisioningIssueUrl(options.trackerOwner, options.trackerRepo, created.issue.number),
       metadata,
     };
   } catch (error) {
     return {
       ok: false,
       message: error instanceof Error ? error.message : "Unknown project provisioning request error.",
+    };
+  }
+}
+
+export async function handleStartProjectCommand(options: {
+  issueManager: ProjectProvisioningIssueManager;
+  workDir: string;
+  trackerOwner: string;
+  trackerRepo: string;
+  projectName: string;
+  requestedBy: string;
+  requestedAt?: string;
+}): Promise<StartProjectCommandHandlingResult> {
+  try {
+    const normalized = normalizeProjectNameInput(options.projectName);
+    const defaultProject = buildDefaultProjectContext(options.workDir, options.trackerOwner, options.trackerRepo);
+    const registry = await readProjectRegistry(options.workDir, defaultProject);
+    const existingProject = findProjectBySlug(registry, normalized.slug);
+    const duplicateIssue = await findOpenProvisioningIssueForSlug(options.issueManager, normalized.slug);
+
+    if (existingProject && existingProject.status !== "failed") {
+      await setActiveProjectState({
+        workDir: options.workDir,
+        slug: existingProject.slug,
+        requestedBy: options.requestedBy,
+        source: "start-project-command",
+        updatedAt: options.requestedAt,
+      });
+      return buildResumedStartProjectResult(
+        existingProject,
+        existingProject.status === "active"
+          ? `Resumed existing project \`${existingProject.slug}\`.`
+          : `Project \`${existingProject.slug}\` already exists with status \`${existingProject.status}\`; resuming that flow.`,
+      );
+    }
+
+    if (existingProject && existingProject.status === "failed") {
+      if (duplicateIssue) {
+        await setActiveProjectState({
+          workDir: options.workDir,
+          slug: existingProject.slug,
+          requestedBy: options.requestedBy,
+          source: "start-project-command",
+          updatedAt: options.requestedAt,
+        });
+        return buildResumedStartProjectResult(
+          existingProject,
+          `Resumed existing project \`${existingProject.slug}\` and kept recovery issue #${duplicateIssue.number} active.`,
+          {
+            number: duplicateIssue.number,
+            url: buildProjectProvisioningIssueUrl(options.trackerOwner, options.trackerRepo, duplicateIssue.number),
+            alreadyOpen: true,
+          },
+        );
+      }
+
+      const recoveryRequest = await createProjectProvisioningRequestIssue({
+        issueManager: options.issueManager,
+        workDir: options.workDir,
+        trackerOwner: options.trackerOwner,
+        trackerRepo: options.trackerRepo,
+        projectName: options.projectName,
+        requestedBy: options.requestedBy,
+        requestedAt: options.requestedAt,
+      });
+      if (!recoveryRequest.ok) {
+        return recoveryRequest;
+      }
+
+      await setActiveProjectState({
+        workDir: options.workDir,
+        slug: existingProject.slug,
+        requestedBy: options.requestedBy,
+        source: "start-project-command",
+        updatedAt: options.requestedAt,
+      });
+      return buildResumedStartProjectResult(
+        existingProject,
+        `Resumed existing project \`${existingProject.slug}\` and queued recovery issue #${recoveryRequest.issueNumber}.`,
+        {
+          number: recoveryRequest.issueNumber,
+          url: recoveryRequest.issueUrl,
+          alreadyOpen: false,
+        },
+      );
+    }
+
+    if (duplicateIssue) {
+      await setActiveProjectState({
+        workDir: options.workDir,
+        slug: normalized.slug,
+        requestedBy: options.requestedBy,
+        source: "start-project-command",
+        updatedAt: options.requestedAt,
+      });
+      const metadata = buildProjectProvisioningMetadata({
+        trackerOwner: options.trackerOwner,
+        normalizedProject: normalized,
+        requestedBy: options.requestedBy,
+        requestedAt: options.requestedAt,
+      });
+      return buildCreatedStartProjectResult({
+        metadata,
+        trackerOwner: options.trackerOwner,
+        trackerRepo: options.trackerRepo,
+        issueNumber: duplicateIssue.number,
+        alreadyOpen: true,
+      });
+    }
+
+    const request = await createProjectProvisioningRequestIssue({
+      issueManager: options.issueManager,
+      workDir: options.workDir,
+      trackerOwner: options.trackerOwner,
+      trackerRepo: options.trackerRepo,
+      projectName: options.projectName,
+      requestedBy: options.requestedBy,
+      requestedAt: options.requestedAt,
+    });
+    if (!request.ok) {
+      return request;
+    }
+
+    await setActiveProjectState({
+      workDir: options.workDir,
+      slug: request.metadata.slug,
+      requestedBy: options.requestedBy,
+      source: "start-project-command",
+      updatedAt: options.requestedAt,
+    });
+    return buildCreatedStartProjectResult({
+      metadata: request.metadata,
+      trackerOwner: options.trackerOwner,
+      trackerRepo: options.trackerRepo,
+      issueNumber: request.issueNumber,
+      alreadyOpen: false,
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Unknown project start request error.",
     };
   }
 }
@@ -310,6 +572,25 @@ export async function executeProjectProvisioningIssue(options: {
       metadata,
       record,
       failureStep: "workspace",
+      message,
+    };
+  }
+
+  try {
+    await setActiveProjectState({
+      workDir: options.workDir,
+      slug: metadata.slug,
+      requestedBy: metadata.requestedBy,
+      source: "project-provisioning",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown active project state update error.";
+    await persistRecord({ status: "failed" }, { lastError: message }).catch(() => undefined);
+    return {
+      ok: false,
+      metadata,
+      record,
+      failureStep: "active-project",
       message,
     };
   }

--- a/src/runtime/loopUtils.test.ts
+++ b/src/runtime/loopUtils.test.ts
@@ -83,4 +83,63 @@ describe("loopUtils retry handling", () => {
 
     expect(selected?.number).toBe(2);
   });
+
+  it("prefers issues for the active project when one is selected", () => {
+    const selected = selectIssueForWork(
+      [
+        {
+          number: 3,
+          title: "Default issue",
+          description: "default",
+          state: "open",
+          labels: [],
+        },
+        {
+          number: 4,
+          title: "Active project issue",
+          description: "managed",
+          state: "open",
+          labels: ["project:habit-cli"],
+        },
+      ],
+      { activeProjectSlug: "habit-cli" },
+    );
+
+    expect(selected?.number).toBe(4);
+  });
+
+  it("prefers the active project's provisioning issue while creation is still pending", () => {
+    const selected = selectIssueForWork(
+      [
+        {
+          number: 5,
+          title: "Default issue",
+          description: "default",
+          state: "open",
+          labels: [],
+        },
+        {
+          number: 6,
+          title: "Start project Habit CLI",
+          description: [
+            "<!-- evolvo:project-provisioning",
+            "owner: evolvo-auto",
+            "display_name: Habit CLI",
+            "slug: habit-cli",
+            "repo_name: habit-cli",
+            "issue_label: project:habit-cli",
+            "workspace_relative_path: projects/habit-cli",
+            "requested_by: discord:operator-1",
+            "requested_at: 2026-03-08T09:00:00.000Z",
+            "-->",
+          ].join("\n"),
+          state: "open",
+          labels: [],
+        },
+      ],
+      { activeProjectSlug: "habit-cli" },
+    );
+
+    expect(selected?.number).toBe(6);
+  });
 });

--- a/src/runtime/loopUtils.ts
+++ b/src/runtime/loopUtils.ts
@@ -1,4 +1,5 @@
 import { generateStartupIssueTemplates } from "../issues/startupIssueBootstrap.js";
+import { parseProjectProvisioningIssueMetadata } from "../issues/projectProvisioningIssue.js";
 import type { TaskIssueManager, IssueSummary } from "../issues/taskIssueManager.js";
 import { GitHubApiError } from "../github/githubClient.js";
 import {
@@ -7,6 +8,7 @@ import {
   isChallengeIssue,
   isChallengeRetryReadyIssue,
 } from "../issues/challengeIssue.js";
+import { PROJECT_LABEL_PREFIX } from "../projects/projectNaming.js";
 
 const OUTDATED_LABELS = new Set(["outdated", "obsolete", "wontfix", "invalid", "duplicate"]);
 const MIN_REPLENISH_ISSUES = 3;
@@ -17,13 +19,12 @@ const RUN_LOOP_GITHUB_RETRY_MAX_DELAY_MS = 1_000;
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
 
-export function selectIssueForWork(issues: IssueSummary[]): IssueSummary | null {
-  const notCompleted = issues.filter((issue) => !hasIssueLabel(issue, "completed") && !hasIssueLabel(issue, "blocked"));
-  if (notCompleted.length === 0) {
+function selectHighestPriorityIssue(issues: IssueSummary[]): IssueSummary | null {
+  if (issues.length === 0) {
     return null;
   }
 
-  const challengeCandidates = notCompleted.filter((issue) => isChallengeIssue(issue));
+  const challengeCandidates = issues.filter((issue) => isChallengeIssue(issue));
   if (challengeCandidates.length > 0) {
     const inProgressChallenge = challengeCandidates.find((issue) => isChallengeInProgressIssue(issue));
     if (inProgressChallenge) {
@@ -38,8 +39,43 @@ export function selectIssueForWork(issues: IssueSummary[]): IssueSummary | null 
     return challengeCandidates[0] ?? null;
   }
 
-  const inProgress = notCompleted.find((issue) => hasIssueLabel(issue, "in progress"));
-  return inProgress ?? notCompleted[0] ?? null;
+  const inProgress = issues.find((issue) => hasIssueLabel(issue, "in progress"));
+  return inProgress ?? issues[0] ?? null;
+}
+
+function issueTargetsActiveProject(issue: IssueSummary, activeProjectSlug: string): boolean {
+  const normalizedSlug = activeProjectSlug.trim().toLowerCase();
+  if (!normalizedSlug) {
+    return false;
+  }
+
+  const provisioningSlug = parseProjectProvisioningIssueMetadata(issue.description)?.slug?.trim().toLowerCase();
+  if (provisioningSlug === normalizedSlug) {
+    return true;
+  }
+
+  return issue.labels.some((label) => label.trim().toLowerCase() === `${PROJECT_LABEL_PREFIX}${normalizedSlug}`);
+}
+
+export function selectIssueForWork(
+  issues: IssueSummary[],
+  options: { activeProjectSlug?: string | null } = {},
+): IssueSummary | null {
+  const notCompleted = issues.filter((issue) => !hasIssueLabel(issue, "completed") && !hasIssueLabel(issue, "blocked"));
+  if (notCompleted.length === 0) {
+    return null;
+  }
+
+  const activeProjectSlug = options.activeProjectSlug?.trim() || null;
+  if (activeProjectSlug) {
+    const activeProjectIssues = notCompleted.filter((issue) => issueTargetsActiveProject(issue, activeProjectSlug));
+    const prioritized = selectHighestPriorityIssue(activeProjectIssues);
+    if (prioritized) {
+      return prioritized;
+    }
+  }
+
+  return selectHighestPriorityIssue(notCompleted);
 }
 
 export function isOutdatedIssue(issue: IssueSummary): boolean {

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -800,9 +800,20 @@ describe("operatorControl", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const onStartProject = vi.fn().mockResolvedValue({
       ok: true,
-      message: "Created issue #556.",
-      issueNumber: 556,
-      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/556",
+      action: "created",
+      message: "Created provisioning issue #556 for project `habit-cli`.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        workspacePath: "projects/habit-cli",
+        status: "provisioning",
+      },
+      trackerIssue: {
+        number: 556,
+        url: "https://github.com/evolvo-auto/evolvo-ts/issues/556",
+        alreadyOpen: false,
+      },
     });
     const fetchSpy = vi.fn()
       .mockResolvedValueOnce(
@@ -864,9 +875,20 @@ describe("operatorControl", () => {
 
     const onStartProject = vi.fn().mockResolvedValue({
       ok: true,
-      message: "Created issue #555.",
-      issueNumber: 555,
-      issueUrl: "https://github.com/evolvo-auto/evolvo-ts/issues/555",
+      action: "created",
+      message: "Created provisioning issue #555 for project `habit-cli`.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        workspacePath: "projects/habit-cli",
+        status: "provisioning",
+      },
+      trackerIssue: {
+        number: 555,
+        url: "https://github.com/evolvo-auto/evolvo-ts/issues/555",
+        alreadyOpen: false,
+      },
     });
     const fetchSpy = vi.fn()
       .mockResolvedValueOnce(
@@ -901,11 +923,66 @@ describe("operatorControl", () => {
         method: "POST",
         body: JSON.stringify({
           content: [
-            "<@operator-1> Project start request queued for `Habit CLI`.",
+            "<@operator-1> Created new project for `Habit CLI`.",
+            "Created provisioning issue #555 for project `habit-cli`.",
             "Tracker issue: #555 (https://github.com/evolvo-auto/evolvo-ts/issues/555)",
             "Planned label: `project:habit-cli`",
             "Planned repository: `habit-cli`",
             "Planned workspace: `projects/habit-cli`",
+          ].join("\n"),
+        }),
+      }),
+    );
+  });
+
+  it("acknowledges an authorized /startProject request by resuming an existing project", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStartProject = vi.fn().mockResolvedValue({
+      ok: true,
+      action: "resumed",
+      message: "Resumed existing project `habit-cli`.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repositoryName: "habit-cli",
+        repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
+        workspacePath: "/tmp/evolvo/projects/habit-cli",
+        status: "active",
+      },
+    });
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7150", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7151", content: "/startProject Habit CLI", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-resume" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await pollDiscordGracefulShutdownCommand(workDir, { onStartProject });
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: [
+            "<@operator-1> Resumed existing project `Habit CLI`.",
+            "Resumed existing project `habit-cli`.",
+            "Registry status: `active`",
+            "Execution repository: https://github.com/evolvo-auto/habit-cli",
+            "Workspace: `/tmp/evolvo/projects/habit-cli`",
           ].join("\n"),
         }),
       }),

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -40,9 +40,38 @@ export type StartProjectCommandRequest = {
 export type StartProjectCommandResult =
   | {
     ok: true;
+    action: "created";
     message: string;
-    issueNumber: number;
-    issueUrl: string;
+    project: {
+      displayName: string;
+      slug: string;
+      repositoryName: string;
+      workspacePath: string;
+      status: "provisioning";
+    };
+    trackerIssue: {
+      number: number;
+      url: string;
+      alreadyOpen: boolean;
+    };
+  }
+  | {
+    ok: true;
+    action: "resumed";
+    message: string;
+    project: {
+      displayName: string;
+      slug: string;
+      repositoryName: string;
+      repositoryUrl: string;
+      workspacePath: string;
+      status: "active" | "provisioning" | "failed";
+    };
+    trackerIssue?: {
+      number: number;
+      url: string;
+      alreadyOpen: boolean;
+    };
   }
   | {
     ok: false;
@@ -373,19 +402,31 @@ async function sendStartProjectAcknowledgement(
   request: StartProjectCommandRequest,
   result: StartProjectCommandResult,
 ): Promise<void> {
-  const content = result.ok
+  const content = !result.ok
     ? [
-      `<@${config.operatorUserId}> Project start request queued for \`${request.displayName}\`.`,
-      `Tracker issue: #${result.issueNumber} (${result.issueUrl})`,
-      `Planned label: \`${request.issueLabel}\``,
-      `Planned repository: \`${request.repositoryName}\``,
-      `Planned workspace: \`${request.workspaceRelativePath}\``,
-    ].join("\n")
-    : [
       `<@${config.operatorUserId}> Could not queue project start request for \`${request.displayName}\`.`,
       result.message,
       "Usage: `/startProject <project-name>`",
-    ].join("\n");
+    ].join("\n")
+    : result.action === "created"
+      ? [
+        `<@${config.operatorUserId}> ${result.trackerIssue.alreadyOpen ? "Project creation is already queued" : "Created new project"} for \`${result.project.displayName}\`.`,
+        result.message,
+        `Tracker issue: #${result.trackerIssue.number} (${result.trackerIssue.url})`,
+        `Planned label: \`project:${result.project.slug}\``,
+        `Planned repository: \`${result.project.repositoryName}\``,
+        `Planned workspace: \`${result.project.workspacePath}\``,
+      ].join("\n")
+      : [
+        `<@${config.operatorUserId}> Resumed existing project \`${result.project.displayName}\`.`,
+        result.message,
+        `Registry status: \`${result.project.status}\``,
+        `Execution repository: ${result.project.repositoryUrl}`,
+        `Workspace: \`${result.project.workspacePath}\``,
+        ...(result.trackerIssue
+          ? [`Recovery issue: #${result.trackerIssue.number} (${result.trackerIssue.url})`]
+          : []),
+      ].join("\n");
 
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- add canonical active-project state so  can deterministically switch work to an existing project
- change project-start handling to create missing projects, resume existing active/provisioning projects, and reuse failed-project recovery without duplicating repos
- update runtime selection and Discord acknowledgements to show whether the command created or resumed the project

Closes #357

## Validation
- pnpm lint
- pnpm build
- pnpm test