### PR TITLE
fix: reject blank active project state inputs

### DIFF
--- a/src/projects/activeProjectState.test.ts
+++ b/src/projects/activeProjectState.test.ts
@@ -62,6 +62,52 @@ describe("activeProjectState", () => {
     await expect(readActiveProjectState(workDir)).resolves.toEqual(state);
   });
 
+  it("rejects blank slugs before writing active project state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await expect(
+      setActiveProjectState({
+        workDir,
+        slug: "   ",
+        requestedBy: "discord:operator-1",
+        source: "start-project-command",
+        updatedAt: "2026-03-08T12:00:00.000Z",
+      }),
+    ).rejects.toThrow("Active project state slug cannot be empty.");
+    await expect(readActiveProjectState(workDir)).resolves.toEqual({
+      version: 2,
+      activeProjectSlug: null,
+      selectionState: null,
+      updatedAt: null,
+      requestedBy: null,
+      source: null,
+    });
+  });
+
+  it("rejects blank operator identities before writing active project state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+
+    await expect(
+      setActiveProjectState({
+        workDir,
+        slug: "habit-cli",
+        requestedBy: "   ",
+        source: "start-project-command",
+        updatedAt: "2026-03-08T12:00:00.000Z",
+      }),
+    ).rejects.toThrow("Active project state requestedBy cannot be empty.");
+    await expect(readActiveProjectState(workDir)).resolves.toEqual({
+      version: 2,
+      activeProjectSlug: null,
+      selectionState: null,
+      updatedAt: null,
+      requestedBy: null,
+      source: null,
+    });
+  });
+
   it("migrates version-1 active project state into the current shape without warning", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const workDir = await createTempWorkDir();
@@ -176,6 +222,34 @@ describe("activeProjectState", () => {
         requestedBy: "discord:operator-1",
         source: "stop-project-command",
       },
+    });
+  });
+
+  it("rejects blank stop operators before overwriting active project state", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    await setActiveProjectState({
+      workDir,
+      slug: "habit-cli",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
+      updatedAt: "2026-03-08T12:20:00.000Z",
+    });
+
+    await expect(
+      stopActiveProjectState({
+        workDir,
+        requestedBy: "   ",
+        updatedAt: "2026-03-08T12:25:00.000Z",
+      }),
+    ).rejects.toThrow("Active project state requestedBy cannot be empty.");
+    await expect(readActiveProjectState(workDir)).resolves.toEqual({
+      version: 2,
+      activeProjectSlug: "habit-cli",
+      selectionState: "active",
+      updatedAt: "2026-03-08T12:20:00.000Z",
+      requestedBy: "discord:operator-1",
+      source: "start-project-command",
     });
   });
 

--- a/src/projects/activeProjectState.ts
+++ b/src/projects/activeProjectState.ts
@@ -33,6 +33,15 @@ function normalizeNonEmptyString(value: unknown): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+function requireNonEmptyInput(value: string, label: "slug" | "requestedBy"): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error(`Active project state ${label} cannot be empty.`);
+  }
+
+  return normalized;
+}
+
 function normalizeSource(value: unknown): ActiveProjectStateSource | null {
   if (
     value === "start-project-command" ||
@@ -140,12 +149,15 @@ export async function setActiveProjectState(options: {
   source: ActiveProjectStateSource;
   updatedAt?: string;
 }): Promise<ActiveProjectState> {
+  const activeProjectSlug = requireNonEmptyInput(options.slug, "slug");
+  const requestedBy = requireNonEmptyInput(options.requestedBy, "requestedBy");
+
   return writeActiveProjectState(options.workDir, {
     version: ACTIVE_PROJECT_STATE_VERSION,
-    activeProjectSlug: options.slug.trim(),
+    activeProjectSlug,
     selectionState: "active",
     updatedAt: options.updatedAt?.trim() || new Date().toISOString(),
-    requestedBy: options.requestedBy.trim(),
+    requestedBy,
     source: options.source,
   });
 }
@@ -173,12 +185,13 @@ export async function stopActiveProjectState(options: {
     };
   }
 
+  const requestedBy = requireNonEmptyInput(options.requestedBy, "requestedBy");
   const nextState: ActiveProjectState = {
     version: ACTIVE_PROJECT_STATE_VERSION,
     activeProjectSlug: currentState.activeProjectSlug,
     selectionState: "stopped",
     updatedAt: options.updatedAt?.trim() || new Date().toISOString(),
-    requestedBy: options.requestedBy.trim(),
+    requestedBy,
     source: "stop-project-command",
   };
   await writeActiveProjectState(options.workDir, nextState);


### PR DESCRIPTION
## Summary
- reject blank `slug` and `requestedBy` values in `setActiveProjectState()` before persisting state
- reject blank `requestedBy` values in `stopActiveProjectState()` on the write path so stop requests cannot overwrite valid state with an empty operator identity
- add regression tests proving invalid inputs fail fast and leave persisted state unchanged

Closes #374

## Validation
- pnpm validate