### PR TITLE
fix(operator-control): add stopProject command

### DIFF
--- a/src/main.replenishment.integration.test.ts
+++ b/src/main.replenishment.integration.test.ts
@@ -18,7 +18,9 @@ const buildLifecycleStateCommentMock = vi.fn();
 const writeRuntimeReadinessSignalMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
 const ensureProjectRegistryMock = vi.fn();
+const readProjectRegistryMock = vi.fn();
 const readActiveProjectStateMock = vi.fn();
+const stopActiveProjectStateMock = vi.fn();
 const resolveProjectExecutionContextForIssueMock = vi.fn();
 const buildProjectRoutingBlockedCommentMock = vi.fn();
 
@@ -220,10 +222,14 @@ vi.mock("./projects/projectRegistry.js", () => ({
     defaultBranch: context.defaultBranch ?? null,
   }),
   ensureProjectRegistry: ensureProjectRegistryMock,
+  readProjectRegistry: readProjectRegistryMock,
+  findProjectBySlug: (registry: { projects: Array<{ slug: string }> }, slug: string) =>
+    registry.projects.find((project) => project.slug === slug) ?? null,
 }));
 
 vi.mock("./projects/activeProjectState.js", () => ({
   readActiveProjectState: readActiveProjectStateMock,
+  stopActiveProjectState: stopActiveProjectStateMock,
 }));
 
 vi.mock("./projects/projectExecutionContext.js", () => ({
@@ -414,13 +420,60 @@ describe("main replenishment integration", () => {
         },
       ],
     });
+    readProjectRegistryMock.mockReset();
+    readProjectRegistryMock.mockResolvedValue({
+      version: 1,
+      projects: [
+        {
+          slug: "evolvo",
+          displayName: "Evolvo",
+          kind: "default",
+          issueLabel: "project:evolvo",
+          trackerRepo: {
+            owner: "owner",
+            repo: "repo",
+            url: "https://github.com/owner/repo",
+          },
+          executionRepo: {
+            owner: "owner",
+            repo: "repo",
+            url: "https://github.com/owner/repo",
+            defaultBranch: "main",
+          },
+          cwd: "/tmp/evolvo",
+          status: "active",
+          sourceIssueNumber: null,
+          createdAt: "2026-03-07T12:00:00.000Z",
+          updatedAt: "2026-03-07T12:00:00.000Z",
+          provisioning: {
+            labelCreated: false,
+            repoCreated: true,
+            workspacePrepared: true,
+            lastError: null,
+          },
+        },
+      ],
+    });
     readActiveProjectStateMock.mockReset();
     readActiveProjectStateMock.mockResolvedValue({
-      version: 1,
+      version: 2,
       activeProjectSlug: null,
+      selectionState: null,
       updatedAt: null,
       requestedBy: null,
       source: null,
+    });
+    stopActiveProjectStateMock.mockReset();
+    stopActiveProjectStateMock.mockResolvedValue({
+      status: "no-active-project",
+      state: {
+        version: 2,
+        activeProjectSlug: null,
+        selectionState: null,
+        updatedAt: null,
+        requestedBy: null,
+        source: null,
+      },
     });
     resolveProjectExecutionContextForIssueMock.mockReset();
     resolveProjectExecutionContextForIssueMock.mockResolvedValue({

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -39,7 +39,9 @@ const markGracefulShutdownRequestEnforcedMock = vi.fn();
 const tryResolveRepositoryDefaultBranchMock = vi.fn();
 const configureCodingAgentExecutionContextMock = vi.fn();
 const ensureProjectRegistryMock = vi.fn();
+const readProjectRegistryMock = vi.fn();
 const readActiveProjectStateMock = vi.fn();
+const stopActiveProjectStateMock = vi.fn();
 const resolveProjectExecutionContextForIssueMock = vi.fn();
 const buildProjectRoutingBlockedCommentMock = vi.fn();
 const handleStartProjectCommandMock = vi.fn();
@@ -195,10 +197,14 @@ vi.mock("./projects/projectRegistry.js", () => ({
     defaultBranch: context.defaultBranch ?? null,
   }),
   ensureProjectRegistry: ensureProjectRegistryMock,
+  readProjectRegistry: readProjectRegistryMock,
+  findProjectBySlug: (registry: { projects: Array<{ slug: string }> }, slug: string) =>
+    registry.projects.find((project) => project.slug === slug) ?? null,
 }));
 
 vi.mock("./projects/activeProjectState.js", () => ({
   readActiveProjectState: readActiveProjectStateMock,
+  stopActiveProjectState: stopActiveProjectStateMock,
 }));
 
 vi.mock("./projects/projectExecutionContext.js", () => ({
@@ -353,13 +359,28 @@ describe("main", () => {
     buildProjectProvisioningCompletionSummaryMock.mockReturnValue("Provisioning complete summary");
     ensureProjectRegistryMock.mockReset();
     ensureProjectRegistryMock.mockResolvedValue({ version: 1, projects: [DEFAULT_PROJECT_EXECUTION_CONTEXT.project] });
+    readProjectRegistryMock.mockReset();
+    readProjectRegistryMock.mockResolvedValue({ version: 1, projects: [DEFAULT_PROJECT_EXECUTION_CONTEXT.project] });
     readActiveProjectStateMock.mockReset();
     readActiveProjectStateMock.mockResolvedValue({
-      version: 1,
+      version: 2,
       activeProjectSlug: null,
+      selectionState: null,
       updatedAt: null,
       requestedBy: null,
       source: null,
+    });
+    stopActiveProjectStateMock.mockReset();
+    stopActiveProjectStateMock.mockResolvedValue({
+      status: "stopped",
+      state: {
+        version: 2,
+        activeProjectSlug: "habit-cli",
+        selectionState: "stopped",
+        updatedAt: "2026-03-08T10:00:00.000Z",
+        requestedBy: "discord:operator-1",
+        source: "stop-project-command",
+      },
     });
     resolveProjectExecutionContextForIssueMock.mockReset();
     resolveProjectExecutionContextForIssueMock.mockResolvedValue({
@@ -503,6 +524,7 @@ describe("main", () => {
 
   afterEach(() => {
     process.argv = originalArgv;
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -595,6 +617,56 @@ describe("main", () => {
     expect(console.log).toHaveBeenCalledWith(
       "[startProject] created new project flow for Habit CLI (habit-cli).",
     );
+  });
+
+  it("routes /stopProject requests through the stop-project state handler", async () => {
+    readProjectRegistryMock.mockResolvedValueOnce({
+      version: 1,
+      projects: [
+        DEFAULT_PROJECT_EXECUTION_CONTEXT.project,
+        {
+          ...DEFAULT_PROJECT_EXECUTION_CONTEXT.project,
+          slug: "habit-cli",
+          displayName: "Habit CLI",
+          kind: "managed",
+          issueLabel: "project:habit-cli",
+          executionRepo: {
+            owner: "owner",
+            repo: "habit-cli",
+            url: "https://github.com/owner/habit-cli",
+            defaultBranch: "main",
+          },
+          cwd: "/tmp/evolvo/projects/habit-cli",
+        },
+      ],
+    });
+    const { main } = await import("./main.js");
+
+    await main();
+
+    const discordHandlers = startDiscordGracefulShutdownListenerMock.mock.calls[0]?.[1];
+    const result = await discordHandlers.onStopProject({
+      messageId: "7201",
+      requestedAt: "2026-03-08T10:00:00.000Z",
+      requestedBy: "discord:operator-1",
+    });
+
+    expect(stopActiveProjectStateMock).toHaveBeenCalledWith({
+      workDir: "/tmp/evolvo",
+      requestedBy: "discord:operator-1",
+      updatedAt: "2026-03-08T10:00:00.000Z",
+    });
+    expect(result).toEqual({
+      ok: true,
+      action: "stopped",
+      message: "Project `habit-cli` will not be selected again until `/startProject <project-name>` is used.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+      },
+    });
+    expect(console.log).toHaveBeenCalledWith("[stopProject] received stop request from discord:operator-1.");
+    expect(console.log).toHaveBeenCalledWith("[stopProject] halted project Habit CLI. Runtime remains online.");
   });
 
   it("logs and excludes unauthorized issues before normal selection", async () => {
@@ -848,8 +920,9 @@ describe("main", () => {
 
   it("prefers issues for the active project when one is selected", async () => {
     readActiveProjectStateMock.mockResolvedValueOnce({
-      version: 1,
+      version: 2,
       activeProjectSlug: "habit-cli",
+      selectionState: "active",
       updatedAt: "2026-03-08T09:10:00.000Z",
       requestedBy: "discord:operator-1",
       source: "start-project-command",
@@ -887,6 +960,49 @@ describe("main", () => {
 
     expect(markInProgressMock).toHaveBeenCalledWith(22);
     expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #22: Managed issue\n\nproject");
+  });
+
+  it("keeps the runtime online and idle when the active project is stopped", async () => {
+    vi.useFakeTimers();
+    readActiveProjectStateMock.mockResolvedValueOnce({
+      version: 2,
+      activeProjectSlug: "habit-cli",
+      selectionState: "stopped",
+      updatedAt: "2026-03-08T10:05:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "stop-project-command",
+    });
+    listOpenIssuesMock.mockResolvedValueOnce([
+      { number: 23, title: "Stopped project issue", description: "halted", state: "open", labels: ["project:habit-cli"] },
+    ]);
+    readGracefulShutdownRequestMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        version: 1,
+        source: "discord",
+        command: "/quit",
+        mode: "after-current-task",
+        messageId: "9901",
+        requestedAt: "2026-03-08T10:06:00.000Z",
+        enforcedAt: null,
+      });
+    const { main } = await import("./main.js");
+
+    const mainPromise = main();
+    await vi.advanceTimersByTimeAsync(1000);
+    await mainPromise;
+
+    expect(runCodingAgentMock).not.toHaveBeenCalled();
+    expect(runPlannerAgentMock).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      "[stopProject] project habit-cli is halted. Runtime remains online and is waiting for further operator instructions.",
+    );
+    expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
+      "Graceful shutdown via /quit is being enforced. Stopping before starting a new task.",
+    );
   });
 
   it("blocks issues with invalid project labels before execution", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import {
 } from "./runtime/gracefulShutdown.js";
 import {
   notifyCycleLimitDecisionAppliedInDiscord,
+  type StopProjectCommandResult,
   notifyIssueStartedInDiscord,
   notifyRuntimeQuittingInDiscord,
   pollDiscordGracefulShutdownCommand,
@@ -73,7 +74,7 @@ import {
   handleStartProjectCommand,
   isProjectProvisioningRequestIssue,
 } from "./projects/projectProvisioning.js";
-import { readActiveProjectState } from "./projects/activeProjectState.js";
+import { readActiveProjectState, stopActiveProjectState } from "./projects/activeProjectState.js";
 import {
   PROJECT_ROUTING_BLOCKED_LABEL,
   buildProjectRoutingBlockedComment,
@@ -82,12 +83,15 @@ import {
 import {
   buildDefaultProjectContext,
   ensureProjectRegistry,
+  findProjectBySlug,
+  readProjectRegistry,
 } from "./projects/projectRegistry.js";
 
 const MAX_ISSUE_CYCLES = 5;
 const MIN_REPLENISH_ISSUES = 3;
 const MAX_OPEN_ISSUES = 5;
 const RUN_LOOP_GITHUB_MAX_RETRIES = 2;
+const STOPPED_PROJECT_IDLE_WAIT_MS = 1_000;
 export const DEFAULT_PROMPT = LOOP_DEFAULT_PROMPT;
 
 function getLifecycleEntityKind(issue: IssueSummary): "issue" | "challenge" {
@@ -218,6 +222,22 @@ function isEnforcedGracefulShutdownRequest(request: GracefulShutdownRequest | nu
   return request?.enforcedAt !== null;
 }
 
+function buildStopProjectResultLog(result: StopProjectCommandResult): string {
+  if (!result.ok) {
+    return `[stopProject] failed: ${result.message}`;
+  }
+
+  if (result.action === "stopped") {
+    return `[stopProject] halted project ${result.project?.displayName ?? result.project?.slug ?? "unknown"}. Runtime remains online.`;
+  }
+
+  if (result.action === "already-stopped") {
+    return `[stopProject] project ${result.project?.displayName ?? result.project?.slug ?? "unknown"} was already halted. Runtime remains online.`;
+  }
+
+  return "[stopProject] no active project was selected. Runtime remains online.";
+}
+
 async function readPendingGracefulShutdownRequest(
   workDir: string,
   discordHandlers: DiscordControlHandlers,
@@ -284,7 +304,8 @@ export async function main(): Promise<void> {
     repo: GITHUB_REPO,
     workDir: WORK_DIR,
   });
-  let activeProjectSlug = (await readActiveProjectState(WORK_DIR)).activeProjectSlug;
+  let activeProjectState = await readActiveProjectState(WORK_DIR);
+  let stoppedProjectIdleLoggedSlug: string | null = null;
   const discordHandlers: DiscordControlHandlers = {
     onStartProject: async (request) => {
       const result = await handleStartProjectCommand({
@@ -297,7 +318,15 @@ export async function main(): Promise<void> {
         requestedAt: request.requestedAt,
       });
       if (result.ok) {
-        activeProjectSlug = result.project.slug;
+        activeProjectState = {
+          version: activeProjectState.version,
+          activeProjectSlug: result.project.slug,
+          selectionState: "active",
+          updatedAt: request.requestedAt,
+          requestedBy: request.requestedBy,
+          source: "start-project-command",
+        };
+        stoppedProjectIdleLoggedSlug = null;
         console.log(
           result.action === "created"
             ? `[startProject] created new project flow for ${result.project.displayName} (${result.project.slug}).`
@@ -306,6 +335,59 @@ export async function main(): Promise<void> {
       } else {
         console.error(`[startProject] failed for ${request.displayName}: ${result.message}`);
       }
+      return result;
+    },
+    onStopProject: async (request) => {
+      console.log(`[stopProject] received stop request from ${request.requestedBy}.`);
+      const stopResult = await stopActiveProjectState({
+        workDir: WORK_DIR,
+        requestedBy: request.requestedBy,
+        updatedAt: request.requestedAt,
+      });
+      activeProjectState = stopResult.state;
+      let projectRecord = null;
+      if (stopResult.state.activeProjectSlug !== null) {
+        try {
+          const registry = await readProjectRegistry(WORK_DIR, defaultProjectContext);
+          projectRecord = findProjectBySlug(registry, stopResult.state.activeProjectSlug);
+        } catch {
+          projectRecord = null;
+        }
+      }
+      const result: StopProjectCommandResult = stopResult.status === "stopped"
+        ? {
+          ok: true,
+          action: "stopped",
+          message: `Project \`${projectRecord?.slug ?? stopResult.state.activeProjectSlug ?? "unknown"}\` will not be selected again until \`/startProject <project-name>\` is used.`,
+          ...(projectRecord
+            ? {
+              project: {
+                displayName: projectRecord.displayName,
+                slug: projectRecord.slug,
+              },
+            }
+            : {}),
+        }
+        : stopResult.status === "already-stopped"
+          ? {
+            ok: true,
+            action: "already-stopped",
+            message: `Project \`${projectRecord?.slug ?? stopResult.state.activeProjectSlug ?? "unknown"}\` is already halted. Use \`/startProject <project-name>\` to resume it later.`,
+            ...(projectRecord
+              ? {
+                project: {
+                  displayName: projectRecord.displayName,
+                  slug: projectRecord.slug,
+                },
+              }
+              : {}),
+          }
+          : {
+            ok: true,
+            action: "no-active-project",
+            message: "There is no active project to stop. Evolvo remains online and ready for further operator commands.",
+          };
+      console.log(buildStopProjectResultLog(result));
       return result;
     },
   };
@@ -403,10 +485,36 @@ export async function main(): Promise<void> {
           }
 
           const selectedIssue = selectIssueForWork(retryEligibleIssues, {
-            activeProjectSlug,
+            activeProjectSlug: activeProjectState.selectionState === "active" ? activeProjectState.activeProjectSlug : null,
+            stoppedProjectSlug: activeProjectState.selectionState === "stopped" ? activeProjectState.activeProjectSlug : null,
           });
+          if (selectedIssue !== null || activeProjectState.selectionState !== "stopped") {
+            stoppedProjectIdleLoggedSlug = null;
+          }
 
           if (!selectedIssue) {
+            if (activeProjectState.selectionState === "stopped" && activeProjectState.activeProjectSlug !== null) {
+              if (
+                await stopIfGracefulShutdownPreventsNewWork(
+                  WORK_DIR,
+                  "Stopping before entering stopped-project idle mode.",
+                  discordHandlers,
+                )
+              ) {
+                return;
+              }
+
+              if (stoppedProjectIdleLoggedSlug !== activeProjectState.activeProjectSlug) {
+                console.log(
+                  `[stopProject] project ${activeProjectState.activeProjectSlug} is halted. Runtime remains online and is waiting for further operator instructions.`,
+                );
+                stoppedProjectIdleLoggedSlug = activeProjectState.activeProjectSlug;
+              }
+              await waitForRunLoopRetry(STOPPED_PROJECT_IDLE_WAIT_MS);
+              cycle -= 1;
+              continue issueCycleLoop;
+            }
+
             if (
               await stopIfGracefulShutdownPreventsNewWork(
                 WORK_DIR,
@@ -565,7 +673,15 @@ export async function main(): Promise<void> {
             );
 
             if (provisioningResult.ok) {
-              activeProjectSlug = provisioningResult.record.slug;
+              activeProjectState = {
+                version: activeProjectState.version,
+                activeProjectSlug: provisioningResult.record.slug,
+                selectionState: "active",
+                updatedAt: new Date().toISOString(),
+                requestedBy: provisioningResult.metadata.requestedBy,
+                source: "project-provisioning",
+              };
+              stoppedProjectIdleLoggedSlug = null;
               await transitionIssueLifecycleState(issueManager, {
                 issue: selectedIssue,
                 nextState: "accepted",

--- a/src/projects/activeProjectState.test.ts
+++ b/src/projects/activeProjectState.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getActiveProjectStatePath,
   readActiveProjectState,
+  stopActiveProjectState,
   setActiveProjectState,
 } from "./activeProjectState.js";
 
@@ -26,8 +27,9 @@ describe("activeProjectState", () => {
     tempDirs.push(workDir);
 
     await expect(readActiveProjectState(workDir)).resolves.toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: null,
+      selectionState: null,
       updatedAt: null,
       requestedBy: null,
       source: null,
@@ -47,8 +49,9 @@ describe("activeProjectState", () => {
     });
 
     expect(state).toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: "habit-cli",
+      selectionState: "active",
       updatedAt: "2026-03-08T12:00:00.000Z",
       requestedBy: "discord:operator-1",
       source: "start-project-command",
@@ -57,6 +60,123 @@ describe("activeProjectState", () => {
       `${JSON.stringify(state, null, 2)}\n`,
     );
     await expect(readActiveProjectState(workDir)).resolves.toEqual(state);
+  });
+
+  it("migrates version-1 active project state into the current shape without warning", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    const statePath = getActiveProjectStatePath(workDir);
+    await mkdir(join(workDir, ".evolvo"), { recursive: true });
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        activeProjectSlug: "habit-cli",
+        updatedAt: "2026-03-08T12:00:00.000Z",
+        requestedBy: "discord:operator-1",
+        source: "start-project-command",
+      }),
+      "utf8",
+    );
+
+    await expect(readActiveProjectState(workDir)).resolves.toEqual({
+      version: 2,
+      activeProjectSlug: "habit-cli",
+      selectionState: "active",
+      updatedAt: "2026-03-08T12:00:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("stops the active project without clearing its identity", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await setActiveProjectState({
+      workDir,
+      slug: "habit-cli",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+      updatedAt: "2026-03-08T12:00:00.000Z",
+    });
+
+    await expect(
+      stopActiveProjectState({
+        workDir,
+        requestedBy: "discord:operator-1",
+        updatedAt: "2026-03-08T12:10:00.000Z",
+      }),
+    ).resolves.toEqual({
+      status: "stopped",
+      state: {
+        version: 2,
+        activeProjectSlug: "habit-cli",
+        selectionState: "stopped",
+        updatedAt: "2026-03-08T12:10:00.000Z",
+        requestedBy: "discord:operator-1",
+        source: "stop-project-command",
+      },
+    });
+  });
+
+  it("reports when there is no active project to stop", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await expect(
+      stopActiveProjectState({
+        workDir,
+        requestedBy: "discord:operator-1",
+        updatedAt: "2026-03-08T12:15:00.000Z",
+      }),
+    ).resolves.toEqual({
+      status: "no-active-project",
+      state: {
+        version: 2,
+        activeProjectSlug: null,
+        selectionState: null,
+        updatedAt: null,
+        requestedBy: null,
+        source: null,
+      },
+    });
+  });
+
+  it("treats repeated stop requests as already stopped", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await setActiveProjectState({
+      workDir,
+      slug: "habit-cli",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+      updatedAt: "2026-03-08T12:20:00.000Z",
+    });
+    await stopActiveProjectState({
+      workDir,
+      requestedBy: "discord:operator-1",
+      updatedAt: "2026-03-08T12:25:00.000Z",
+    });
+
+    await expect(
+      stopActiveProjectState({
+        workDir,
+        requestedBy: "discord:operator-1",
+        updatedAt: "2026-03-08T12:30:00.000Z",
+      }),
+    ).resolves.toEqual({
+      status: "already-stopped",
+      state: {
+        version: 2,
+        activeProjectSlug: "habit-cli",
+        selectionState: "stopped",
+        updatedAt: "2026-03-08T12:25:00.000Z",
+        requestedBy: "discord:operator-1",
+        source: "stop-project-command",
+      },
+    });
   });
 
   it("recovers malformed state files with a safe empty state", async () => {
@@ -72,8 +192,9 @@ describe("activeProjectState", () => {
     await writeFile(statePath, "{\"activeProjectSlug\":", "utf8");
 
     await expect(readActiveProjectState(workDir)).resolves.toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: null,
+      selectionState: null,
       updatedAt: null,
       requestedBy: null,
       source: null,
@@ -99,6 +220,7 @@ describe("activeProjectState", () => {
       JSON.stringify({
         version: 99,
         activeProjectSlug: 7,
+        selectionState: "paused",
         updatedAt: false,
         requestedBy: "discord:operator-1",
         source: "unknown",
@@ -107,8 +229,9 @@ describe("activeProjectState", () => {
     );
 
     await expect(readActiveProjectState(workDir)).resolves.toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: null,
+      selectionState: null,
       updatedAt: null,
       requestedBy: null,
       source: null,

--- a/src/projects/activeProjectState.ts
+++ b/src/projects/activeProjectState.ts
@@ -6,13 +6,19 @@ import {
 } from "../runtime/localStateFile.js";
 
 const ACTIVE_PROJECT_STATE_FILE_NAME = "active-project.json";
-const ACTIVE_PROJECT_STATE_VERSION = 1;
+const ACTIVE_PROJECT_STATE_VERSION = 2;
 
-export type ActiveProjectStateSource = "start-project-command" | "project-provisioning";
+export type ActiveProjectSelectionState = "active" | "stopped";
+
+export type ActiveProjectStateSource =
+  | "start-project-command"
+  | "project-provisioning"
+  | "stop-project-command";
 
 export type ActiveProjectState = {
   version: typeof ACTIVE_PROJECT_STATE_VERSION;
   activeProjectSlug: string | null;
+  selectionState: ActiveProjectSelectionState | null;
   updatedAt: string | null;
   requestedBy: string | null;
   source: ActiveProjectStateSource | null;
@@ -28,7 +34,19 @@ function normalizeNonEmptyString(value: unknown): string | null {
 }
 
 function normalizeSource(value: unknown): ActiveProjectStateSource | null {
-  if (value === "start-project-command" || value === "project-provisioning") {
+  if (
+    value === "start-project-command" ||
+    value === "project-provisioning" ||
+    value === "stop-project-command"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function normalizeSelectionState(value: unknown): ActiveProjectSelectionState | null {
+  if (value === "active" || value === "stopped") {
     return value;
   }
 
@@ -39,6 +57,7 @@ function createDefaultActiveProjectState(): ActiveProjectState {
   return {
     version: ACTIVE_PROJECT_STATE_VERSION,
     activeProjectSlug: null,
+    selectionState: null,
     updatedAt: null,
     requestedBy: null,
     source: null,
@@ -54,15 +73,22 @@ function normalizeActiveProjectState(raw: unknown): RecoverableJsonStateNormaliz
   }
 
   const candidate = raw as Partial<ActiveProjectState>;
+  const rawVersion = (raw as { version?: unknown }).version;
   const activeProjectSlug = normalizeNonEmptyString(candidate.activeProjectSlug);
+  const selectionState = normalizeSelectionState(candidate.selectionState);
   const updatedAt = normalizeNonEmptyString(candidate.updatedAt);
   const requestedBy = normalizeNonEmptyString(candidate.requestedBy);
   const source = normalizeSource(candidate.source);
-  const version = candidate.version === ACTIVE_PROJECT_STATE_VERSION ? ACTIVE_PROJECT_STATE_VERSION : null;
+  const version = rawVersion === 1 || rawVersion === ACTIVE_PROJECT_STATE_VERSION
+    ? ACTIVE_PROJECT_STATE_VERSION
+    : null;
+  const normalizedSelectionState = selectionState ?? (activeProjectSlug ? "active" : null);
 
   if (
     version === null ||
     ("activeProjectSlug" in candidate && candidate.activeProjectSlug !== null && activeProjectSlug === null) ||
+    ("selectionState" in candidate && candidate.selectionState !== null && selectionState === null) ||
+    (activeProjectSlug === null && normalizedSelectionState !== null) ||
     ("updatedAt" in candidate && candidate.updatedAt !== null && updatedAt === null) ||
     ("requestedBy" in candidate && candidate.requestedBy !== null && requestedBy === null) ||
     ("source" in candidate && candidate.source !== null && source === null)
@@ -77,6 +103,7 @@ function normalizeActiveProjectState(raw: unknown): RecoverableJsonStateNormaliz
     state: {
       version: ACTIVE_PROJECT_STATE_VERSION,
       activeProjectSlug,
+      selectionState: normalizedSelectionState,
       updatedAt,
       requestedBy,
       source,
@@ -98,6 +125,14 @@ export async function readActiveProjectState(workDir: string): Promise<ActivePro
   });
 }
 
+async function writeActiveProjectState(
+  workDir: string,
+  state: ActiveProjectState,
+): Promise<ActiveProjectState> {
+  await writeAtomicJsonState(getActiveProjectStatePath(workDir), state);
+  return state;
+}
+
 export async function setActiveProjectState(options: {
   workDir: string;
   slug: string;
@@ -105,13 +140,50 @@ export async function setActiveProjectState(options: {
   source: ActiveProjectStateSource;
   updatedAt?: string;
 }): Promise<ActiveProjectState> {
-  const state: ActiveProjectState = {
+  return writeActiveProjectState(options.workDir, {
     version: ACTIVE_PROJECT_STATE_VERSION,
     activeProjectSlug: options.slug.trim(),
+    selectionState: "active",
     updatedAt: options.updatedAt?.trim() || new Date().toISOString(),
     requestedBy: options.requestedBy.trim(),
     source: options.source,
+  });
+}
+
+export async function stopActiveProjectState(options: {
+  workDir: string;
+  requestedBy: string;
+  updatedAt?: string;
+}): Promise<{
+  status: "stopped" | "already-stopped" | "no-active-project";
+  state: ActiveProjectState;
+}> {
+  const currentState = await readActiveProjectState(options.workDir);
+  if (currentState.activeProjectSlug === null) {
+    return {
+      status: "no-active-project",
+      state: currentState,
+    };
+  }
+
+  if (currentState.selectionState === "stopped") {
+    return {
+      status: "already-stopped",
+      state: currentState,
+    };
+  }
+
+  const nextState: ActiveProjectState = {
+    version: ACTIVE_PROJECT_STATE_VERSION,
+    activeProjectSlug: currentState.activeProjectSlug,
+    selectionState: "stopped",
+    updatedAt: options.updatedAt?.trim() || new Date().toISOString(),
+    requestedBy: options.requestedBy.trim(),
+    source: "stop-project-command",
   };
-  await writeAtomicJsonState(getActiveProjectStatePath(options.workDir), state);
-  return state;
+  await writeActiveProjectState(options.workDir, nextState);
+  return {
+    status: "stopped",
+    state: nextState,
+  };
 }

--- a/src/projects/projectProvisioning.test.ts
+++ b/src/projects/projectProvisioning.test.ts
@@ -302,8 +302,9 @@ describe("projectProvisioning", () => {
       },
     });
     expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: "habit-cli",
+      selectionState: "active",
       updatedAt: "2026-03-08T08:00:00.000Z",
       requestedBy: "discord:operator-1",
       source: "start-project-command",
@@ -379,8 +380,9 @@ describe("projectProvisioning", () => {
     });
     expect(issueManager.createIssue).not.toHaveBeenCalled();
     expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: "habit-cli",
+      selectionState: "active",
       updatedAt: "2026-03-08T08:05:00.000Z",
       requestedBy: "discord:operator-1",
       source: "start-project-command",
@@ -562,8 +564,9 @@ describe("projectProvisioning", () => {
       },
     });
     expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: "habit-cli",
+      selectionState: "active",
       updatedAt: "2026-03-08T08:15:00.000Z",
       requestedBy: "discord:operator-1",
       source: "start-project-command",
@@ -631,8 +634,9 @@ describe("projectProvisioning", () => {
     );
     expect(resolve(workDir, "projects", "habit-cli")).toBe(result.record.cwd);
     expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
-      version: 1,
+      version: 2,
       activeProjectSlug: "habit-cli",
+      selectionState: "active",
       updatedAt: expect.any(String),
       requestedBy: "discord:operator-1",
       source: "project-provisioning",

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -328,7 +328,7 @@ export async function writeDiscordControlCursor(workDir: string, lastSeenMessage
 export async function recordDiscordControlCommandReceipt(
   workDir: string,
   input: {
-    command: "start-project";
+    command: "start-project" | "stop-project";
     messageId: string;
     recordedAt?: string;
   },

--- a/src/runtime/loopUtils.test.ts
+++ b/src/runtime/loopUtils.test.ts
@@ -142,4 +142,28 @@ describe("loopUtils retry handling", () => {
 
     expect(selected?.number).toBe(6);
   });
+
+  it("skips issues for a stopped project", () => {
+    const selected = selectIssueForWork(
+      [
+        {
+          number: 7,
+          title: "Stopped project issue",
+          description: "halted",
+          state: "open",
+          labels: ["project:habit-cli"],
+        },
+        {
+          number: 8,
+          title: "Fallback issue",
+          description: "other",
+          state: "open",
+          labels: [],
+        },
+      ],
+      { stoppedProjectSlug: "habit-cli" },
+    );
+
+    expect(selected?.number).toBe(8);
+  });
 });

--- a/src/runtime/loopUtils.ts
+++ b/src/runtime/loopUtils.ts
@@ -43,8 +43,8 @@ function selectHighestPriorityIssue(issues: IssueSummary[]): IssueSummary | null
   return inProgress ?? issues[0] ?? null;
 }
 
-function issueTargetsActiveProject(issue: IssueSummary, activeProjectSlug: string): boolean {
-  const normalizedSlug = activeProjectSlug.trim().toLowerCase();
+function issueTargetsProject(issue: IssueSummary, projectSlug: string): boolean {
+  const normalizedSlug = projectSlug.trim().toLowerCase();
   if (!normalizedSlug) {
     return false;
   }
@@ -59,23 +59,31 @@ function issueTargetsActiveProject(issue: IssueSummary, activeProjectSlug: strin
 
 export function selectIssueForWork(
   issues: IssueSummary[],
-  options: { activeProjectSlug?: string | null } = {},
+  options: { activeProjectSlug?: string | null; stoppedProjectSlug?: string | null } = {},
 ): IssueSummary | null {
   const notCompleted = issues.filter((issue) => !hasIssueLabel(issue, "completed") && !hasIssueLabel(issue, "blocked"));
   if (notCompleted.length === 0) {
     return null;
   }
 
+  const stoppedProjectSlug = options.stoppedProjectSlug?.trim() || null;
+  const selectableIssues = stoppedProjectSlug
+    ? notCompleted.filter((issue) => !issueTargetsProject(issue, stoppedProjectSlug))
+    : notCompleted;
+  if (selectableIssues.length === 0) {
+    return null;
+  }
+
   const activeProjectSlug = options.activeProjectSlug?.trim() || null;
   if (activeProjectSlug) {
-    const activeProjectIssues = notCompleted.filter((issue) => issueTargetsActiveProject(issue, activeProjectSlug));
+    const activeProjectIssues = selectableIssues.filter((issue) => issueTargetsProject(issue, activeProjectSlug));
     const prioritized = selectHighestPriorityIssue(activeProjectIssues);
     if (prioritized) {
       return prioritized;
     }
   }
 
-  return selectHighestPriorityIssue(notCompleted);
+  return selectHighestPriorityIssue(selectableIssues);
 }
 
 export function isOutdatedIssue(issue: IssueSummary): boolean {

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -989,6 +989,100 @@ describe("operatorControl", () => {
     );
   });
 
+  it("acknowledges an authorized /stopProject request and keeps the runtime online", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStopProject = vi.fn().mockResolvedValue({
+      ok: true,
+      action: "stopped",
+      message: "Project `habit-cli` will not be selected again until `/startProject <project-name>` is used.",
+      project: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+      },
+    });
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7160", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7161", content: "/stopProject", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-stop" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await pollDiscordGracefulShutdownCommand(workDir, { onStopProject });
+
+    expect(onStopProject).toHaveBeenCalledWith({
+      messageId: "7161",
+      requestedAt: expect.any(String),
+      requestedBy: "discord:operator-1",
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: [
+            "<@operator-1> Stopped current project `Habit CLI`.",
+            "Project `habit-cli` will not be selected again until `/startProject <project-name>` is used.",
+            "Runtime remains online and is waiting for further operator commands.",
+          ].join("\n"),
+        }),
+      }),
+    );
+  });
+
+  it("acknowledges invalid authorized /stopProject commands without calling the handler", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStopProject = vi.fn();
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7170", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7171", content: "/stopProject now", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-stop-invalid" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await pollDiscordGracefulShutdownCommand(workDir, { onStopProject });
+
+    expect(onStopProject).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: [
+            "<@operator-1> Could not stop the current project.",
+            "`/stopProject` does not take any arguments.",
+            "Usage: `/stopProject`",
+          ].join("\n"),
+        }),
+      }),
+    );
+  });
+
   it("acknowledges invalid authorized /startProject commands without calling the handler", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
@@ -1106,6 +1200,33 @@ describe("operatorControl", () => {
     await pollDiscordGracefulShutdownCommand(workDir, { onStartProject });
 
     expect(onStartProject).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores /stopProject messages from unauthorized users", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStopProject = vi.fn();
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7310", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7311", content: "/stopProject", author: { id: "intruder-1" } }]),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await pollDiscordGracefulShutdownCommand(workDir, { onStopProject });
+
+    expect(onStopProject).not.toHaveBeenCalled();
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -37,6 +37,12 @@ export type StartProjectCommandRequest = {
   workspaceRelativePath: string;
 };
 
+export type StopProjectCommandRequest = {
+  messageId: string;
+  requestedAt: string;
+  requestedBy: string;
+};
+
 export type StartProjectCommandResult =
   | {
     ok: true;
@@ -78,8 +84,24 @@ export type StartProjectCommandResult =
     message: string;
   };
 
+export type StopProjectCommandResult =
+  | {
+    ok: true;
+    action: "stopped" | "already-stopped" | "no-active-project";
+    message: string;
+    project?: {
+      displayName: string;
+      slug: string;
+    };
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
 export type DiscordControlHandlers = {
   onStartProject?: (request: StartProjectCommandRequest) => Promise<StartProjectCommandResult>;
+  onStopProject?: (request: StopProjectCommandRequest) => Promise<StopProjectCommandResult>;
 };
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -96,6 +118,7 @@ type DiscordOperatorStep =
   | "send-issue-start"
   | "read-control-commands"
   | "send-quit-ack"
+  | "send-stop-project-ack"
   | "send-start-project-ack"
   | "send-cycle-decision-ack"
   | "send-quit-message";
@@ -217,6 +240,15 @@ function parseStartProjectName(content: string): string | null {
   return match[1]?.trim() ?? "";
 }
 
+function parseStopProjectCommand(content: string): string | null {
+  const match = content.match(/^\/stopproject(?:\s+(.+))?$/i);
+  if (!match) {
+    return null;
+  }
+
+  return match[1]?.trim() ?? "";
+}
+
 function buildAuthHeaders(config: DiscordControlConfig): Record<string, string> {
   return {
     Authorization: `Bot ${config.botToken}`,
@@ -295,7 +327,7 @@ async function sendStartupBootMessage(config: DiscordControlConfig): Promise<voi
   const startedAt = new Date().toISOString();
   const content = [
     "🤖 Evolvo runtime booted.",
-    "Operator control is online for cycle-limit decisions, graceful shutdown (`/quit`, `/quit after tasks`), and `/startProject` requests.",
+    "Operator control is online for cycle-limit decisions, graceful shutdown (`/quit`, `/quit after tasks`), project start (`/startProject`), and project stop (`/stopProject`) requests.",
     `Started at: ${startedAt}`,
   ].join("\n");
 
@@ -427,6 +459,40 @@ async function sendStartProjectAcknowledgement(
           ? [`Recovery issue: #${result.trackerIssue.number} (${result.trackerIssue.url})`]
           : []),
       ].join("\n");
+
+  await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ content }),
+  });
+}
+
+async function sendStopProjectAcknowledgement(
+  config: DiscordControlConfig,
+  result: StopProjectCommandResult,
+): Promise<void> {
+  const content = !result.ok
+    ? [
+      `<@${config.operatorUserId}> Could not stop the current project.`,
+      result.message,
+      "Usage: `/stopProject`",
+    ].join("\n")
+    : result.action === "stopped"
+      ? [
+        `<@${config.operatorUserId}> Stopped current project \`${result.project?.displayName ?? result.project?.slug ?? "unknown"}\`.`,
+        result.message,
+        "Runtime remains online and is waiting for further operator commands.",
+      ].join("\n")
+      : result.action === "already-stopped"
+        ? [
+          `<@${config.operatorUserId}> Project \`${result.project?.displayName ?? result.project?.slug ?? "unknown"}\` is already stopped.`,
+          result.message,
+          "Runtime remains online and is waiting for further operator commands.",
+        ].join("\n")
+        : [
+          `<@${config.operatorUserId}> No active project is currently selected.`,
+          result.message,
+          "Runtime remains online and is waiting for further operator commands.",
+        ].join("\n");
 
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",
@@ -690,6 +756,41 @@ export async function pollDiscordGracefulShutdownCommand(
             logDiscordMissingAccessHint(sendMessage);
           }
         } else {
+          const stopProjectCommandSuffix = parseStopProjectCommand(message.content);
+          if (stopProjectCommandSuffix !== null && handlers.onStopProject) {
+            const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
+              command: "stop-project",
+              messageId: message.id,
+            });
+            if (recordedReceipt) {
+              let commandResult: StopProjectCommandResult;
+
+              try {
+                if (stopProjectCommandSuffix.length > 0) {
+                  throw new Error("`/stopProject` does not take any arguments.");
+                }
+
+                commandResult = await handlers.onStopProject({
+                  messageId: message.id,
+                  requestedAt: new Date().toISOString(),
+                  requestedBy: `discord:${config.operatorUserId}`,
+                });
+              } catch (error) {
+                commandResult = {
+                  ok: false,
+                  message: error instanceof Error ? error.message : "Unknown project stop request error.",
+                };
+              }
+
+              try {
+                await sendStopProjectAcknowledgement(config, commandResult);
+              } catch (error) {
+                const sendMessage = buildStepFailureMessage("send-stop-project-ack", error);
+                console.error(`Discord project stop acknowledgement failed: ${sendMessage}`);
+                logDiscordMissingAccessHint(sendMessage);
+              }
+            }
+          } else {
           const requestedProjectName = parseStartProjectName(message.content);
           if (requestedProjectName !== null && handlers.onStartProject) {
             const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
@@ -739,6 +840,7 @@ export async function pollDiscordGracefulShutdownCommand(
                 logDiscordMissingAccessHint(sendMessage);
               }
             }
+          }
           }
         }
       }


### PR DESCRIPTION
## Summary
- add a persisted stopped-project selection state so `/stopProject` can halt project selection without shutting the runtime down
- extend Discord operator control with `/stopProject` parsing, acknowledgements, and receipt tracking
- keep the runtime online in a stopped-project idle mode until a later operator command resumes or switches project work

Closes #356

## Validation
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test