### PR TITLE
fix: disable live Discord transport during Vitest runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Outside the cycle-limit prompt, Discord operator control is explicit plain-text 
 - `startProject <project-name>`
 - `stopProject`
 
+Vitest runs set `EVOLVO_DISCORD_TRANSPORT=disabled`, so automated tests never send live Discord messages and must exercise Discord behavior through mocks, spies, or other controlled doubles.
+
 If Discord vars are not configured, Evolvo does not attempt Discord and keeps existing non-Discord behavior.
 
 ## Startup Flow

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -34,6 +34,7 @@ describe("operatorControl", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.stubEnv("EVOLVO_DISCORD_TRANSPORT", "live");
   });
 
   afterEach(async () => {
@@ -46,6 +47,30 @@ describe("operatorControl", () => {
 
   it("returns null config when required Discord environment variables are missing", () => {
     expect(getDiscordControlConfigFromEnv({})).toBeNull();
+  });
+
+  it("returns null config when Discord transport is explicitly disabled", () => {
+    expect(getDiscordControlConfigFromEnv({
+      DISCORD_BOT_TOKEN: "bot-token",
+      DISCORD_CONTROL_GUILD_ID: "guild-1",
+      DISCORD_CONTROL_CHANNEL_ID: "channel-1",
+      DISCORD_OPERATOR_USER_ID: "operator-1",
+      EVOLVO_DISCORD_TRANSPORT: "disabled",
+    })).toBeNull();
+  });
+
+  it("skips Discord startup checks entirely when Discord transport is disabled", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+    vi.stubEnv("EVOLVO_DISCORD_TRANSPORT", "disabled");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await runDiscordOperatorControlStartupCheck();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("returns null decision when Discord operator control is not configured", async () => {

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -177,9 +177,17 @@ function parsePositiveIntegerEnv(
   return parsed;
 }
 
+function isDiscordTransportDisabled(env: NodeJS.ProcessEnv): boolean {
+  return env.EVOLVO_DISCORD_TRANSPORT?.trim().toLowerCase() === "disabled";
+}
+
 export function getDiscordControlConfigFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): DiscordControlConfig | null {
+  if (isDiscordTransportDisabled(env)) {
+    return null;
+  }
+
   const botToken = getRequiredTrimmedEnv("DISCORD_BOT_TOKEN", env);
   const guildId = getRequiredTrimmedEnv("DISCORD_CONTROL_GUILD_ID", env);
   const controlChannelId = getRequiredTrimmedEnv("DISCORD_CONTROL_CHANNEL_ID", env);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    env: {
+      EVOLVO_DISCORD_TRANSPORT: "disabled",
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add an explicit `EVOLVO_DISCORD_TRANSPORT=disabled` gate to Discord config resolution
- make Vitest set that transport mode by default so automated tests never send live Discord messages
- keep Discord logic testable by opting unit tests back into `live` mode only when fetch is mocked

## Validation
- pnpm lint
- pnpm build
- pnpm test

Closes #376