### PR TITLE
feat(planner): use direct OpenAI responses

### DIFF
--- a/src/agents/plannerAgent.test.ts
+++ b/src/agents/plannerAgent.test.ts
@@ -1,27 +1,30 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const threadRunMock = vi.fn();
-const startThreadMock = vi.fn(() => ({
-  run: threadRunMock,
+const runPlannerOpenAiMock = vi.fn();
+
+vi.mock("../environment.js", () => ({
+  OPENAI_API_KEY: "planner-openai-key",
 }));
 
-vi.mock("@openai/codex-sdk", () => ({
-  Codex: class {
-    public startThread = startThreadMock;
-  },
+vi.mock("./plannerOpenAi.js", () => ({
+  runPlannerOpenAi: runPlannerOpenAiMock,
 }));
 
 describe("plannerAgent", () => {
   beforeEach(() => {
-    startThreadMock.mockClear();
-    threadRunMock.mockReset();
+    vi.resetModules();
+    runPlannerOpenAiMock.mockReset();
   });
 
-  it("uses Codex repo analysis and creates exact planned issues on startup", async () => {
-    threadRunMock.mockResolvedValueOnce({
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses direct OpenAI planner analysis and creates exact planned issues on startup", async () => {
+    runPlannerOpenAiMock.mockResolvedValueOnce({
       finalResponse: JSON.stringify({
         issues: [
           { title: "Stabilize lifecycle transition retries", description: "Tighten lifecycle transition retry behavior." },
@@ -49,12 +52,11 @@ describe("plannerAgent", () => {
     });
 
     expect(result.startupBootstrap).toBe(true);
-    expect(startThreadMock).toHaveBeenCalledWith(expect.objectContaining({
-      workingDirectory: "/tmp/evolvo",
-      sandboxMode: "read-only",
-      approvalPolicy: "never",
-      networkAccessEnabled: false,
-    }));
+    expect(runPlannerOpenAiMock).toHaveBeenCalledWith({
+      apiKey: "planner-openai-key",
+      prompt: expect.stringContaining("Inspect this repository and propose new GitHub issues for Evolvo."),
+      workDir: "/tmp/evolvo",
+    });
     expect(issueManager.listRecentClosedIssues).toHaveBeenCalledWith(300);
     expect(createPlannedIssuesMock).toHaveBeenCalledWith({
       minimumIssueCount: 3,
@@ -70,7 +72,7 @@ describe("plannerAgent", () => {
   });
 
   it("deduplicates repeated planner titles after follow-up normalization before creating issues", async () => {
-    threadRunMock.mockResolvedValueOnce({
+    runPlannerOpenAiMock.mockResolvedValueOnce({
       finalResponse: JSON.stringify({
         issues: [
           { title: "Harden planner duplicate filtering", description: "Use recent issue history to prevent repeats." },
@@ -78,7 +80,7 @@ describe("plannerAgent", () => {
             title: "Harden planner duplicate filtering (follow-up 1)",
             description: "This follow-up variant should also be ignored.",
           },
-          { title: "Improve Codex planner diagnostics", description: "Capture planner failures with clearer logs." },
+          { title: "Improve planner API diagnostics", description: "Capture planner failures with clearer logs." },
         ],
       }),
     });
@@ -104,13 +106,13 @@ describe("plannerAgent", () => {
       maximumOpenIssues: 5,
       issues: [
         { title: "Harden planner duplicate filtering", description: "Use recent issue history to prevent repeats." },
-        { title: "Improve Codex planner diagnostics", description: "Capture planner failures with clearer logs." },
+        { title: "Improve planner API diagnostics", description: "Capture planner failures with clearer logs." },
       ],
     });
   });
 
   it("deduplicates repeated closed-issue follow-ups before applying the 25-item prompt cap", async () => {
-    threadRunMock.mockResolvedValueOnce({
+    runPlannerOpenAiMock.mockResolvedValueOnce({
       finalResponse: JSON.stringify({ issues: [] }),
     });
     const createPlannedIssuesMock = vi.fn().mockResolvedValueOnce({ created: [] });
@@ -144,7 +146,7 @@ describe("plannerAgent", () => {
       workDir: "/tmp/evolvo",
     });
 
-    const plannerPrompt = threadRunMock.mock.calls[0]?.[0] as string;
+    const plannerPrompt = runPlannerOpenAiMock.mock.calls[0]?.[0]?.prompt as string;
     const recentlyClosedSection = plannerPrompt
       .split("Recently closed issues:\n")[1]
       ?.split("\n\nReturn only structured JSON matching the schema.")[0] ?? "";
@@ -162,7 +164,7 @@ describe("plannerAgent", () => {
   });
 
   it("skips malformed planner issue drafts and logs diagnostics", async () => {
-    threadRunMock.mockResolvedValueOnce({
+    runPlannerOpenAiMock.mockResolvedValueOnce({
       finalResponse: JSON.stringify({
         issues: [
           null,
@@ -209,7 +211,7 @@ describe("plannerAgent", () => {
 
   it("persists replenishment failure artifacts with planner prompt and raw final response", async () => {
     const rawFinalResponse = JSON.stringify({ result: [] });
-    threadRunMock.mockResolvedValueOnce({
+    runPlannerOpenAiMock.mockResolvedValueOnce({
       finalResponse: rawFinalResponse,
     });
     const createPlannedIssuesMock = vi.fn();
@@ -278,7 +280,7 @@ describe("plannerAgent", () => {
   });
 
   it("returns no created issues when planner analysis fails", async () => {
-    threadRunMock.mockRejectedValueOnce(new Error("planner failed"));
+    runPlannerOpenAiMock.mockRejectedValueOnce(new Error("planner failed"));
     const createPlannedIssuesMock = vi.fn();
     const issueManager = {
       listOpenIssues: vi.fn().mockResolvedValueOnce([]),

--- a/src/agents/plannerAgent.ts
+++ b/src/agents/plannerAgent.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { Codex, type ThreadOptions } from "@openai/codex-sdk";
 import {
   PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT,
   normalizePlannedIssueComparisonTitle,
@@ -7,7 +6,9 @@ import {
   type PlannedIssueDraft,
   type TaskIssueManager,
 } from "../issues/taskIssueManager.js";
+import { OPENAI_API_KEY } from "../environment.js";
 import { writeAtomicJsonState } from "../runtime/localStateFile.js";
+import { runPlannerOpenAi } from "./plannerOpenAi.js";
 
 export type PlannerAgentInput = {
   cycle: number;
@@ -22,35 +23,6 @@ export type PlannerAgentResult = {
   created: IssueSummary[];
   startupBootstrap: boolean;
 };
-
-const codex = new Codex();
-
-const PLANNER_THREAD_OPTIONS: Omit<ThreadOptions, "workingDirectory"> = {
-  sandboxMode: "read-only",
-  approvalPolicy: "never",
-  modelReasoningEffort: "medium",
-  networkAccessEnabled: false,
-};
-
-const PLANNER_OUTPUT_SCHEMA = {
-  type: "object",
-  properties: {
-    issues: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          title: { type: "string" },
-          description: { type: "string" },
-        },
-        required: ["title", "description"],
-        additionalProperties: false,
-      },
-    },
-  },
-  required: ["issues"],
-  additionalProperties: false,
-} as const;
 
 type PlannerResponse = {
   issues: unknown[];
@@ -233,15 +205,13 @@ export async function runPlannerAgent(input: PlannerAgentInput): Promise<Planner
     const recentClosedIssues = await input.issueManager.listRecentClosedIssues(
       PLANNED_ISSUE_RECENT_CLOSED_LOOKBACK_LIMIT,
     );
-    const thread = codex.startThread({
-      ...PLANNER_THREAD_OPTIONS,
-      workingDirectory: input.workDir,
-    });
     plannerPrompt = buildPlannerPrompt(input, openIssues, recentClosedIssues);
-    const turn = await thread.run(plannerPrompt, {
-      outputSchema: PLANNER_OUTPUT_SCHEMA,
+    const plannerResult = await runPlannerOpenAi({
+      apiKey: OPENAI_API_KEY,
+      prompt: plannerPrompt,
+      workDir: input.workDir,
     });
-    plannerFinalResponse = turn.finalResponse;
+    plannerFinalResponse = plannerResult.finalResponse;
     const plannedIssues = parsePlannerResponse(plannerFinalResponse);
     const created = (
       await input.issueManager.createPlannedIssues({

--- a/src/agents/plannerOpenAi.test.ts
+++ b/src/agents/plannerOpenAi.test.ts
@@ -1,0 +1,223 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.fn();
+const fetchMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+describe("plannerOpenAi", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("calls the Responses API, requires initial repository inspection, and feeds tool output back to the model", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "planner-openai-"));
+    await mkdir(join(workDir, "src"), { recursive: true });
+    await writeFile(join(workDir, "README.md"), "# Evolvo\n", "utf8");
+    await writeFile(join(workDir, "src", "main.ts"), "export const main = true;\n", "utf8");
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: "completed",
+            output: [
+              { type: "reasoning" },
+              {
+                type: "function_call",
+                call_id: "call_list_repo",
+                name: "list_repository_entries",
+                arguments: JSON.stringify({ path: ".", limit: 10 }),
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                role: "assistant",
+                content: [
+                  {
+                    type: "output_text",
+                    text: JSON.stringify({
+                      issues: [
+                        {
+                          title: "Investigate planner routing hotspots",
+                          description: "Ground planner issue selection in current repository hotspots.",
+                        },
+                      ],
+                    }),
+                  },
+                ],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+    try {
+      const { PLANNER_OPENAI_MODEL, runPlannerOpenAi } = await import("./plannerOpenAi.js");
+
+      const result = await runPlannerOpenAi({
+        apiKey: "planner-key",
+        prompt: "Inspect the repository and return JSON issues.",
+        workDir,
+      });
+
+      expect(result.finalResponse).toContain("Investigate planner routing hotspots");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://api.openai.com/v1/responses",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer planner-key",
+            "Content-Type": "application/json",
+          }),
+        }),
+      );
+
+      const firstRequest = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string) as {
+        model: string;
+        tool_choice: string;
+        input: Array<{ role?: string; content?: string }>;
+        tools: Array<{ name: string }>;
+      };
+      expect(firstRequest.model).toBe(PLANNER_OPENAI_MODEL);
+      expect(firstRequest.tool_choice).toBe("required");
+      expect(firstRequest.input).toEqual([{ role: "user", content: "Inspect the repository and return JSON issues." }]);
+      expect(firstRequest.tools.map((tool) => tool.name)).toEqual([
+        "list_repository_entries",
+        "read_repository_file",
+        "search_repository",
+      ]);
+
+      const secondRequest = JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string) as {
+        tool_choice: string;
+        input: Array<{ type?: string; call_id?: string; output?: string }>;
+      };
+      expect(secondRequest.tool_choice).toBe("auto");
+
+      const toolOutput = secondRequest.input.find((item) => item.type === "function_call_output");
+      expect(toolOutput).toEqual(
+        expect.objectContaining({
+          type: "function_call_output",
+          call_id: "call_list_repo",
+        }),
+      );
+
+      const parsedToolOutput = JSON.parse(toolOutput?.output ?? "{}") as {
+        ok: boolean;
+        entries: Array<{ path: string; type: string }>;
+      };
+      expect(parsedToolOutput.ok).toBe(true);
+      expect(parsedToolOutput.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "README.md", type: "file" }),
+          expect.objectContaining({ path: "src", type: "directory" }),
+        ]),
+      );
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads bounded repository file ranges for planner inspection", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "planner-openai-read-"));
+    await mkdir(join(workDir, "src"), { recursive: true });
+    await writeFile(join(workDir, "src", "example.ts"), "first\nsecond\nthird\nfourth\n", "utf8");
+
+    try {
+      const { runPlannerRepositoryTool } = await import("./plannerOpenAi.js");
+
+      const result = await runPlannerRepositoryTool(
+        "read_repository_file",
+        {
+          path: "src/example.ts",
+          startLine: 2,
+          lineCount: 2,
+        },
+        workDir,
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: true,
+          path: "src/example.ts",
+          startLine: 2,
+          endLine: 3,
+          totalLines: 4,
+          truncated: true,
+          content: "2: second\n3: third",
+        }),
+      );
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to JavaScript search when ripgrep is unavailable", async () => {
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], _options: unknown, callback: (error: Error, stdout: string, stderr: string) => void) => {
+        const error = Object.assign(new Error("ripgrep missing"), { code: "ENOENT" });
+        callback(error, "", "");
+      },
+    );
+
+    const workDir = await mkdtemp(join(tmpdir(), "planner-openai-search-"));
+    await writeFile(join(workDir, "notes.txt"), "first line\nplanner issue evidence\n", "utf8");
+
+    try {
+      const { runPlannerRepositoryTool } = await import("./plannerOpenAi.js");
+
+      const result = await runPlannerRepositoryTool(
+        "search_repository",
+        {
+          query: "planner",
+          path: ".",
+          limit: 5,
+        },
+        workDir,
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: true,
+          path: ".",
+          query: "planner",
+          fallback: "javascript-search",
+        }),
+      );
+      expect(result.results).toEqual([expect.stringContaining("notes.txt:2:planner issue evidence")]);
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/plannerOpenAi.ts
+++ b/src/agents/plannerOpenAi.ts
@@ -1,0 +1,745 @@
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { relative, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const OPENAI_RESPONSES_API_URL = "https://api.openai.com/v1/responses";
+export const PLANNER_OPENAI_MODEL = "gpt-5.3-codex";
+const PLANNER_MAX_TOOL_ROUNDS = 8;
+const PLANNER_REPOSITORY_LIST_LIMIT = 200;
+const PLANNER_REPOSITORY_READ_LINE_LIMIT = 400;
+const PLANNER_REPOSITORY_SEARCH_LIMIT = 50;
+const PLANNER_IGNORED_DIRECTORY_NAMES = new Set([".git", "node_modules", "dist"]);
+
+const PLANNER_SYSTEM_INSTRUCTIONS = [
+  "You are Evolvo's repository planner.",
+  "Inspect the repository with the available tools before proposing issues.",
+  "Start by inspecting repository structure or searching for likely hotspots, then read the specific files you rely on.",
+  "Ground every issue in current repository evidence and the open/closed issue history supplied in the user prompt.",
+  "Prefer reliability, runtime safety, validation quality, planning quality, observability, and operational robustness.",
+  "Keep each issue bounded, actionable, and specific to Evolvo's real codebase.",
+  "Do not propose duplicate, lightly reworded, generic, or follow-up-titled issues.",
+  "Return only JSON that matches the provided schema.",
+].join("\n");
+
+const PLANNER_RESPONSE_SCHEMA = {
+  type: "object",
+  properties: {
+    issues: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          description: { type: "string" },
+        },
+        required: ["title", "description"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["issues"],
+  additionalProperties: false,
+} as const;
+
+const PLANNER_REPOSITORY_TOOLS = [
+  {
+    type: "function",
+    name: "list_repository_entries",
+    description: "List files and directories under a repository path so you can orient yourself before reading code.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: {
+          type: ["string", "null"],
+          description: "Relative repository path to inspect. Use null or '.' for the repository root.",
+        },
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: PLANNER_REPOSITORY_LIST_LIMIT,
+          description: "Maximum number of entries to return.",
+        },
+      },
+      required: ["path", "limit"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+  {
+    type: "function",
+    name: "read_repository_file",
+    description: "Read a bounded range of lines from a repository file.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Relative repository file path to read.",
+        },
+        startLine: {
+          type: "integer",
+          minimum: 1,
+          description: "1-based line number to start reading from.",
+        },
+        lineCount: {
+          type: "integer",
+          minimum: 1,
+          maximum: PLANNER_REPOSITORY_READ_LINE_LIMIT,
+          description: "Maximum number of lines to read.",
+        },
+      },
+      required: ["path", "startLine", "lineCount"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+  {
+    type: "function",
+    name: "search_repository",
+    description: "Search repository files for symbols, strings, or architectural patterns.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The ripgrep-compatible pattern or exact symbol/string to search for.",
+        },
+        path: {
+          type: ["string", "null"],
+          description: "Optional relative repository path to limit the search. Use null or '.' for the whole repository.",
+        },
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: PLANNER_REPOSITORY_SEARCH_LIMIT,
+          description: "Maximum number of matching lines to return.",
+        },
+      },
+      required: ["query", "path", "limit"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+] as const;
+
+type PlannerResponseInputItem =
+  | {
+      role: "user";
+      content: string;
+    }
+  | PlannerResponseOutputItem
+  | {
+      type: "function_call_output";
+      call_id: string;
+      output: string;
+    };
+
+type PlannerResponseOutputItem =
+  | PlannerResponseMessageItem
+  | PlannerResponseFunctionCallItem
+  | PlannerResponseReasoningItem
+  | PlannerResponseUnknownItem;
+
+type PlannerResponseMessageItem = {
+  type: "message";
+  role?: string;
+  content?: Array<
+    | {
+        type: "output_text";
+        text?: string;
+      }
+    | {
+        type: "refusal";
+        refusal?: string;
+      }
+    | Record<string, unknown>
+  >;
+};
+
+type PlannerResponseFunctionCallItem = {
+  type: "function_call";
+  call_id?: string;
+  name?: string;
+  arguments?: string;
+};
+
+type PlannerResponseReasoningItem = {
+  type: "reasoning";
+};
+
+type PlannerResponseUnknownItem = {
+  type?: string;
+  [key: string]: unknown;
+};
+
+type PlannerApiResponse = {
+  status?: string;
+  error?: {
+    message?: string;
+  } | null;
+  incomplete_details?: {
+    reason?: string;
+  } | null;
+  output?: PlannerResponseOutputItem[];
+};
+
+type PlannerRepositoryToolResult = {
+  ok: boolean;
+  [key: string]: unknown;
+};
+
+type RunPlannerOpenAiInput = {
+  apiKey: string;
+  prompt: string;
+  workDir: string;
+};
+
+export type RunPlannerOpenAiResult = {
+  finalResponse: string;
+};
+
+export async function runPlannerOpenAi(input: RunPlannerOpenAiInput): Promise<RunPlannerOpenAiResult> {
+  const conversation: PlannerResponseInputItem[] = [{ role: "user", content: input.prompt }];
+  let toolCallCount = 0;
+
+  for (let round = 0; round < PLANNER_MAX_TOOL_ROUNDS; round += 1) {
+    const response = await createPlannerResponse({
+      apiKey: input.apiKey,
+      input: conversation,
+      requireInitialToolCall: round === 0,
+    });
+    const output = Array.isArray(response.output) ? response.output : [];
+    conversation.push(...output);
+
+    const functionCalls = output.filter(isPlannerResponseFunctionCall);
+    if (functionCalls.length === 0) {
+      const finalResponse = extractPlannerFinalResponse(response);
+      if (toolCallCount === 0) {
+        throw new Error("Planner completed without inspecting the repository.");
+      }
+
+      return { finalResponse };
+    }
+
+    toolCallCount += functionCalls.length;
+    for (const functionCall of functionCalls) {
+      conversation.push({
+        type: "function_call_output",
+        call_id: requireNonEmptyString(functionCall.call_id, "Planner function call did not include a call_id."),
+        output: JSON.stringify(
+          await runPlannerRepositoryTool(
+            requireNonEmptyString(functionCall.name, "Planner function call did not include a tool name."),
+            parsePlannerToolArguments(functionCall.arguments),
+            input.workDir,
+          ),
+        ),
+      });
+    }
+  }
+
+  throw new Error(`Planner exceeded the maximum tool-call rounds (${PLANNER_MAX_TOOL_ROUNDS}).`);
+}
+
+export async function runPlannerRepositoryTool(
+  name: string,
+  rawArguments: unknown,
+  workDir: string,
+): Promise<PlannerRepositoryToolResult> {
+  try {
+    switch (name) {
+      case "list_repository_entries":
+        return await listRepositoryEntries(rawArguments, workDir);
+      case "read_repository_file":
+        return await readRepositoryFile(rawArguments, workDir);
+      case "search_repository":
+        return await searchRepository(rawArguments, workDir);
+      default:
+        return {
+          ok: false,
+          error: `Unknown planner tool: ${name}`,
+        };
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      tool: name,
+    };
+  }
+}
+
+async function createPlannerResponse(options: {
+  apiKey: string;
+  input: PlannerResponseInputItem[];
+  requireInitialToolCall: boolean;
+}): Promise<PlannerApiResponse> {
+  const response = await fetch(OPENAI_RESPONSES_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${options.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: PLANNER_OPENAI_MODEL,
+      instructions: PLANNER_SYSTEM_INSTRUCTIONS,
+      input: options.input,
+      tools: PLANNER_REPOSITORY_TOOLS,
+      tool_choice: options.requireInitialToolCall ? "required" : "auto",
+      parallel_tool_calls: false,
+      reasoning: { effort: "medium" },
+      text: {
+        format: {
+          type: "json_schema",
+          name: "planner_issue_batch",
+          strict: true,
+          schema: PLANNER_RESPONSE_SCHEMA,
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await buildPlannerApiErrorMessage(response));
+  }
+
+  const parsed = (await response.json()) as PlannerApiResponse;
+  if (parsed.error?.message) {
+    throw new Error(`Planner API request failed: ${parsed.error.message}`);
+  }
+  if (parsed.status === "failed") {
+    throw new Error("Planner API request failed without an error message.");
+  }
+  if (parsed.status === "incomplete") {
+    const reason = parsed.incomplete_details?.reason?.trim();
+    throw new Error(
+      reason ? `Planner API response was incomplete: ${reason}` : "Planner API response was incomplete.",
+    );
+  }
+
+  return parsed;
+}
+
+async function buildPlannerApiErrorMessage(response: Response): Promise<string> {
+  const fallbackMessage = `Planner API request failed with status ${response.status}.`;
+  let rawBody = "";
+
+  try {
+    rawBody = await response.text();
+  } catch {
+    return fallbackMessage;
+  }
+
+  if (!rawBody.trim()) {
+    return fallbackMessage;
+  }
+
+  try {
+    const parsed = JSON.parse(rawBody) as {
+      error?: {
+        message?: string;
+      };
+    };
+    const message = parsed.error?.message?.trim();
+    if (message) {
+      return `Planner API request failed (${response.status}): ${message}`;
+    }
+  } catch {
+    // Fall back to raw text handling below.
+  }
+
+  return fallbackMessage;
+}
+
+function parsePlannerToolArguments(rawArguments: string | undefined): unknown {
+  if (typeof rawArguments !== "string" || rawArguments.trim().length === 0) {
+    throw new Error("Planner function call did not include arguments.");
+  }
+
+  return JSON.parse(rawArguments) as unknown;
+}
+
+function extractPlannerFinalResponse(response: PlannerApiResponse): string {
+  const output = Array.isArray(response.output) ? response.output : [];
+  const refusal = findPlannerRefusal(output);
+  if (refusal !== null) {
+    throw new Error(`Planner response was refused: ${refusal}`);
+  }
+
+  const texts: string[] = [];
+  for (const item of output) {
+    if (item.type !== "message" || !Array.isArray(item.content)) {
+      continue;
+    }
+
+    for (const contentItem of item.content) {
+      if (contentItem.type === "output_text" && typeof contentItem.text === "string" && contentItem.text.trim().length > 0) {
+        texts.push(contentItem.text);
+      }
+    }
+  }
+
+  const finalResponse = texts.join("\n").trim();
+  if (!finalResponse) {
+    throw new Error("Planner API response did not include assistant output text.");
+  }
+
+  return finalResponse;
+}
+
+function findPlannerRefusal(output: PlannerResponseOutputItem[]): string | null {
+  for (const item of output) {
+    if (item.type !== "message" || !Array.isArray(item.content)) {
+      continue;
+    }
+
+    for (const contentItem of item.content) {
+      if (contentItem.type === "refusal" && typeof contentItem.refusal === "string" && contentItem.refusal.trim().length > 0) {
+        return contentItem.refusal.trim();
+      }
+    }
+  }
+
+  return null;
+}
+
+function isPlannerResponseFunctionCall(item: PlannerResponseOutputItem): item is PlannerResponseFunctionCallItem {
+  return item.type === "function_call";
+}
+
+async function listRepositoryEntries(rawArguments: unknown, workDir: string): Promise<PlannerRepositoryToolResult> {
+  const args = expectObject(rawArguments, "Planner list_repository_entries arguments must be an object.");
+  const path = getNullableStringArgument(args, "path");
+  const limit = getPositiveIntegerArgument(args, "limit", 1, PLANNER_REPOSITORY_LIST_LIMIT);
+  const absolutePath = resolveRepositoryPath(workDir, path);
+  const stat = await fs.stat(absolutePath);
+
+  if (!stat.isDirectory()) {
+    throw new Error(`Repository path is not a directory: ${path ?? "."}`);
+  }
+
+  const directoryEntries = (await fs.readdir(absolutePath, { withFileTypes: true }))
+    .filter((entry) => !PLANNER_IGNORED_DIRECTORY_NAMES.has(entry.name))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const limitedEntries = directoryEntries.slice(0, limit);
+
+  return {
+    ok: true,
+    path: toRepositoryRelativePath(workDir, absolutePath),
+    entries: limitedEntries.map((entry) => {
+      const entryAbsolutePath = resolve(absolutePath, entry.name);
+      return {
+        path: toRepositoryRelativePath(workDir, entryAbsolutePath),
+        type: entry.isDirectory() ? "directory" : entry.isFile() ? "file" : "other",
+      };
+    }),
+    truncated: directoryEntries.length > limit,
+  };
+}
+
+async function readRepositoryFile(rawArguments: unknown, workDir: string): Promise<PlannerRepositoryToolResult> {
+  const args = expectObject(rawArguments, "Planner read_repository_file arguments must be an object.");
+  const path = getRequiredStringArgument(args, "path");
+  const startLine = getPositiveIntegerArgument(args, "startLine", 1, Number.MAX_SAFE_INTEGER);
+  const lineCount = getPositiveIntegerArgument(args, "lineCount", 1, PLANNER_REPOSITORY_READ_LINE_LIMIT);
+  const absolutePath = resolveRepositoryPath(workDir, path);
+  const stat = await fs.stat(absolutePath);
+
+  if (!stat.isFile()) {
+    throw new Error(`Repository path is not a file: ${path}`);
+  }
+
+  const fileContent = await fs.readFile(absolutePath, "utf8");
+  const lines = splitFileContentIntoLines(fileContent);
+  const startIndex = Math.max(0, startLine - 1);
+  const selectedLines = lines.slice(startIndex, startIndex + lineCount);
+
+  return {
+    ok: true,
+    path: toRepositoryRelativePath(workDir, absolutePath),
+    startLine,
+    endLine: startIndex + selectedLines.length,
+    totalLines: lines.length,
+    truncated: startIndex + selectedLines.length < lines.length,
+    content: selectedLines.map((line, index) => `${startIndex + index + 1}: ${line}`).join("\n"),
+  };
+}
+
+async function searchRepository(rawArguments: unknown, workDir: string): Promise<PlannerRepositoryToolResult> {
+  const args = expectObject(rawArguments, "Planner search_repository arguments must be an object.");
+  const query = getRequiredStringArgument(args, "query");
+  const path = getNullableStringArgument(args, "path");
+  const limit = getPositiveIntegerArgument(args, "limit", 1, PLANNER_REPOSITORY_SEARCH_LIMIT);
+  const absolutePath = resolveRepositoryPath(workDir, path);
+
+  return searchRepositoryWithRipgrep({ workDir, absolutePath, query, limit }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return searchRepositoryWithoutRipgrep({ workDir, absolutePath, query, limit });
+    }
+
+    throw error;
+  });
+}
+
+async function searchRepositoryWithRipgrep(options: {
+  workDir: string;
+  absolutePath: string;
+  query: string;
+  limit: number;
+}): Promise<PlannerRepositoryToolResult> {
+  const relativePath = toRepositoryRelativePath(options.workDir, options.absolutePath);
+  const args = [
+    "-n",
+    "--color",
+    "never",
+    "--hidden",
+    "--glob",
+    "!.git/**",
+    "--glob",
+    "!node_modules/**",
+    "--glob",
+    "!dist/**",
+    "--regexp",
+    options.query,
+    relativePath,
+  ];
+
+  try {
+    const { stdout } = await execFileAsync("rg", args, {
+      cwd: options.workDir,
+      maxBuffer: 1024 * 1024,
+    });
+    const lines = splitSearchOutput(stdout, options.limit);
+    return {
+      ok: true,
+      path: relativePath,
+      query: options.query,
+      results: lines,
+      truncated: countSearchLines(stdout) > options.limit,
+    };
+  } catch (error) {
+    const execError = error as Error & {
+      code?: number | string;
+      stdout?: string;
+      stderr?: string;
+    };
+    if (execError.code === 1) {
+      return {
+        ok: true,
+        path: relativePath,
+        query: options.query,
+        results: [],
+        truncated: false,
+      };
+    }
+    if (typeof execError.code === "number" && execError.code > 1) {
+      const stderr = typeof execError.stderr === "string" ? execError.stderr.trim() : "";
+      throw new Error(stderr || `ripgrep search failed with exit code ${execError.code}.`);
+    }
+
+    throw error;
+  }
+}
+
+async function searchRepositoryWithoutRipgrep(options: {
+  workDir: string;
+  absolutePath: string;
+  query: string;
+  limit: number;
+}): Promise<PlannerRepositoryToolResult> {
+  const relativePath = toRepositoryRelativePath(options.workDir, options.absolutePath);
+  const results: string[] = [];
+  const matcher = buildFallbackSearchMatcher(options.query);
+
+  await walkSearchPath(options.workDir, options.absolutePath, async (filePath) => {
+    if (results.length >= options.limit) {
+      return true;
+    }
+
+    try {
+      const content = await fs.readFile(filePath, "utf8");
+      const lines = splitFileContentIntoLines(content);
+      for (let index = 0; index < lines.length; index += 1) {
+        if (matchesSearchLine(lines[index], matcher)) {
+          results.push(`${toRepositoryRelativePath(options.workDir, filePath)}:${index + 1}:${lines[index]}`);
+          if (results.length >= options.limit) {
+            return true;
+          }
+        }
+      }
+    } catch {
+      return false;
+    }
+
+    return false;
+  });
+
+  return {
+    ok: true,
+    path: relativePath,
+    query: options.query,
+    results,
+    truncated: false,
+    fallback: "javascript-search",
+  };
+}
+
+async function walkSearchPath(
+  workDir: string,
+  absolutePath: string,
+  visitFile: (filePath: string) => Promise<boolean>,
+): Promise<boolean> {
+  const stat = await fs.stat(absolutePath);
+  if (stat.isFile()) {
+    return visitFile(absolutePath);
+  }
+  if (!stat.isDirectory()) {
+    return false;
+  }
+
+  const directoryEntries = (await fs.readdir(absolutePath, { withFileTypes: true }))
+    .filter((entry) => !PLANNER_IGNORED_DIRECTORY_NAMES.has(entry.name))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of directoryEntries) {
+    const entryAbsolutePath = resolve(absolutePath, entry.name);
+    const entryRelativePath = toRepositoryRelativePath(workDir, entryAbsolutePath);
+    if (PLANNER_IGNORED_DIRECTORY_NAMES.has(entry.name) || PLANNER_IGNORED_DIRECTORY_NAMES.has(entryRelativePath)) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      if (await walkSearchPath(workDir, entryAbsolutePath, visitFile)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (entry.isFile() && (await visitFile(entryAbsolutePath))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function splitSearchOutput(stdout: string, limit: number): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .slice(0, limit);
+}
+
+function countSearchLines(stdout: string): number {
+  return stdout.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+}
+
+function splitFileContentIntoLines(content: string): string[] {
+  const lines = content.split(/\r?\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  return lines;
+}
+
+function buildFallbackSearchMatcher(query: string): RegExp | string {
+  try {
+    return new RegExp(query);
+  } catch {
+    return query;
+  }
+}
+
+function matchesSearchLine(line: string, matcher: RegExp | string): boolean {
+  if (matcher instanceof RegExp) {
+    matcher.lastIndex = 0;
+    return matcher.test(line);
+  }
+
+  return line.includes(matcher);
+}
+
+function resolveRepositoryPath(workDir: string, toolPath: string | null): string {
+  const requestedPath = normalizeRequestedRepositoryPath(toolPath);
+  const absolutePath = resolve(workDir, requestedPath);
+  const relativePath = relative(workDir, absolutePath);
+  if (relativePath.startsWith("..") || resolve(workDir, relativePath) !== absolutePath) {
+    throw new Error(`Planner tool path must stay within the repository: ${requestedPath}`);
+  }
+
+  return absolutePath;
+}
+
+function toRepositoryRelativePath(workDir: string, absolutePath: string): string {
+  const relativePath = relative(workDir, absolutePath);
+  return relativePath.length === 0 ? "." : relativePath.split("\\").join("/");
+}
+
+function normalizeRequestedRepositoryPath(toolPath: string | null): string {
+  if (toolPath === null) {
+    return ".";
+  }
+
+  const normalized = toolPath.trim();
+  return normalized.length === 0 ? "." : normalized;
+}
+
+function expectObject(value: unknown, errorMessage: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(errorMessage);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function getRequiredStringArgument(args: Record<string, unknown>, name: string): string {
+  const value = args[name];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Planner tool argument "${name}" must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function getNullableStringArgument(args: Record<string, unknown>, name: string): string | null {
+  const value = args[name];
+  if (value === null || typeof value === "undefined") {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`Planner tool argument "${name}" must be a string or null.`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? "." : trimmed;
+}
+
+function getPositiveIntegerArgument(
+  args: Record<string, unknown>,
+  name: string,
+  minimum: number,
+  maximum: number,
+): number {
+  const value = args[name];
+  if (!Number.isInteger(value)) {
+    throw new Error(`Planner tool argument "${name}" must be an integer.`);
+  }
+
+  const numericValue = value as number;
+  if (numericValue < minimum || numericValue > maximum) {
+    throw new Error(`Planner tool argument "${name}" must be between ${minimum} and ${maximum}.`);
+  }
+
+  return numericValue;
+}
+
+function requireNonEmptyString(value: string | undefined, errorMessage: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(errorMessage);
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary
- migrate the planner from the Codex SDK path to direct OpenAI Responses API calls with `gpt-5.3-codex`
- give the planner bounded local repository tools for listing, reading, and searching files before it proposes issues
- keep planner orchestration and failure-artifact behavior in `plannerAgent.ts` and cover the new helper with dedicated tests

## Validation
- pnpm exec vitest run src/agents/plannerAgent.test.ts src/agents/plannerOpenAi.test.ts
- pnpm lint
- pnpm exec tsc --noEmit -p tsconfig.json
- pnpm test

Closes #362