### PR TITLE
fix(planner): persist replenishment failure artifacts

### DIFF
--- a/src/agents/plannerAgent.test.ts
+++ b/src/agents/plannerAgent.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const threadRunMock = vi.fn();
@@ -204,6 +207,76 @@ describe("plannerAgent", () => {
     warnSpy.mockRestore();
   });
 
+  it("persists replenishment failure artifacts with planner prompt and raw final response", async () => {
+    const rawFinalResponse = JSON.stringify({ result: [] });
+    threadRunMock.mockResolvedValueOnce({
+      finalResponse: rawFinalResponse,
+    });
+    const createPlannedIssuesMock = vi.fn();
+    const issueManager = {
+      listOpenIssues: vi.fn().mockResolvedValueOnce([
+        { number: 17, title: "Open reliability gap", description: "Still open.", state: "open", labels: [] },
+      ]),
+      listRecentClosedIssues: vi.fn().mockResolvedValueOnce([
+        { number: 16, title: "Closed planning fix", description: "Already done.", state: "closed", labels: [] },
+      ]),
+      createPlannedIssues: createPlannedIssuesMock,
+    } as unknown as import("../issues/taskIssueManager.js").TaskIssueManager;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { runPlannerAgent } = await import("./plannerAgent.js");
+    const workDir = await mkdtemp(join(tmpdir(), "planner-agent-"));
+
+    try {
+      const result = await runPlannerAgent({
+        cycle: 2,
+        openIssueCount: 1,
+        minimumIssueCount: 3,
+        maximumOpenIssues: 5,
+        issueManager,
+        workDir,
+      });
+
+      const artifactPath = join(workDir, ".evolvo", "planner-replenishment-failure.json");
+      const artifact = JSON.parse(await readFile(artifactPath, "utf8")) as {
+        schemaVersion: number;
+        cycle: number;
+        openIssueCount: number;
+        startupBootstrap: boolean;
+        plannerPrompt: string | null;
+        finalResponse: string | null;
+        error: {
+          name: string;
+          message: string;
+          stack: string | null;
+        };
+      };
+
+      expect(artifact.schemaVersion).toBe(1);
+      expect(artifact.cycle).toBe(2);
+      expect(artifact.openIssueCount).toBe(1);
+      expect(artifact.startupBootstrap).toBe(false);
+      expect(artifact.plannerPrompt).toContain("Current open issues:\n- #17 Open reliability gap");
+      expect(artifact.plannerPrompt).toContain("Recently closed issues:\n- #16 Closed planning fix");
+      expect(artifact.finalResponse).toBe(rawFinalResponse);
+      expect(artifact.error.name).toBe("Error");
+      expect(artifact.error.message).toBe("Planner response did not contain an issues array.");
+      expect(typeof artifact.error.stack).toBe("string");
+      expect(errorSpy).toHaveBeenNthCalledWith(
+        1,
+        "Queue repository analysis failed during replenishment planning: Planner response did not contain an issues array.",
+      );
+      expect(errorSpy).toHaveBeenNthCalledWith(
+        2,
+        "Planner replenishment failure artifact saved to `.evolvo/planner-replenishment-failure.json`.",
+      );
+      expect(createPlannedIssuesMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ created: [], startupBootstrap: false });
+    } finally {
+      errorSpy.mockRestore();
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns no created issues when planner analysis fails", async () => {
     threadRunMock.mockRejectedValueOnce(new Error("planner failed"));
     const createPlannedIssuesMock = vi.fn();
@@ -214,18 +287,41 @@ describe("plannerAgent", () => {
     } as unknown as import("../issues/taskIssueManager.js").TaskIssueManager;
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { runPlannerAgent } = await import("./plannerAgent.js");
+    const workDir = await mkdtemp(join(tmpdir(), "planner-agent-"));
 
-    const result = await runPlannerAgent({
-      cycle: 2,
-      openIssueCount: 1,
-      minimumIssueCount: 3,
-      maximumOpenIssues: 5,
-      issueManager,
-      workDir: "/tmp/evolvo",
-    });
+    try {
+      const result = await runPlannerAgent({
+        cycle: 2,
+        openIssueCount: 1,
+        minimumIssueCount: 3,
+        maximumOpenIssues: 5,
+        issueManager,
+        workDir,
+      });
 
-    expect(errorSpy).toHaveBeenCalledWith("Queue repository analysis failed during replenishment planning: planner failed");
-    expect(createPlannedIssuesMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ created: [], startupBootstrap: false });
+      const artifact = JSON.parse(
+        await readFile(join(workDir, ".evolvo", "planner-replenishment-failure.json"), "utf8"),
+      ) as {
+        plannerPrompt: string | null;
+        finalResponse: string | null;
+        error: {
+          message: string;
+        };
+      };
+
+      expect(errorSpy).toHaveBeenNthCalledWith(1, "Queue repository analysis failed during replenishment planning: planner failed");
+      expect(errorSpy).toHaveBeenNthCalledWith(
+        2,
+        "Planner replenishment failure artifact saved to `.evolvo/planner-replenishment-failure.json`.",
+      );
+      expect(artifact.plannerPrompt).toContain("Current open issues:\n- none");
+      expect(artifact.finalResponse).toBeNull();
+      expect(artifact.error.message).toBe("planner failed");
+      expect(createPlannedIssuesMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ created: [], startupBootstrap: false });
+    } finally {
+      errorSpy.mockRestore();
+      await rm(workDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/plannerAgent.ts
+++ b/src/agents/plannerAgent.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { Codex, type ThreadOptions } from "@openai/codex-sdk";
 import {
   PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT,
@@ -6,6 +7,7 @@ import {
   type PlannedIssueDraft,
   type TaskIssueManager,
 } from "../issues/taskIssueManager.js";
+import { writeAtomicJsonState } from "../runtime/localStateFile.js";
 
 export type PlannerAgentInput = {
   cycle: number;
@@ -53,6 +55,27 @@ const PLANNER_OUTPUT_SCHEMA = {
 type PlannerResponse = {
   issues: unknown[];
 };
+
+type PlannerFailureArtifact = {
+  schemaVersion: 1;
+  failedAtMs: number;
+  failedAtIso: string;
+  cycle: number;
+  openIssueCount: number;
+  minimumIssueCount: number;
+  maximumOpenIssues: number;
+  startupBootstrap: boolean;
+  plannerPrompt: string | null;
+  finalResponse: string | null;
+  error: {
+    name: string;
+    message: string;
+    stack: string | null;
+  };
+};
+
+const PLANNER_FAILURE_ARTIFACT_RELATIVE_PATH = ".evolvo/planner-replenishment-failure.json";
+const PLANNER_FAILURE_ARTIFACT_SCHEMA_VERSION = 1;
 
 function dedupeClosedIssueHistory(issues: IssueSummary[]): IssueSummary[] {
   const seen = new Set<string>();
@@ -156,8 +179,54 @@ function buildPlannerPrompt(input: PlannerAgentInput, openIssues: IssueSummary[]
   ].join("\n");
 }
 
+function summarizePlannerFailure(error: unknown): PlannerFailureArtifact["error"] {
+  if (error instanceof Error) {
+    return {
+      name: error.name || "Error",
+      message: error.message || "Unknown error.",
+      stack: typeof error.stack === "string" && error.stack.trim().length > 0 ? error.stack : null,
+    };
+  }
+
+  return {
+    name: "NonErrorThrownValue",
+    message: String(error),
+    stack: null,
+  };
+}
+
+async function persistPlannerFailureArtifact(options: {
+  input: PlannerAgentInput;
+  startupBootstrap: boolean;
+  plannerPrompt: string | null;
+  finalResponse: string | null;
+  error: unknown;
+}): Promise<string> {
+  const failedAtMs = Date.now();
+  const artifact: PlannerFailureArtifact = {
+    schemaVersion: PLANNER_FAILURE_ARTIFACT_SCHEMA_VERSION,
+    failedAtMs,
+    failedAtIso: new Date(failedAtMs).toISOString(),
+    cycle: options.input.cycle,
+    openIssueCount: options.input.openIssueCount,
+    minimumIssueCount: options.input.minimumIssueCount,
+    maximumOpenIssues: options.input.maximumOpenIssues,
+    startupBootstrap: options.startupBootstrap,
+    plannerPrompt: options.plannerPrompt,
+    finalResponse: options.finalResponse,
+    error: summarizePlannerFailure(options.error),
+  };
+  await writeAtomicJsonState(
+    join(options.input.workDir, PLANNER_FAILURE_ARTIFACT_RELATIVE_PATH),
+    artifact,
+  );
+  return PLANNER_FAILURE_ARTIFACT_RELATIVE_PATH;
+}
+
 export async function runPlannerAgent(input: PlannerAgentInput): Promise<PlannerAgentResult> {
   const startupBootstrap = input.cycle === 1 && input.openIssueCount === 0;
+  let plannerPrompt: string | null = null;
+  let plannerFinalResponse: string | null = null;
 
   try {
     const openIssues = await input.issueManager.listOpenIssues();
@@ -168,11 +237,12 @@ export async function runPlannerAgent(input: PlannerAgentInput): Promise<Planner
       ...PLANNER_THREAD_OPTIONS,
       workingDirectory: input.workDir,
     });
-    const plannerPrompt = buildPlannerPrompt(input, openIssues, recentClosedIssues);
+    plannerPrompt = buildPlannerPrompt(input, openIssues, recentClosedIssues);
     const turn = await thread.run(plannerPrompt, {
       outputSchema: PLANNER_OUTPUT_SCHEMA,
     });
-    const plannedIssues = parsePlannerResponse(turn.finalResponse);
+    plannerFinalResponse = turn.finalResponse;
+    const plannedIssues = parsePlannerResponse(plannerFinalResponse);
     const created = (
       await input.issueManager.createPlannedIssues({
         minimumIssueCount: input.minimumIssueCount,
@@ -190,6 +260,27 @@ export async function runPlannerAgent(input: PlannerAgentInput): Promise<Planner
       console.error(`Queue repository analysis failed during replenishment planning: ${error.message}`);
     } else {
       console.error("Queue repository analysis failed during replenishment planning with an unknown error.");
+    }
+
+    try {
+      const artifactPath = await persistPlannerFailureArtifact({
+        input,
+        startupBootstrap,
+        plannerPrompt,
+        finalResponse: plannerFinalResponse,
+        error,
+      });
+      console.error(`Planner replenishment failure artifact saved to \`${artifactPath}\`.`);
+    } catch (artifactError) {
+      if (artifactError instanceof Error) {
+        console.error(
+          `Could not persist planner replenishment failure artifact to \`${PLANNER_FAILURE_ARTIFACT_RELATIVE_PATH}\`: ${artifactError.message}`,
+        );
+      } else {
+        console.error(
+          `Could not persist planner replenishment failure artifact to \`${PLANNER_FAILURE_ARTIFACT_RELATIVE_PATH}\`: unknown error.`,
+        );
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary
- persist a .evolvo failure artifact with the planner prompt, raw final response, and exception details
- log the saved artifact path so replenishment failures are diagnosable from runtime output
- add regression coverage for planner parse failures and thrown planner runs

Closes #372