### PR TITLE
fix(operator-control): scan all operator replies before advancing cursor

### DIFF
--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -449,6 +449,45 @@ describe("operatorControl", () => {
     });
   });
 
+  it("returns the first valid decision after scanning all operator replies in a fetched batch", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+    vi.stubEnv("DISCORD_CYCLE_EXTENSION", "7");
+    vi.stubEnv("DISCORD_OPERATOR_TIMEOUT_MS", "5000");
+    vi.stubEnv("DISCORD_OPERATOR_POLL_INTERVAL_MS", "5");
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "channel-1", guild_id: "guild-1" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "5000" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            createDiscordControlMessage(5001, "still thinking", "operator-1"),
+            createDiscordControlMessage(5002, "continue", "operator-1"),
+          ]),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const decisionPromise = requestCycleLimitDecisionFromOperator(100);
+    await vi.runAllTimersAsync();
+    const decision = await decisionPromise;
+
+    expect(decision).toEqual({
+      decision: "continue",
+      additionalCycles: 7,
+      source: "discord",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
   it("sends a Discord confirmation when a cycle-limit continue decision is applied", async () => {
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
     vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -598,16 +598,21 @@ async function waitForOperatorDecision(
       config,
       `/channels/${config.controlChannelId}/messages?after=${afterId}&limit=50`,
     );
-    if (messages.length > 0) {
-      afterId = getHighestSnowflakeId(messages.map((message) => message.id));
-    }
 
-    const operatorMessage = messages.find((message) => message.author?.id === config.operatorUserId);
-    if (operatorMessage) {
+    const orderedMessages = [...messages].sort((left, right) => compareSnowflakeIds(left.id, right.id));
+    for (const operatorMessage of orderedMessages) {
+      if (operatorMessage.author?.id !== config.operatorUserId) {
+        continue;
+      }
+
       const decision = parseOperatorDecision(operatorMessage.content);
       if (decision) {
         return decision;
       }
+    }
+
+    if (orderedMessages.length > 0) {
+      afterId = orderedMessages[orderedMessages.length - 1]?.id ?? afterId;
     }
 
     await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));


### PR DESCRIPTION
## Summary
- scan all fetched operator replies in snowflake order before advancing the cycle-limit prompt cursor
- keep the cursor update after batch inspection so a later valid decision in the same poll window is not skipped
- add a regression test for mixed operator messages in one fetched batch

## Validation
- pnpm exec vitest run src/runtime/operatorControl.test.ts
- pnpm lint
- pnpm build
- pnpm test

Closes #347