### PR TITLE
feat(loop): prioritize next issue selection

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -844,6 +844,36 @@ describe("main", () => {
     );
   });
 
+  it("logs issue prioritization reasoning when related issues compete", async () => {
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        { number: 101, title: "Planner copy polish", description: "Tidy planner selection copy.", state: "open", labels: [] },
+        {
+          number: 102,
+          title: "Planner dependency ordering",
+          description: "Choose the foundational planner selection issue first so it can unblock related planner tasks.",
+          state: "open",
+          labels: [],
+        },
+        { number: 103, title: "Planner selection docs", description: "Document planner selection examples.", state: "open", labels: [] },
+      ])
+      .mockResolvedValueOnce([]);
+    const { main } = await import("./main.js");
+
+    await main();
+
+    expect(markInProgressMock).toHaveBeenCalledWith(102);
+    expect(runCodingAgentMock).toHaveBeenCalledWith(
+      "Issue #102: Planner dependency ordering\n\nChoose the foundational planner selection issue first so it can unblock related planner tasks.",
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Issue prioritization selected #102 Planner dependency ordering over 2 other candidate(s):",
+      ),
+    );
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("dependency or unblock potential"));
+  });
+
   it("resolves managed-project execution context before running the coding agent", async () => {
     listOpenIssuesMock
       .mockResolvedValueOnce([

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,8 @@ import {
   logCreatedIssues,
   logCycleQueueHealth,
   logGitHubFallback,
-  selectIssueForWork,
+  logIssuePrioritizationDecision,
+  prioritizeIssuesForWork,
   waitForRunLoopRetry,
 } from "./runtime/loopUtils.js";
 import {
@@ -484,10 +485,11 @@ export async function main(): Promise<void> {
             return;
           }
 
-          const selectedIssue = selectIssueForWork(retryEligibleIssues, {
+          const selectionDecision = prioritizeIssuesForWork(retryEligibleIssues, {
             activeProjectSlug: activeProjectState.selectionState === "active" ? activeProjectState.activeProjectSlug : null,
             stoppedProjectSlug: activeProjectState.selectionState === "stopped" ? activeProjectState.activeProjectSlug : null,
           });
+          const selectedIssue = selectionDecision.selectedIssue;
           if (selectedIssue !== null || activeProjectState.selectionState !== "stopped") {
             stoppedProjectIdleLoggedSlug = null;
           }
@@ -581,6 +583,7 @@ export async function main(): Promise<void> {
             return;
           }
 
+          logIssuePrioritizationDecision(selectionDecision);
           logCycleQueueHealth({
             cycle,
             openCount: openIssues.length,

--- a/src/runtime/loopUtils.test.ts
+++ b/src/runtime/loopUtils.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GitHubApiError } from "../github/githubClient.js";
-import { getRunLoopRetryDelayMs, isTransientGitHubError, selectIssueForWork, waitForRunLoopRetry } from "./loopUtils.js";
+import {
+  getRunLoopRetryDelayMs,
+  isTransientGitHubError,
+  prioritizeIssuesForWork,
+  selectIssueForWork,
+  waitForRunLoopRetry,
+} from "./loopUtils.js";
 
 describe("loopUtils retry handling", () => {
   afterEach(() => {
@@ -82,6 +88,38 @@ describe("loopUtils retry handling", () => {
     ]);
 
     expect(selected?.number).toBe(2);
+  });
+
+  it("prioritizes the more foundational issue within a related topic cluster", () => {
+    const decision = prioritizeIssuesForWork([
+      {
+        number: 30,
+        title: "Polish planner log wording",
+        description: "Tidy planner selection log copy for readability.",
+        state: "open",
+        labels: [],
+      },
+      {
+        number: 31,
+        title: "Harden planner dependency ordering",
+        description: "Choose the foundational planner selection issue first so it can unblock related planner tasks.",
+        state: "open",
+        labels: [],
+      },
+      {
+        number: 32,
+        title: "Document planner selection examples",
+        description: "Add planner selection examples for future operator review.",
+        state: "open",
+        labels: [],
+      },
+    ]);
+
+    expect(decision.selectedIssue?.number).toBe(31);
+    expect(decision.candidateCount).toBe(3);
+    expect(decision.rationale).toContain("dependency or unblock potential");
+    expect(decision.rationale).toContain("core runtime/control surface");
+    expect(decision.rationale).toContain("shared topic with 2 other open issues");
   });
 
   it("prefers issues for the active project when one is selected", () => {

--- a/src/runtime/loopUtils.ts
+++ b/src/runtime/loopUtils.ts
@@ -16,31 +16,341 @@ const MAX_OPEN_ISSUES = 5;
 const RUN_LOOP_TRANSIENT_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
 const RUN_LOOP_GITHUB_RETRY_BASE_DELAY_MS = 50;
 const RUN_LOOP_GITHUB_RETRY_MAX_DELAY_MS = 1_000;
+const ISSUE_PRIORITY_TOPIC_STOP_WORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "into",
+  "that",
+  "this",
+  "issue",
+  "issues",
+  "task",
+  "tasks",
+  "evolvo",
+  "self",
+  "improvement",
+  "open",
+  "work",
+]);
+
+type IssuePrioritySignal = {
+  label: string;
+  weight: number;
+};
+
+type RankedIssueCandidate = {
+  issue: IssueSummary;
+  score: number;
+  signals: IssuePrioritySignal[];
+  originalIndex: number;
+};
+
+export type IssueSelectionDecision = {
+  selectedIssue: IssueSummary | null;
+  candidateCount: number;
+  rationale: string | null;
+};
 
 export const DEFAULT_PROMPT = "No open issues available. Create an issue first.";
 
-function selectHighestPriorityIssue(issues: IssueSummary[]): IssueSummary | null {
-  if (issues.length === 0) {
+function normalizeTopicToken(token: string): string | null {
+  const normalized = token
+    .toLowerCase()
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "");
+  if (!normalized || normalized.length < 4 || /^\d+$/.test(normalized) || ISSUE_PRIORITY_TOPIC_STOP_WORDS.has(normalized)) {
     return null;
+  }
+
+  if (normalized.endsWith("ies") && normalized.length > 4) {
+    return `${normalized.slice(0, -3)}y`;
+  }
+
+  if (normalized.endsWith("s") && normalized.length > 4) {
+    return normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
+function buildTopicTokenSet(issue: IssueSummary): Set<string> {
+  const text = `${issue.title}\n${issue.description}`;
+  const tokens = text
+    .split(/\s+/)
+    .map((token) => normalizeTopicToken(token))
+    .filter((token): token is string => token !== null);
+  return new Set(tokens);
+}
+
+function countTopicOverlap(left: Set<string>, right: Set<string>): number {
+  let overlap = 0;
+  for (const token of left) {
+    if (right.has(token)) {
+      overlap += 1;
+    }
+  }
+
+  return overlap;
+}
+
+function hasPriorityKeyword(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function buildPrioritySignals(
+  issue: IssueSummary,
+  issues: IssueSummary[],
+  topicTokensByIssueNumber: Map<number, Set<string>>,
+): IssuePrioritySignal[] {
+  const text = `${issue.title}\n${issue.description}`.toLowerCase();
+  const signals: IssuePrioritySignal[] = [];
+
+  if (
+    hasPriorityKeyword(text, [
+      /\b(unblock|unlock|prerequisite|foundational|foundation|infrastructure|depends? on|sequenc(?:e|ing)|come first)\b/,
+      /\bshared infrastructure\b/,
+    ])
+  ) {
+    signals.push({
+      label: "dependency or unblock potential",
+      weight: 140,
+    });
+  }
+
+  if (
+    hasPriorityKeyword(text, [
+      /\brun(?: |-)?loop\b/,
+      /\bqueue\b/,
+      /\breplenish(?:ment)?\b/,
+      /\bbootstrap\b/,
+      /\brestart\b/,
+      /\breadiness\b/,
+      /\blifecycle\b/,
+      /\bstate(?: transition)?\b/,
+      /\bselection\b/,
+      /\bprioriti[sz](?:e|ation)\b/,
+      /\bretry\b/,
+      /\bplanner\b/,
+      /\breview\b/,
+      /\bvalidation\b/,
+      /\bgithub\b/,
+      /\boperator\b/,
+      /\bcontrol\b/,
+    ])
+  ) {
+    signals.push({
+      label: "core runtime/control surface",
+      weight: 110,
+    });
+  }
+
+  if (
+    hasPriorityKeyword(text, [
+      /\bfail(?:ure|ed|ing|s)?\b/,
+      /\berror\b/,
+      /\bflak(?:e|y|iness)\b/,
+      /\btimeout\b/,
+      /\bcrash\b/,
+      /\bbug\b/,
+      /\bregression\b/,
+      /\bdiagnostic\b/,
+      /\bincorrect\b/,
+      /\bopaque\b/,
+      /\brisk\b/,
+    ])
+  ) {
+    signals.push({
+      label: "reliability or failure evidence",
+      weight: 90,
+    });
+  }
+
+  if (
+    hasPriorityKeyword(text, [
+      /\bshared\b/,
+      /\breusable\b/,
+      /\bworkflow\b/,
+      /\borchestrat(?:e|ion)\b/,
+      /\bselector\b/,
+      /\bplanning\b/,
+      /\bquality\b/,
+      /\brobust(?:ness)?\b/,
+      /\bsequenc(?:e|ing)\b/,
+    ])
+  ) {
+    signals.push({
+      label: "system-wide leverage",
+      weight: 70,
+    });
+  }
+
+  const issueTopicTokens = topicTokensByIssueNumber.get(issue.number) ?? new Set<string>();
+  const relatedIssueCount = issues.filter((candidate) => {
+    if (candidate.number === issue.number) {
+      return false;
+    }
+
+    const candidateTokens = topicTokensByIssueNumber.get(candidate.number) ?? new Set<string>();
+    return countTopicOverlap(issueTopicTokens, candidateTokens) >= 2;
+  }).length;
+  if (relatedIssueCount > 0) {
+    signals.push({
+      label: `shared topic with ${relatedIssueCount} other open issue${relatedIssueCount === 1 ? "" : "s"}`,
+      weight: Math.min(60, relatedIssueCount * 20),
+    });
+  }
+
+  return signals;
+}
+
+function compareRankedIssueCandidates(left: RankedIssueCandidate, right: RankedIssueCandidate): number {
+  if (right.score !== left.score) {
+    return right.score - left.score;
+  }
+
+  if (right.signals.length !== left.signals.length) {
+    return right.signals.length - left.signals.length;
+  }
+
+  if (left.issue.number !== right.issue.number) {
+    return left.issue.number - right.issue.number;
+  }
+
+  return left.originalIndex - right.originalIndex;
+}
+
+function formatIssuePrioritySignalLabels(signals: IssuePrioritySignal[]): string {
+  const sortedLabels = [...signals]
+    .sort((left, right) => right.weight - left.weight)
+    .map((signal) => signal.label);
+  const uniqueLabels = [...new Set(sortedLabels)].slice(0, 3);
+
+  if (uniqueLabels.length === 0) {
+    return "stable tie-break after comparing equally actionable issues";
+  }
+
+  if (uniqueLabels.length === 1) {
+    return uniqueLabels[0] ?? "stable tie-break after comparing equally actionable issues";
+  }
+
+  if (uniqueLabels.length === 2) {
+    return `${uniqueLabels[0]} and ${uniqueLabels[1]}`;
+  }
+
+  return `${uniqueLabels[0]}, ${uniqueLabels[1]}, and ${uniqueLabels[2]}`;
+}
+
+function buildSelectionRationale(prefix: string | null, details: string | null): string | null {
+  if (prefix && details) {
+    return `${prefix}; ${details}`;
+  }
+
+  return prefix ?? details;
+}
+
+function rankIssueCandidates(issues: IssueSummary[]): IssueSelectionDecision {
+  if (issues.length === 0) {
+    return {
+      selectedIssue: null,
+      candidateCount: 0,
+      rationale: null,
+    };
+  }
+
+  if (issues.length === 1) {
+    return {
+      selectedIssue: issues[0] ?? null,
+      candidateCount: 1,
+      rationale: null,
+    };
+  }
+
+  const topicTokensByIssueNumber = new Map<number, Set<string>>(
+    issues.map((issue) => [issue.number, buildTopicTokenSet(issue)]),
+  );
+  const ranked = issues
+    .map((issue, originalIndex) => {
+      const signals = buildPrioritySignals(issue, issues, topicTokensByIssueNumber);
+      const score = signals.reduce((total, signal) => total + signal.weight, 0);
+      return {
+        issue,
+        score,
+        signals,
+        originalIndex,
+      };
+    })
+    .sort(compareRankedIssueCandidates);
+  const selected = ranked[0];
+
+  return {
+    selectedIssue: selected?.issue ?? null,
+    candidateCount: issues.length,
+    rationale: selected
+      ? `selected for ${formatIssuePrioritySignalLabels(selected.signals)}`
+      : null,
+  };
+}
+
+function prioritizeIssueCandidates(issues: IssueSummary[]): IssueSelectionDecision {
+  if (issues.length === 0) {
+    return {
+      selectedIssue: null,
+      candidateCount: 0,
+      rationale: null,
+    };
   }
 
   const challengeCandidates = issues.filter((issue) => isChallengeIssue(issue));
   if (challengeCandidates.length > 0) {
     const inProgressChallenge = challengeCandidates.find((issue) => isChallengeInProgressIssue(issue));
     if (inProgressChallenge) {
-      return inProgressChallenge;
+      return {
+        selectedIssue: inProgressChallenge,
+        candidateCount: issues.length,
+        rationale: issues.length > 1
+          ? "resuming an in-progress challenge takes precedence over other open work"
+          : null,
+      };
     }
 
     const retryReadyChallenge = challengeCandidates.find((issue) => isChallengeRetryReadyIssue(issue));
     if (retryReadyChallenge) {
-      return retryReadyChallenge;
+      return {
+        selectedIssue: retryReadyChallenge,
+        candidateCount: issues.length,
+        rationale: issues.length > 1
+          ? "retry-ready challenge work takes precedence over first-attempt work"
+          : null,
+      };
     }
 
-    return challengeCandidates[0] ?? null;
+    const challengeDecision = rankIssueCandidates(challengeCandidates);
+    return {
+      selectedIssue: challengeDecision.selectedIssue,
+      candidateCount: issues.length,
+      rationale: issues.length > 1
+        ? buildSelectionRationale(
+          "challenge work takes precedence over self-improvement issues",
+          challengeDecision.rationale,
+        )
+        : null,
+    };
   }
 
   const inProgress = issues.find((issue) => hasIssueLabel(issue, "in progress"));
-  return inProgress ?? issues[0] ?? null;
+  if (inProgress) {
+    return {
+      selectedIssue: inProgress,
+      candidateCount: issues.length,
+      rationale: issues.length > 1
+        ? "resuming an in-progress issue takes precedence over starting new work"
+        : null,
+    };
+  }
+
+  return rankIssueCandidates(issues);
 }
 
 function issueTargetsProject(issue: IssueSummary, projectSlug: string): boolean {
@@ -57,13 +367,17 @@ function issueTargetsProject(issue: IssueSummary, projectSlug: string): boolean 
   return issue.labels.some((label) => label.trim().toLowerCase() === `${PROJECT_LABEL_PREFIX}${normalizedSlug}`);
 }
 
-export function selectIssueForWork(
+export function prioritizeIssuesForWork(
   issues: IssueSummary[],
   options: { activeProjectSlug?: string | null; stoppedProjectSlug?: string | null } = {},
-): IssueSummary | null {
+): IssueSelectionDecision {
   const notCompleted = issues.filter((issue) => !hasIssueLabel(issue, "completed") && !hasIssueLabel(issue, "blocked"));
   if (notCompleted.length === 0) {
-    return null;
+    return {
+      selectedIssue: null,
+      candidateCount: 0,
+      rationale: null,
+    };
   }
 
   const stoppedProjectSlug = options.stoppedProjectSlug?.trim() || null;
@@ -71,19 +385,44 @@ export function selectIssueForWork(
     ? notCompleted.filter((issue) => !issueTargetsProject(issue, stoppedProjectSlug))
     : notCompleted;
   if (selectableIssues.length === 0) {
-    return null;
+    return {
+      selectedIssue: null,
+      candidateCount: 0,
+      rationale: null,
+    };
   }
 
   const activeProjectSlug = options.activeProjectSlug?.trim() || null;
   if (activeProjectSlug) {
     const activeProjectIssues = selectableIssues.filter((issue) => issueTargetsProject(issue, activeProjectSlug));
-    const prioritized = selectHighestPriorityIssue(activeProjectIssues);
-    if (prioritized) {
-      return prioritized;
+    if (activeProjectIssues.length > 0) {
+      const decision = prioritizeIssueCandidates(activeProjectIssues);
+      return {
+        selectedIssue: decision.selectedIssue,
+        candidateCount: selectableIssues.length,
+        rationale: selectableIssues.length > 1
+          ? buildSelectionRationale(
+            `active project issues take precedence while ${activeProjectSlug} is selected`,
+            decision.rationale,
+          )
+          : null,
+      };
     }
   }
 
-  return selectHighestPriorityIssue(selectableIssues);
+  const decision = prioritizeIssueCandidates(selectableIssues);
+  return {
+    selectedIssue: decision.selectedIssue,
+    candidateCount: selectableIssues.length,
+    rationale: selectableIssues.length > 1 ? decision.rationale : null,
+  };
+}
+
+export function selectIssueForWork(
+  issues: IssueSummary[],
+  options: { activeProjectSlug?: string | null; stoppedProjectSlug?: string | null } = {},
+): IssueSummary | null {
+  return prioritizeIssuesForWork(issues, options).selectedIssue;
 }
 
 export function isOutdatedIssue(issue: IssueSummary): boolean {
@@ -97,6 +436,16 @@ export function buildPromptFromIssue(issue: IssueSummary): string {
 
 export function formatIssueForLog(issue: IssueSummary): string {
   return `#${issue.number} ${issue.title}`;
+}
+
+export function logIssuePrioritizationDecision(decision: IssueSelectionDecision): void {
+  if (decision.selectedIssue === null || decision.candidateCount < 2 || !decision.rationale) {
+    return;
+  }
+
+  console.log(
+    `Issue prioritization selected ${formatIssueForLog(decision.selectedIssue)} over ${decision.candidateCount - 1} other candidate(s): ${decision.rationale}.`,
+  );
 }
 
 export function logCycleQueueHealth(options: {


### PR DESCRIPTION
## Summary
- replace blind next-issue selection with an explainable prioritization decision that weighs dependencies, leverage, reliability signals, and related-topic clustering
- keep existing challenge, in-progress, and active-project precedence rules while adding rationale logging when multiple actionable issues compete
- add regression coverage proving related issues are sequenced intentionally instead of by list order

Closes #364