### PR TITLE
fix: align Discord operator control with plain-text commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ When configured, if Evolvo reaches its cycle limit it posts a control prompt in 
 - `continue` -> extend cycle budget by `DISCORD_CYCLE_EXTENSION`
 - `quit` -> exit cleanly
 
+Outside the cycle-limit prompt, Discord operator control is explicit plain-text message polling, not Discord slash commands. Send normal channel messages such as:
+
+- `quit after current task`
+- `quit after tasks`
+- `startProject <project-name>`
+- `stopProject`
+
 If Discord vars are not configured, Evolvo does not attempt Discord and keeps existing non-Discord behavior.
 
 ## Startup Flow

--- a/docs/project-system-design.md
+++ b/docs/project-system-design.md
@@ -6,7 +6,7 @@ Design a first-class Project system so Evolvo can keep using a single central is
 The target operator entrypoint is:
 
 ```text
-/startProject <project-name>
+startProject <project-name>
 ```
 
 This design covers the Project model, label-based routing, project state, repository/workspace provisioning, Discord integration, runtime implications, and failure handling. It does not implement the feature directly.
@@ -170,13 +170,13 @@ The runtime must stop assuming one global working directory:
 - `src/agents/runCodingAgent.ts` should run against a project-specific thread or thread factory, not a single long-lived global thread tied to one cwd.
 - runtime helpers that persist project-specific artifacts should receive a resolved project cwd when the work belongs to a managed project.
 
-## Recommended `/startProject <project-name>` Flow
+## Recommended `startProject <project-name>` Flow
 
 The safest design is issue-driven rather than performing full provisioning directly inside the Discord polling loop.
 
 Recommended flow:
 
-1. Authorized operator sends `/startProject <project-name>` in the control channel.
+1. Authorized operator sends `startProject <project-name>` in the control channel.
 2. Discord control validates and normalizes the requested name into a slug.
 3. Runtime creates a central tracker provisioning issue in the default Evolvo project.
    - title example: `Start project <display-name>`
@@ -281,7 +281,7 @@ Provisioning changes:
 1. Add a generic GitHub admin client/service for repo and label creation.
 2. Add project workspace preparation helpers.
 3. Add a provisioning issue type or metadata parser.
-4. Extend Discord operator control with `/startProject <project-name>`.
+4. Extend Discord operator control with `startProject <project-name>`.
 5. Persist provisioning progress/failure in `.evolvo/projects.json`.
 6. Add `.gitignore` coverage for `projects/`.
 
@@ -301,7 +301,7 @@ Phase 2: Provisioning pipeline
 - provisioning state transitions
 
 Phase 3: Operator workflow
-- `/startProject <project-name>` command parsing
+- `startProject <project-name>` command parsing
 - provisioning-issue creation
 - Discord acknowledgements and diagnostics
 - recovery/retry behavior for failed provisioning requests
@@ -313,4 +313,4 @@ To stay within the current max-five-open-issues queue limit, this design creates
 Created from this design:
 
 - `#317` project registry, label routing, and project-aware execution context
-- `#318` project provisioning pipeline and `/startProject <project-name>` operator flow
+- `#318` project provisioning pipeline and `startProject <project-name>` operator flow

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -571,7 +571,7 @@ describe("main", () => {
     expect(stopDiscordGracefulShutdownListenerMock).toHaveBeenCalledTimes(1);
   });
 
-  it("routes /startProject requests through the create-or-resume project handler", async () => {
+  it("routes startProject requests through the create-or-resume project handler", async () => {
     const { main } = await import("./main.js");
 
     await main();
@@ -619,7 +619,7 @@ describe("main", () => {
     );
   });
 
-  it("routes /stopProject requests through the stop-project state handler", async () => {
+  it("routes stopProject requests through the stop-project state handler", async () => {
     readProjectRegistryMock.mockResolvedValueOnce({
       version: 1,
       projects: [
@@ -659,7 +659,7 @@ describe("main", () => {
     expect(result).toEqual({
       ok: true,
       action: "stopped",
-      message: "Project `habit-cli` will not be selected again until `/startProject <project-name>` is used.",
+      message: "Project `habit-cli` will not be selected again until `startProject <project-name>` is used.",
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
@@ -983,7 +983,7 @@ describe("main", () => {
       .mockResolvedValueOnce({
         version: 1,
         source: "discord",
-        command: "/quit",
+        command: "quit after current task",
         mode: "after-current-task",
         messageId: "9901",
         requestedAt: "2026-03-08T10:06:00.000Z",
@@ -1001,7 +1001,7 @@ describe("main", () => {
       "[stopProject] project habit-cli is halted. Runtime remains online and is waiting for further operator instructions.",
     );
     expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
-      "Graceful shutdown via /quit is being enforced. Stopping before starting a new task.",
+      "Graceful shutdown via quit after current task is being enforced. Stopping before starting a new task.",
     );
   });
 
@@ -1912,7 +1912,7 @@ describe("main", () => {
     readGracefulShutdownRequestMock.mockResolvedValueOnce({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "9001",
       requestedAt: "2026-03-07T12:00:00.000Z",
@@ -1926,14 +1926,14 @@ describe("main", () => {
     expect(runCodingAgentMock).not.toHaveBeenCalled();
     expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
-      "Graceful shutdown requested via Discord /quit. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
+      "Graceful shutdown requested via Discord quit after current task. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
     expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
-      "Graceful shutdown via /quit is being enforced. Stopping before starting a new task.",
+      "Graceful shutdown via quit after current task is being enforced. Stopping before starting a new task.",
     );
   });
 
-  it("finishes the current task and stops before selecting another issue after /quit is requested", async () => {
+  it("finishes the current task and stops before selecting another issue after quit after current task is requested", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([
         { number: 301, title: "Current task", description: "finish this", state: "open", labels: [] },
@@ -1948,7 +1948,7 @@ describe("main", () => {
       .mockResolvedValueOnce({
         version: 1,
         source: "discord",
-        command: "/quit",
+        command: "quit after current task",
         mode: "after-current-task",
         messageId: "9002",
         requestedAt: "2026-03-07T12:05:00.000Z",
@@ -1964,14 +1964,14 @@ describe("main", () => {
     expect(markInProgressMock).not.toHaveBeenCalledWith(302);
     expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
-      "Graceful shutdown requested via Discord /quit. Current task completed. Stopping before starting another issue. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
+      "Graceful shutdown requested via Discord quit after current task. Current task completed. Stopping before starting another issue. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
     expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
-      "Graceful shutdown via /quit is being enforced. Current task completed. Stopping before starting another issue.",
+      "Graceful shutdown via quit after current task is being enforced. Current task completed. Stopping before starting another issue.",
     );
   });
 
-  it("drains existing issues and suppresses planner replenishment after /quit after tasks", async () => {
+  it("drains existing issues and suppresses planner replenishment after quit after tasks", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([
         { number: 401, title: "First queued task", description: "one", state: "open", labels: [] },
@@ -1984,7 +1984,7 @@ describe("main", () => {
     readGracefulShutdownRequestMock.mockResolvedValue({
       version: 1,
       source: "discord",
-      command: "/quit after tasks",
+      command: "quit after tasks",
       mode: "after-tasks",
       messageId: "9010",
       requestedAt: "2026-03-07T12:10:00.000Z",
@@ -2000,10 +2000,10 @@ describe("main", () => {
     expect(runPlannerAgentMock).not.toHaveBeenCalled();
     expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
-      "Graceful shutdown requested via Discord /quit after tasks. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
+      "Graceful shutdown requested via Discord quit after tasks. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
     expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
-      "Graceful shutdown via /quit after tasks is being enforced. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started.",
+      "Graceful shutdown via quit after tasks is being enforced. Queue-drain shutdown is active. Planning and replenishment are disabled, so no new work will be started.",
     );
   });
 
@@ -2011,7 +2011,7 @@ describe("main", () => {
     readGracefulShutdownRequestMock.mockResolvedValue({
       version: 1,
       source: "discord",
-      command: "/quit after tasks",
+      command: "quit after tasks",
       mode: "after-tasks",
       messageId: "9011",
       requestedAt: "2026-03-07T12:15:00.000Z",
@@ -2025,10 +2025,10 @@ describe("main", () => {
     expect(runCodingAgentMock).not.toHaveBeenCalled();
     expect(markGracefulShutdownRequestEnforcedMock).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith(
-      "Graceful shutdown requested via Discord /quit after tasks. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
+      "Graceful shutdown requested via Discord quit after tasks. Stopping before starting a new task. Shutdown intent remains persisted so later restarts do not resume work unexpectedly.",
     );
     expect(notifyRuntimeQuittingInDiscordMock).toHaveBeenCalledWith(
-      "Graceful shutdown via /quit after tasks is being enforced. Stopping before starting a new task.",
+      "Graceful shutdown via quit after tasks is being enforced. Stopping before starting a new task.",
     );
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -358,7 +358,7 @@ export async function main(): Promise<void> {
         ? {
           ok: true,
           action: "stopped",
-          message: `Project \`${projectRecord?.slug ?? stopResult.state.activeProjectSlug ?? "unknown"}\` will not be selected again until \`/startProject <project-name>\` is used.`,
+          message: `Project \`${projectRecord?.slug ?? stopResult.state.activeProjectSlug ?? "unknown"}\` will not be selected again until \`startProject <project-name>\` is used.`,
           ...(projectRecord
             ? {
               project: {
@@ -372,7 +372,7 @@ export async function main(): Promise<void> {
           ? {
             ok: true,
             action: "already-stopped",
-            message: `Project \`${projectRecord?.slug ?? stopResult.state.activeProjectSlug ?? "unknown"}\` is already halted. Use \`/startProject <project-name>\` to resume it later.`,
+            message: `Project \`${projectRecord?.slug ?? stopResult.state.activeProjectSlug ?? "unknown"}\` is already halted. Use \`startProject <project-name>\` to resume it later.`,
             ...(projectRecord
               ? {
                 project: {

--- a/src/projects/projectProvisioning.ts
+++ b/src/projects/projectProvisioning.ts
@@ -635,7 +635,7 @@ export function buildProjectProvisioningOutcomeComment(
   if (!result.ok) {
     lines.push(`- Failure step: \`${result.failureStep ?? "unknown"}\``);
     lines.push(`- Error: ${result.message}`);
-    lines.push("- Recovery: inspect `.evolvo/projects.json`, fix the failing step, then resend `/startProject <project-name>` to requeue provisioning.");
+    lines.push("- Recovery: inspect `.evolvo/projects.json`, fix the failing step, then resend `startProject <project-name>` to requeue provisioning.");
   }
 
   return lines.join("\n");

--- a/src/runtime/gracefulShutdown.test.ts
+++ b/src/runtime/gracefulShutdown.test.ts
@@ -45,7 +45,7 @@ describe("gracefulShutdown", () => {
       request: {
         version: 1,
         source: "discord",
-        command: "/quit",
+        command: "quit after current task",
         mode: "after-current-task",
         messageId: "9001",
         requestedAt: "2026-03-07T12:00:00.000Z",
@@ -71,7 +71,7 @@ describe("gracefulShutdown", () => {
     await expect(consumeGracefulShutdownRequest(workDir)).resolves.toEqual({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "9010",
       requestedAt: "2026-03-07T13:00:00.000Z",
@@ -95,7 +95,7 @@ describe("gracefulShutdown", () => {
       request: {
         version: 1,
         source: "discord",
-        command: "/quit after tasks",
+        command: "quit after tasks",
         mode: "after-tasks",
         messageId: "9050",
         requestedAt: "2026-03-07T13:30:00.000Z",
@@ -123,7 +123,7 @@ describe("gracefulShutdown", () => {
       request: {
         version: 1,
         source: "discord",
-        command: "/quit",
+        command: "quit after current task",
         mode: "after-current-task",
         messageId: "9055",
         requestedAt: "2026-03-07T13:35:00.000Z",
@@ -133,7 +133,7 @@ describe("gracefulShutdown", () => {
     await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "9055",
       requestedAt: "2026-03-07T13:35:00.000Z",
@@ -187,7 +187,7 @@ describe("gracefulShutdown", () => {
     );
   });
 
-  it("normalizes persisted graceful shutdown payloads", async () => {
+  it("normalizes persisted graceful shutdown payloads from legacy slash-prefixed commands", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     await recordGracefulShutdownRequest(workDir, { messageId: "seed-request" });
@@ -205,7 +205,7 @@ describe("gracefulShutdown", () => {
     await expect(readGracefulShutdownRequest(workDir)).resolves.toEqual({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "9200",
       requestedAt: "2026-03-07T15:00:00.000Z",
@@ -234,7 +234,7 @@ describe("gracefulShutdown", () => {
       request: {
         version: 1,
         source: "discord",
-        command: "/quit",
+        command: "quit after current task",
         mode: "after-current-task",
         messageId: "9300",
         requestedAt: "2026-03-07T17:00:00.000Z",

--- a/src/runtime/gracefulShutdown.ts
+++ b/src/runtime/gracefulShutdown.ts
@@ -13,7 +13,7 @@ export type GracefulShutdownMode = "after-current-task" | "after-tasks";
 export type GracefulShutdownRequest = {
   version: typeof GRACEFUL_SHUTDOWN_REQUEST_VERSION;
   source: "discord";
-  command: "/quit" | "/quit after tasks";
+  command: "quit after current task" | "quit after tasks";
   mode: GracefulShutdownMode;
   messageId: string;
   requestedAt: string;
@@ -37,6 +37,34 @@ function normalizeMessageId(value: unknown): string | null {
   return value.trim();
 }
 
+function normalizeGracefulShutdownCommand(
+  command: unknown,
+  mode: unknown,
+): { command: GracefulShutdownRequest["command"]; mode: GracefulShutdownMode } | null {
+  if (command === "quit after tasks" || command === "/quit after tasks") {
+    return {
+      command: "quit after tasks",
+      mode: "after-tasks",
+    };
+  }
+
+  if (command === "quit after current task" || command === "quit" || command === "/quit") {
+    if (mode === "after-tasks") {
+      return {
+        command: "quit after tasks",
+        mode: "after-tasks",
+      };
+    }
+
+    return {
+      command: "quit after current task",
+      mode: "after-current-task",
+    };
+  }
+
+  return null;
+}
+
 function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest | null {
   if (typeof raw !== "object" || raw === null) {
     return null;
@@ -48,17 +76,9 @@ function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest
     return null;
   }
 
-  let command: GracefulShutdownRequest["command"] | null = null;
-  let mode: GracefulShutdownMode | null = null;
-  if (candidate.command === "/quit after tasks") {
-    command = "/quit after tasks";
-    mode = "after-tasks";
-  } else if (candidate.command === "/quit") {
-    command = "/quit";
-    mode = candidate.mode === "after-tasks" ? "after-tasks" : "after-current-task";
-  }
-
-  if (command === null || mode === null) {
+  // Accept legacy slash-prefixed values so upgrades preserve pending shutdown intent.
+  const normalizedCommand = normalizeGracefulShutdownCommand(candidate.command, candidate.mode);
+  if (normalizedCommand === null) {
     return null;
   }
 
@@ -71,8 +91,8 @@ function normalizeGracefulShutdownRequest(raw: unknown): GracefulShutdownRequest
   return {
     version: GRACEFUL_SHUTDOWN_REQUEST_VERSION,
     source: "discord",
-    command,
-    mode,
+    command: normalizedCommand.command,
+    mode: normalizedCommand.mode,
     messageId,
     requestedAt,
     enforcedAt,
@@ -211,7 +231,7 @@ export async function recordGracefulShutdownRequest(
   const request: GracefulShutdownRequest = {
     version: GRACEFUL_SHUTDOWN_REQUEST_VERSION,
     source: "discord",
-    command: mode === "after-tasks" ? "/quit after tasks" : "/quit",
+    command: mode === "after-tasks" ? "quit after tasks" : "quit after current task",
     mode,
     messageId,
     requestedAt,

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -116,7 +116,7 @@ describe("operatorControl", () => {
       "https://discord.com/api/v10/channels/channel-1/messages",
       expect.objectContaining({
         method: "POST",
-        body: expect.stringContaining("graceful shutdown"),
+        body: expect.stringContaining("plain-text mode"),
       }),
     );
   });
@@ -415,7 +415,7 @@ describe("operatorControl", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
-  it("returns quit when operator replies /quit", async () => {
+  it("returns quit when operator replies quit", async () => {
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
     vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
     vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
@@ -432,7 +432,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "5001", content: "/quit", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "5001", content: "quit", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       );
@@ -587,7 +587,7 @@ describe("operatorControl", () => {
     );
   });
 
-  it("records and acknowledges an authorized /quit graceful shutdown command", async () => {
+  it("records and acknowledges an authorized quit after current task graceful shutdown command", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -601,7 +601,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7001", content: "/quit", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "7001", content: "quit after current task", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -613,7 +613,7 @@ describe("operatorControl", () => {
     expect(request).toEqual({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "7001",
       requestedAt: expect.any(String),
@@ -626,13 +626,13 @@ describe("operatorControl", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          content: "<@operator-1> Confirmed: `/quit` is now active.\nEvolvo will finish the current task and then stop before starting another issue.",
+          content: "<@operator-1> Confirmed: `quit after current task` is now active.\nEvolvo will finish the current task and then stop before starting another issue.",
         }),
       }),
     );
   });
 
-  it("confirms the active shutdown plan when /quit is repeated after a queue-drain request already exists", async () => {
+  it("confirms the active shutdown plan when quit after current task is repeated after a queue-drain request already exists", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -650,7 +650,7 @@ describe("operatorControl", () => {
     const fetchSpy = vi.fn()
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "8000", content: "/quit", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "8000", content: "quit after current task", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -662,7 +662,7 @@ describe("operatorControl", () => {
     expect(request).toEqual({
       version: 1,
       source: "discord",
-      command: "/quit after tasks",
+      command: "quit after tasks",
       mode: "after-tasks",
       messageId: "7999",
       requestedAt: "2026-03-08T09:00:00.000Z",
@@ -674,13 +674,13 @@ describe("operatorControl", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          content: "<@operator-1> Confirmed: `/quit after tasks` was already active, so the new command did not change the shutdown plan.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
+          content: "<@operator-1> Confirmed: `quit after tasks` was already active, so the new command did not change the shutdown plan.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
         }),
       }),
     );
   });
 
-  it("records and acknowledges an authorized /quit after tasks queue-drain command", async () => {
+  it("records and acknowledges an authorized quit after tasks queue-drain command", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -694,7 +694,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7051", content: "/quit   after   tasks", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "7051", content: "quit   after   tasks", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -706,7 +706,7 @@ describe("operatorControl", () => {
     expect(request).toEqual({
       version: 1,
       source: "discord",
-      command: "/quit after tasks",
+      command: "quit after tasks",
       mode: "after-tasks",
       messageId: "7051",
       requestedAt: expect.any(String),
@@ -719,7 +719,7 @@ describe("operatorControl", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          content: "<@operator-1> Confirmed: `/quit after tasks` is now active.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
+          content: "<@operator-1> Confirmed: `quit after tasks` is now active.\nEvolvo will finish the current actionable queue, will not plan or create new work, and will stop once the queue is drained.",
         }),
       }),
     );
@@ -742,7 +742,7 @@ describe("operatorControl", () => {
         new Response(
           JSON.stringify([
             createDiscordControlMessage(7060, "noise"),
-            createDiscordControlMessage(7061, "/quit", "operator-1"),
+            createDiscordControlMessage(7061, "quit after current task", "operator-1"),
           ]),
           { status: 200 },
         ),
@@ -755,7 +755,7 @@ describe("operatorControl", () => {
     expect(request).toEqual({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "7061",
       requestedAt: expect.any(String),
@@ -789,7 +789,7 @@ describe("operatorControl", () => {
     const secondPage = Array.from({ length: 10 }, (_, index) => {
       const id = 9051 + index;
       if (id === 9058) {
-        return createDiscordControlMessage(id, "/quit", "operator-1");
+        return createDiscordControlMessage(id, "quit after current task", "operator-1");
       }
 
       return createDiscordControlMessage(id, `noise-${id}`);
@@ -805,7 +805,7 @@ describe("operatorControl", () => {
     expect(request).toEqual({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "9058",
       requestedAt: expect.any(String),
@@ -858,8 +858,8 @@ describe("operatorControl", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify([
-            createDiscordControlMessage(9401, "/quit", "operator-1"),
-            createDiscordControlMessage(9402, "/startProject Habit CLI", "operator-1"),
+            createDiscordControlMessage(9401, "quit after current task", "operator-1"),
+            createDiscordControlMessage(9402, "startProject Habit CLI", "operator-1"),
           ]),
           { status: 200 },
         ),
@@ -868,8 +868,8 @@ describe("operatorControl", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify([
-            createDiscordControlMessage(9401, "/quit", "operator-1"),
-            createDiscordControlMessage(9402, "/startProject Habit CLI", "operator-1"),
+            createDiscordControlMessage(9401, "quit after current task", "operator-1"),
+            createDiscordControlMessage(9402, "startProject Habit CLI", "operator-1"),
           ]),
           { status: 200 },
         ),
@@ -893,7 +893,7 @@ describe("operatorControl", () => {
     expect(replayedRequest).toEqual({
       version: 1,
       source: "discord",
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
       messageId: "9401",
       requestedAt: expect.any(String),
@@ -904,7 +904,7 @@ describe("operatorControl", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(5);
   });
 
-  it("queues an authorized /startProject request and acknowledges the created tracker issue", async () => {
+  it("queues an authorized startProject request and acknowledges the created tracker issue", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -935,7 +935,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7101", content: "/startProject Habit CLI", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "7101", content: "startProject Habit CLI", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -974,7 +974,7 @@ describe("operatorControl", () => {
     );
   });
 
-  it("acknowledges an authorized /startProject request by resuming an existing project", async () => {
+  it("acknowledges an authorized startProject request by resuming an existing project", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1001,7 +1001,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7151", content: "/startProject Habit CLI", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "7151", content: "startProject Habit CLI", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -1028,7 +1028,7 @@ describe("operatorControl", () => {
     );
   });
 
-  it("acknowledges an authorized /stopProject request and keeps the runtime online", async () => {
+  it("acknowledges an authorized stopProject request and keeps the runtime online", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1039,7 +1039,7 @@ describe("operatorControl", () => {
     const onStopProject = vi.fn().mockResolvedValue({
       ok: true,
       action: "stopped",
-      message: "Project `habit-cli` will not be selected again until `/startProject <project-name>` is used.",
+      message: "Project `habit-cli` will not be selected again until `startProject <project-name>` is used.",
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
@@ -1051,7 +1051,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7161", content: "/stopProject", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "7161", content: "stopProject", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -1073,7 +1073,7 @@ describe("operatorControl", () => {
         body: JSON.stringify({
           content: [
             "<@operator-1> Stopped current project `Habit CLI`.",
-            "Project `habit-cli` will not be selected again until `/startProject <project-name>` is used.",
+            "Project `habit-cli` will not be selected again until `startProject <project-name>` is used.",
             "Runtime remains online and is waiting for further operator commands.",
           ].join("\n"),
         }),
@@ -1081,7 +1081,7 @@ describe("operatorControl", () => {
     );
   });
 
-  it("acknowledges invalid authorized /stopProject commands without calling the handler", async () => {
+  it("acknowledges invalid authorized stopProject commands without calling the handler", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1096,7 +1096,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7171", content: "/stopProject now", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "7171", content: "stopProject now", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -1114,15 +1114,15 @@ describe("operatorControl", () => {
         body: JSON.stringify({
           content: [
             "<@operator-1> Could not stop the current project.",
-            "`/stopProject` does not take any arguments.",
-            "Usage: `/stopProject`",
+            "`stopProject` does not take any arguments.",
+            "Usage: `stopProject`",
           ].join("\n"),
         }),
       }),
     );
   });
 
-  it("acknowledges invalid authorized /startProject commands without calling the handler", async () => {
+  it("acknowledges invalid authorized startProject commands without calling the handler", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1137,7 +1137,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7201", content: "/startProject", author: { id: "operator-1" } }]),
+          JSON.stringify([{ id: "7201", content: "startProject", author: { id: "operator-1" } }]),
           { status: 200 },
         ),
       )
@@ -1156,14 +1156,46 @@ describe("operatorControl", () => {
           content: [
             "<@operator-1> Could not queue project start request for `<missing project name>`.",
             "Project name is required.",
-            "Usage: `/startProject <project-name>`",
+            "Usage: `startProject <project-name>`",
           ].join("\n"),
         }),
       }),
     );
   });
 
-  it("ignores /quit messages from unauthorized users", async () => {
+  it("ignores slash-prefixed control messages from the authorized operator", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+    await gracefulShutdown.writeDiscordControlCursor(workDir, "8099");
+
+    const onStartProject = vi.fn();
+    const onStopProject = vi.fn();
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          createDiscordControlMessage(8100, "/quit", "operator-1"),
+          createDiscordControlMessage(8101, "/startProject Habit CLI", "operator-1"),
+          createDiscordControlMessage(8102, "/stopProject", "operator-1"),
+        ]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const request = await pollDiscordGracefulShutdownCommand(workDir, { onStartProject, onStopProject });
+
+    expect(request).toBeNull();
+    expect(onStartProject).not.toHaveBeenCalled();
+    expect(onStopProject).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(await gracefulShutdown.readDiscordControlCursor(workDir)).toBe("8102");
+  });
+
+  it("ignores quit after current task messages from unauthorized users", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1177,7 +1209,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "8001", content: "/quit", author: { id: "intruder-1" } }]),
+          JSON.stringify([{ id: "8001", content: "quit after current task", author: { id: "intruder-1" } }]),
           { status: 200 },
         ),
       );
@@ -1189,7 +1221,7 @@ describe("operatorControl", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("ignores /quit after tasks messages from unauthorized users", async () => {
+  it("ignores quit after tasks messages from unauthorized users", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1203,7 +1235,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "8011", content: "/quit after tasks", author: { id: "intruder-1" } }]),
+          JSON.stringify([{ id: "8011", content: "quit after tasks", author: { id: "intruder-1" } }]),
           { status: 200 },
         ),
       );
@@ -1215,7 +1247,7 @@ describe("operatorControl", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("ignores /startProject messages from unauthorized users", async () => {
+  it("ignores startProject messages from unauthorized users", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1230,7 +1262,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7301", content: "/startProject Habit CLI", author: { id: "intruder-1" } }]),
+          JSON.stringify([{ id: "7301", content: "startProject Habit CLI", author: { id: "intruder-1" } }]),
           { status: 200 },
         ),
       );
@@ -1242,7 +1274,7 @@ describe("operatorControl", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("ignores /stopProject messages from unauthorized users", async () => {
+  it("ignores stopProject messages from unauthorized users", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
     vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
@@ -1257,7 +1289,7 @@ describe("operatorControl", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify([{ id: "7311", content: "/stopProject", author: { id: "intruder-1" } }]),
+          JSON.stringify([{ id: "7311", content: "stopProject", author: { id: "intruder-1" } }]),
           { status: 200 },
         ),
       );

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -201,10 +201,10 @@ export function getDiscordControlConfigFromEnv(
 
 function parseOperatorDecision(content: string): "continue" | "quit" | null {
   const normalized = content.trim().toLowerCase();
-  if (normalized === "continue" || normalized === "/continue") {
+  if (normalized === "continue") {
     return "continue";
   }
-  if (normalized === "quit" || normalized === "/quit") {
+  if (normalized === "quit") {
     return "quit";
   }
 
@@ -215,15 +215,15 @@ function parseGracefulShutdownCommand(
   content: string,
 ): { command: GracefulShutdownRequest["command"]; mode: GracefulShutdownMode } | null {
   const normalized = content.trim().toLowerCase().replace(/\s+/g, " ");
-  if (normalized === "/quit after tasks") {
+  if (normalized === "quit after tasks") {
     return {
-      command: "/quit after tasks",
+      command: "quit after tasks",
       mode: "after-tasks",
     };
   }
-  if (normalized === "/quit") {
+  if (normalized === "quit after current task") {
     return {
-      command: "/quit",
+      command: "quit after current task",
       mode: "after-current-task",
     };
   }
@@ -232,7 +232,7 @@ function parseGracefulShutdownCommand(
 }
 
 function parseStartProjectName(content: string): string | null {
-  const match = content.match(/^\/startproject(?:\s+(.+))?$/i);
+  const match = content.match(/^startproject(?:\s+(.+))?$/i);
   if (!match) {
     return null;
   }
@@ -241,7 +241,7 @@ function parseStartProjectName(content: string): string | null {
 }
 
 function parseStopProjectCommand(content: string): string | null {
-  const match = content.match(/^\/stopproject(?:\s+(.+))?$/i);
+  const match = content.match(/^stopproject(?:\s+(.+))?$/i);
   if (!match) {
     return null;
   }
@@ -314,7 +314,7 @@ async function sendCycleLimitPrompt(
 ): Promise<{ id: string }> {
   const content = [
     `<@${config.operatorUserId}> Evolvo has reached its cycle limit (${currentLimit}).`,
-    `Reply in this channel with \`continue\` to add ${config.cycleExtension} more cycles, or \`quit\` / \`/quit\` to stop.`,
+    `Reply in this channel with \`continue\` to add ${config.cycleExtension} more cycles, or \`quit\` to stop.`,
   ].join("\n");
 
   return fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
@@ -327,7 +327,9 @@ async function sendStartupBootMessage(config: DiscordControlConfig): Promise<voi
   const startedAt = new Date().toISOString();
   const content = [
     "🤖 Evolvo runtime booted.",
-    "Operator control is online for cycle-limit decisions, graceful shutdown (`/quit`, `/quit after tasks`), project start (`/startProject`), and project stop (`/stopProject`) requests.",
+    "Operator control is online in plain-text mode.",
+    "Send `quit after current task`, `quit after tasks`, `startProject <project-name>`, or `stopProject` as normal channel messages.",
+    "When Evolvo posts a cycle-limit prompt, reply with `continue` or `quit`.",
     `Started at: ${startedAt}`,
   ].join("\n");
 
@@ -438,7 +440,7 @@ async function sendStartProjectAcknowledgement(
     ? [
       `<@${config.operatorUserId}> Could not queue project start request for \`${request.displayName}\`.`,
       result.message,
-      "Usage: `/startProject <project-name>`",
+      "Usage: `startProject <project-name>`",
     ].join("\n")
     : result.action === "created"
       ? [
@@ -474,7 +476,7 @@ async function sendStopProjectAcknowledgement(
     ? [
       `<@${config.operatorUserId}> Could not stop the current project.`,
       result.message,
-      "Usage: `/stopProject`",
+      "Usage: `stopProject`",
     ].join("\n")
     : result.action === "stopped"
       ? [
@@ -742,110 +744,111 @@ export async function pollDiscordGracefulShutdownCommand(
         continue;
       }
 
-      if (message.author?.id === config.operatorUserId) {
-        const shutdownCommand = parseGracefulShutdownCommand(message.content);
-        if (shutdownCommand !== null) {
-          const recordedRequest = await recordGracefulShutdownRequest(workDir, {
-            messageId: message.id,
-            mode: shutdownCommand.mode,
+      const shutdownCommand = parseGracefulShutdownCommand(message.content);
+      if (shutdownCommand !== null) {
+        const recordedRequest = await recordGracefulShutdownRequest(workDir, {
+          messageId: message.id,
+          mode: shutdownCommand.mode,
+        });
+        gracefulShutdownRequest = recordedRequest.request;
+        try {
+          await sendGracefulShutdownAcknowledgement(config, recordedRequest.request, {
+            created: recordedRequest.created,
+            requestedCommand: shutdownCommand.command,
           });
-          gracefulShutdownRequest = recordedRequest.request;
+        } catch (error) {
+          const sendMessage = buildStepFailureMessage("send-quit-ack", error);
+          console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);
+          logDiscordMissingAccessHint(sendMessage);
+        }
+        continue;
+      }
+
+      const stopProjectCommandSuffix = parseStopProjectCommand(message.content);
+      if (stopProjectCommandSuffix !== null && handlers.onStopProject) {
+        const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
+          command: "stop-project",
+          messageId: message.id,
+        });
+        if (recordedReceipt) {
+          let commandResult: StopProjectCommandResult;
+
           try {
-            await sendGracefulShutdownAcknowledgement(config, recordedRequest.request, {
-              created: recordedRequest.created,
-              requestedCommand: shutdownCommand.command,
+            if (stopProjectCommandSuffix.length > 0) {
+              throw new Error("`stopProject` does not take any arguments.");
+            }
+
+            commandResult = await handlers.onStopProject({
+              messageId: message.id,
+              requestedAt: new Date().toISOString(),
+              requestedBy: `discord:${config.operatorUserId}`,
             });
           } catch (error) {
-            const sendMessage = buildStepFailureMessage("send-quit-ack", error);
-            console.error(`Discord graceful shutdown acknowledgement failed: ${sendMessage}`);
+            commandResult = {
+              ok: false,
+              message: error instanceof Error ? error.message : "Unknown project stop request error.",
+            };
+          }
+
+          try {
+            await sendStopProjectAcknowledgement(config, commandResult);
+          } catch (error) {
+            const sendMessage = buildStepFailureMessage("send-stop-project-ack", error);
+            console.error(`Discord project stop acknowledgement failed: ${sendMessage}`);
             logDiscordMissingAccessHint(sendMessage);
           }
-        } else {
-          const stopProjectCommandSuffix = parseStopProjectCommand(message.content);
-          if (stopProjectCommandSuffix !== null && handlers.onStopProject) {
-            const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
-              command: "stop-project",
+        }
+
+        continue;
+      }
+
+      const requestedProjectName = parseStartProjectName(message.content);
+      if (requestedProjectName !== null && handlers.onStartProject) {
+        const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
+          command: "start-project",
+          messageId: message.id,
+        });
+        if (recordedReceipt) {
+          let startProjectRequest: StartProjectCommandRequest | null = null;
+          let commandResult: StartProjectCommandResult;
+
+          try {
+            const normalized = normalizeProjectNameInput(requestedProjectName);
+            startProjectRequest = {
               messageId: message.id,
-            });
-            if (recordedReceipt) {
-              let commandResult: StopProjectCommandResult;
-
-              try {
-                if (stopProjectCommandSuffix.length > 0) {
-                  throw new Error("`/stopProject` does not take any arguments.");
-                }
-
-                commandResult = await handlers.onStopProject({
-                  messageId: message.id,
-                  requestedAt: new Date().toISOString(),
-                  requestedBy: `discord:${config.operatorUserId}`,
-                });
-              } catch (error) {
-                commandResult = {
-                  ok: false,
-                  message: error instanceof Error ? error.message : "Unknown project stop request error.",
-                };
-              }
-
-              try {
-                await sendStopProjectAcknowledgement(config, commandResult);
-              } catch (error) {
-                const sendMessage = buildStepFailureMessage("send-stop-project-ack", error);
-                console.error(`Discord project stop acknowledgement failed: ${sendMessage}`);
-                logDiscordMissingAccessHint(sendMessage);
-              }
-            }
-          } else {
-          const requestedProjectName = parseStartProjectName(message.content);
-          if (requestedProjectName !== null && handlers.onStartProject) {
-            const recordedReceipt = await recordDiscordControlCommandReceipt(workDir, {
-              command: "start-project",
+              requestedAt: new Date().toISOString(),
+              requestedBy: `discord:${config.operatorUserId}`,
+              displayName: normalized.displayName,
+              slug: normalized.slug,
+              repositoryName: normalized.repositoryName,
+              issueLabel: normalized.issueLabel,
+              workspaceRelativePath: normalized.workspaceRelativePath,
+            };
+            commandResult = await handlers.onStartProject(startProjectRequest);
+          } catch (error) {
+            const fallbackDisplayName = requestedProjectName.trim() || "<missing project name>";
+            startProjectRequest = {
               messageId: message.id,
-            });
-            if (recordedReceipt) {
-              let startProjectRequest: StartProjectCommandRequest | null = null;
-              let commandResult: StartProjectCommandResult;
-
-              try {
-                const normalized = normalizeProjectNameInput(requestedProjectName);
-                startProjectRequest = {
-                  messageId: message.id,
-                  requestedAt: new Date().toISOString(),
-                  requestedBy: `discord:${config.operatorUserId}`,
-                  displayName: normalized.displayName,
-                  slug: normalized.slug,
-                  repositoryName: normalized.repositoryName,
-                  issueLabel: normalized.issueLabel,
-                  workspaceRelativePath: normalized.workspaceRelativePath,
-                };
-                commandResult = await handlers.onStartProject(startProjectRequest);
-              } catch (error) {
-                const fallbackDisplayName = requestedProjectName.trim() || "<missing project name>";
-                startProjectRequest = {
-                  messageId: message.id,
-                  requestedAt: new Date().toISOString(),
-                  requestedBy: `discord:${config.operatorUserId}`,
-                  displayName: fallbackDisplayName,
-                  slug: "",
-                  repositoryName: "",
-                  issueLabel: "",
-                  workspaceRelativePath: "",
-                };
-                commandResult = {
-                  ok: false,
-                  message: error instanceof Error ? error.message : "Unknown project start request error.",
-                };
-              }
-
-              try {
-                await sendStartProjectAcknowledgement(config, startProjectRequest, commandResult);
-              } catch (error) {
-                const sendMessage = buildStepFailureMessage("send-start-project-ack", error);
-                console.error(`Discord project start acknowledgement failed: ${sendMessage}`);
-                logDiscordMissingAccessHint(sendMessage);
-              }
-            }
+              requestedAt: new Date().toISOString(),
+              requestedBy: `discord:${config.operatorUserId}`,
+              displayName: fallbackDisplayName,
+              slug: "",
+              repositoryName: "",
+              issueLabel: "",
+              workspaceRelativePath: "",
+            };
+            commandResult = {
+              ok: false,
+              message: error instanceof Error ? error.message : "Unknown project start request error.",
+            };
           }
+
+          try {
+            await sendStartProjectAcknowledgement(config, startProjectRequest, commandResult);
+          } catch (error) {
+            const sendMessage = buildStepFailureMessage("send-start-project-ack", error);
+            console.error(`Discord project start acknowledgement failed: ${sendMessage}`);
+            logDiscordMissingAccessHint(sendMessage);
           }
         }
       }


### PR DESCRIPTION
## Summary
- remove slash-command affordances from Discord operator control and standardize on explicit plain-text channel messages
- keep cycle-limit replies separate from shutdown control by using `quit after current task` and `quit after tasks` for runtime shutdown
- normalize legacy persisted shutdown payloads so existing pending requests survive the contract change

## Validation
- pnpm lint
- pnpm build
- pnpm test

Closes #375