### PR TITLE
fix: move managed project workspaces under /home/paddy

### DIFF
--- a/src/agents/codingAgent.test.ts
+++ b/src/agents/codingAgent.test.ts
@@ -72,11 +72,11 @@ describe("buildCodingPrompt", () => {
   });
 
   it("builds thread options for a resolved project working directory", () => {
-    const options = buildCodingAgentThreadOptions("/tmp/evolvo/projects/habit-cli");
+    const options = buildCodingAgentThreadOptions("/home/paddy/habit-cli");
 
     expect(options).toEqual({
       ...CODING_AGENT_THREAD_OPTIONS,
-      workingDirectory: "/tmp/evolvo/projects/habit-cli",
+      workingDirectory: "/home/paddy/habit-cli",
     });
   });
 });

--- a/src/agents/runCodingAgent.test.ts
+++ b/src/agents/runCodingAgent.test.ts
@@ -450,7 +450,7 @@ describe("runCodingAgent", () => {
 
     const { configureCodingAgentExecutionContext, runCodingAgent } = await import("./runCodingAgent.js");
     configureCodingAgentExecutionContext({
-      workDir: "/tmp/evolvo/projects/habit-cli",
+      workDir: "/home/paddy/habit-cli",
       internalRepositoryUrls: [
         "https://github.com/evolvo-auto/evolvo-ts",
         "https://github.com/evolvo-auto/habit-cli",
@@ -460,7 +460,7 @@ describe("runCodingAgent", () => {
 
     expect(startThreadMock).toHaveBeenCalledWith({
       sandboxMode: "workspace-write",
-      workingDirectory: "/tmp/evolvo/projects/habit-cli",
+      workingDirectory: "/home/paddy/habit-cli",
     });
     expect(result.summary.externalRepositories).toEqual([]);
     expect(result.summary.externalPullRequests).toEqual([]);

--- a/src/issues/projectProvisioningIssue.test.ts
+++ b/src/issues/projectProvisioningIssue.test.ts
@@ -26,7 +26,7 @@ describe("projectProvisioningIssue", () => {
       slug: "habit-cli",
       repositoryName: "habit-cli",
       issueLabel: "project:habit-cli",
-      workspaceRelativePath: "projects/habit-cli",
+      workspacePath: "/home/paddy/habit-cli",
       requestedBy: "discord:operator-1",
       requestedAt: "2026-03-07T12:00:00.000Z",
     });
@@ -38,7 +38,7 @@ describe("projectProvisioningIssue", () => {
       slug: "habit-cli",
       repositoryName: "habit-cli",
       issueLabel: "project:habit-cli",
-      workspaceRelativePath: "projects/habit-cli",
+      workspacePath: "/home/paddy/habit-cli",
       requestedBy: "discord:operator-1",
       requestedAt: "2026-03-07T12:00:00.000Z",
     });
@@ -53,7 +53,7 @@ describe("projectProvisioningIssue", () => {
         slug: "habit-cli",
         repositoryName: "habit-cli",
         issueLabel: "project:habit-cli",
-        workspaceRelativePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         requestedBy: "discord:operator-1",
         requestedAt: "2026-03-07T12:00:00.000Z",
       }),
@@ -67,5 +67,31 @@ describe("projectProvisioningIssue", () => {
       parseProjectProvisioningIssueMetadata("<!-- evolvo:project-provisioning\nslug: habit-cli\n-->"),
     ).toBeNull();
     expect(isProjectProvisioningIssue(createIssue())).toBe(false);
+  });
+
+  it("parses legacy workspace_relative_path metadata for backward compatibility", () => {
+    expect(
+      parseProjectProvisioningIssueMetadata([
+        "<!-- evolvo:project-provisioning",
+        "owner: evolvo-auto",
+        "display_name: Habit CLI",
+        "slug: habit-cli",
+        "repo_name: habit-cli",
+        "issue_label: project:habit-cli",
+        "workspace_relative_path: projects/habit-cli",
+        "requested_by: discord:operator-1",
+        "requested_at: 2026-03-07T12:00:00.000Z",
+        "-->",
+      ].join("\n")),
+    ).toEqual({
+      owner: "evolvo-auto",
+      displayName: "Habit CLI",
+      slug: "habit-cli",
+      repositoryName: "habit-cli",
+      issueLabel: "project:habit-cli",
+      workspacePath: "projects/habit-cli",
+      requestedBy: "discord:operator-1",
+      requestedAt: "2026-03-07T12:00:00.000Z",
+    });
   });
 });

--- a/src/issues/projectProvisioningIssue.ts
+++ b/src/issues/projectProvisioningIssue.ts
@@ -6,7 +6,7 @@ export type ProjectProvisioningIssueMetadata = {
   slug: string;
   repositoryName: string;
   issueLabel: string;
-  workspaceRelativePath: string;
+  workspacePath: string;
   requestedBy: string;
   requestedAt: string;
 };
@@ -35,7 +35,7 @@ export function buildProjectProvisioningIssueBody(metadata: ProjectProvisioningI
     `slug: ${metadata.slug}`,
     `repo_name: ${metadata.repositoryName}`,
     `issue_label: ${metadata.issueLabel}`,
-    `workspace_relative_path: ${metadata.workspaceRelativePath}`,
+    `workspace_path: ${metadata.workspacePath}`,
     `requested_by: ${metadata.requestedBy}`,
     `requested_at: ${metadata.requestedAt}`,
     "-->",
@@ -43,7 +43,7 @@ export function buildProjectProvisioningIssueBody(metadata: ProjectProvisioningI
     "## Requested Targets",
     `- Tracker label: \`${metadata.issueLabel}\``,
     `- Managed repository: \`${metadata.owner}/${metadata.repositoryName}\``,
-    `- Local workspace: \`${metadata.workspaceRelativePath}\``,
+    `- Local workspace: \`${metadata.workspacePath}\``,
     "",
     "## Execution Notes",
     "- Run provisioning on the default Evolvo workflow.",
@@ -92,8 +92,8 @@ export function parseProjectProvisioningIssueMetadata(
     if (key === "issue_label") {
       metadata.issueLabel = value;
     }
-    if (key === "workspace_relative_path") {
-      metadata.workspaceRelativePath = value;
+    if (key === "workspace_path" || key === "workspace_relative_path") {
+      metadata.workspacePath = value;
     }
     if (key === "requested_by") {
       metadata.requestedBy = value;
@@ -108,7 +108,7 @@ export function parseProjectProvisioningIssueMetadata(
   const slug = normalizeNonEmptyString(metadata.slug);
   const repositoryName = normalizeNonEmptyString(metadata.repositoryName);
   const issueLabel = normalizeNonEmptyString(metadata.issueLabel);
-  const workspaceRelativePath = normalizeNonEmptyString(metadata.workspaceRelativePath);
+  const workspacePath = normalizeNonEmptyString(metadata.workspacePath);
   const requestedBy = normalizeNonEmptyString(metadata.requestedBy);
   const requestedAt = normalizeNonEmptyString(metadata.requestedAt);
 
@@ -118,7 +118,7 @@ export function parseProjectProvisioningIssueMetadata(
     !slug ||
     !repositoryName ||
     !issueLabel ||
-    !workspaceRelativePath ||
+    !workspacePath ||
     !requestedBy ||
     !requestedAt
   ) {
@@ -131,7 +131,7 @@ export function parseProjectProvisioningIssueMetadata(
     slug,
     repositoryName,
     issueLabel,
-    workspaceRelativePath,
+    workspacePath,
     requestedBy,
     requestedAt,
   };

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -298,7 +298,7 @@ describe("main", () => {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
-        workspacePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         status: "provisioning",
       },
       trackerIssue: {
@@ -316,7 +316,7 @@ describe("main", () => {
         slug: "habit-cli",
         repositoryName: "habit-cli",
         issueLabel: "project:habit-cli",
-        workspaceRelativePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         requestedBy: "discord:operator-1",
         requestedAt: "2026-03-07T12:00:00.000Z",
       },
@@ -336,7 +336,7 @@ describe("main", () => {
           url: "https://github.com/owner/habit-cli",
           defaultBranch: "main",
         },
-        cwd: "/tmp/evolvo/projects/habit-cli",
+        cwd: "/home/paddy/habit-cli",
         status: "active",
         sourceIssueNumber: 400,
         createdAt: "2026-03-07T12:00:00.000Z",
@@ -349,6 +349,7 @@ describe("main", () => {
         },
       },
       failureStep: null,
+      workspaceAction: "created",
       message: "Provisioned project Habit CLI.",
     });
     isProjectProvisioningRequestIssueMock.mockReset();
@@ -585,7 +586,7 @@ describe("main", () => {
       slug: "habit-cli",
       repositoryName: "habit-cli",
       issueLabel: "project:habit-cli",
-      workspaceRelativePath: "projects/habit-cli",
+      workspacePath: "/home/paddy/habit-cli",
     });
 
     expect(handleStartProjectCommandMock).toHaveBeenCalledWith({
@@ -605,7 +606,7 @@ describe("main", () => {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
-        workspacePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         status: "provisioning",
       },
       trackerIssue: {
@@ -615,7 +616,7 @@ describe("main", () => {
       },
     });
     expect(console.log).toHaveBeenCalledWith(
-      "[startProject] created new project flow for Habit CLI (habit-cli).",
+      "[startProject] created new project flow for Habit CLI (habit-cli) at /home/paddy/habit-cli.",
     );
   });
 
@@ -636,7 +637,7 @@ describe("main", () => {
             url: "https://github.com/owner/habit-cli",
             defaultBranch: "main",
           },
-          cwd: "/tmp/evolvo/projects/habit-cli",
+          cwd: "/home/paddy/habit-cli",
         },
       ],
     });
@@ -753,7 +754,7 @@ describe("main", () => {
         slug: "habit-cli",
         repositoryName: "habit-cli",
         issueLabel: "project:habit-cli",
-        workspaceRelativePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         requestedBy: "discord:operator-1",
         requestedAt: "2026-03-07T12:00:00.000Z",
       },
@@ -773,7 +774,7 @@ describe("main", () => {
           url: "https://github.com/owner/habit-cli",
           defaultBranch: "main",
         },
-        cwd: "/tmp/evolvo/projects/habit-cli",
+        cwd: "/home/paddy/habit-cli",
         status: "failed",
         sourceIssueNumber: 78,
         createdAt: "2026-03-07T12:00:00.000Z",
@@ -786,6 +787,7 @@ describe("main", () => {
         },
       },
       failureStep: "workspace",
+      workspaceAction: null,
       message: "workspace failed",
     });
     const { main } = await import("./main.js");
@@ -899,7 +901,7 @@ describe("main", () => {
             url: "https://github.com/owner/habit-cli",
             defaultBranch: "main",
           },
-          cwd: "/tmp/evolvo/projects/habit-cli",
+          cwd: "/home/paddy/habit-cli",
           status: "active",
           sourceIssueNumber: 318,
           createdAt: "2026-03-07T12:00:00.000Z",
@@ -935,7 +937,7 @@ describe("main", () => {
       lifecycleState: "selected -> executing",
     });
     expect(configureCodingAgentExecutionContextMock).toHaveBeenCalledWith({
-      workDir: "/tmp/evolvo/projects/habit-cli",
+      workDir: "/home/paddy/habit-cli",
       internalRepositoryUrls: [
         "https://github.com/tracker-org/issue-tracker",
         "https://github.com/owner/habit-cli",
@@ -978,7 +980,7 @@ describe("main", () => {
             url: "https://github.com/owner/habit-cli",
             defaultBranch: "main",
           },
-          cwd: "/tmp/evolvo/projects/habit-cli",
+          cwd: "/home/paddy/habit-cli",
         },
         trackerRepository: "owner/repo",
         executionRepository: "owner/habit-cli",

--- a/src/main.ts
+++ b/src/main.ts
@@ -330,8 +330,8 @@ export async function main(): Promise<void> {
         stoppedProjectIdleLoggedSlug = null;
         console.log(
           result.action === "created"
-            ? `[startProject] created new project flow for ${result.project.displayName} (${result.project.slug}).`
-            : `[startProject] resumed existing project ${result.project.displayName} (${result.project.slug}) with status ${result.project.status}.`,
+            ? `[startProject] created new project flow for ${result.project.displayName} (${result.project.slug}) at ${result.project.workspacePath}.`
+            : `[startProject] resumed existing project ${result.project.displayName} (${result.project.slug}) with status ${result.project.status} at ${result.project.workspacePath}.`,
         );
       } else {
         console.error(`[startProject] failed for ${request.displayName}: ${result.message}`);

--- a/src/projects/projectNaming.test.ts
+++ b/src/projects/projectNaming.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  MANAGED_PROJECT_WORKSPACE_ROOT,
   buildProjectIssueLabel,
   normalizeProjectNameInput,
 } from "./projectNaming.js";
@@ -11,12 +12,18 @@ describe("projectNaming", () => {
       slug: "habit-cli",
       repositoryName: "habit-cli",
       issueLabel: "project:habit-cli",
-      workspaceRelativePath: "projects/habit-cli",
+      workspacePath: `${MANAGED_PROJECT_WORKSPACE_ROOT}/habit-cli`,
     });
   });
 
   it("builds reserved project labels", () => {
     expect(buildProjectIssueLabel("habit-cli")).toBe("project:habit-cli");
+  });
+
+  it("supports overriding the managed workspace root", () => {
+    expect(normalizeProjectNameInput("Habit CLI", { workspaceRoot: "/tmp/workspaces" }).workspacePath).toBe(
+      "/tmp/workspaces/habit-cli",
+    );
   });
 
   it("rejects whitespace-only project names", () => {

--- a/src/projects/projectNaming.ts
+++ b/src/projects/projectNaming.ts
@@ -1,19 +1,34 @@
+import { join } from "node:path";
+
 export const DEFAULT_PROJECT_SLUG = "evolvo";
 export const PROJECT_LABEL_PREFIX = "project:";
+export const MANAGED_PROJECT_WORKSPACE_ROOT = "/home/paddy";
 
 export type NormalizedProjectName = {
   displayName: string;
   slug: string;
   repositoryName: string;
   issueLabel: string;
-  workspaceRelativePath: string;
+  workspacePath: string;
 };
 
 export function buildProjectIssueLabel(slug: string): string {
   return `${PROJECT_LABEL_PREFIX}${slug}`;
 }
 
-export function normalizeProjectNameInput(input: string): NormalizedProjectName {
+export function resolveManagedProjectWorkspacePath(
+  slug: string,
+  workspaceRoot = MANAGED_PROJECT_WORKSPACE_ROOT,
+): string {
+  return join(workspaceRoot, slug);
+}
+
+export function normalizeProjectNameInput(
+  input: string,
+  options: {
+    workspaceRoot?: string;
+  } = {},
+): NormalizedProjectName {
   const displayName = input.trim().replace(/\s+/g, " ");
   if (!displayName) {
     throw new Error("Project name is required.");
@@ -41,6 +56,6 @@ export function normalizeProjectNameInput(input: string): NormalizedProjectName 
     slug,
     repositoryName: slug,
     issueLabel: buildProjectIssueLabel(slug),
-    workspaceRelativePath: `projects/${slug}`,
+    workspacePath: resolveManagedProjectWorkspacePath(slug, options.workspaceRoot),
   };
 }

--- a/src/projects/projectProvisioning.test.ts
+++ b/src/projects/projectProvisioning.test.ts
@@ -19,6 +19,10 @@ async function createTempWorkDir(): Promise<string> {
   return mkdtemp(join(tmpdir(), "project-provisioning-"));
 }
 
+function createManagedWorkspacePath(workDir: string, slug = "habit-cli"): string {
+  return resolve(workDir, slug);
+}
+
 function createProvisioningIssue(description: string): IssueSummary {
   return {
     number: 318,
@@ -64,6 +68,7 @@ describe("projectProvisioning", () => {
       projectName: " Habit   CLI ",
       requestedBy: "discord:operator-1",
       requestedAt: "2026-03-07T12:00:00.000Z",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual({
@@ -77,7 +82,7 @@ describe("projectProvisioning", () => {
         slug: "habit-cli",
         repositoryName: "habit-cli",
         issueLabel: "project:habit-cli",
-        workspaceRelativePath: "projects/habit-cli",
+        workspacePath: createManagedWorkspacePath(workDir),
         requestedBy: "discord:operator-1",
         requestedAt: "2026-03-07T12:00:00.000Z",
       },
@@ -102,7 +107,7 @@ describe("projectProvisioning", () => {
             slug: "habit-cli",
             repositoryName: "habit-cli",
             issueLabel: "project:habit-cli",
-            workspaceRelativePath: "projects/habit-cli",
+            workspacePath: createManagedWorkspacePath(workDir),
             requestedBy: "discord:operator-1",
             requestedAt: "2026-03-07T12:00:00.000Z",
           }),
@@ -120,6 +125,7 @@ describe("projectProvisioning", () => {
       trackerRepo: "evolvo-ts",
       projectName: "Habit CLI",
       requestedBy: "discord:operator-1",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual({
@@ -155,7 +161,7 @@ describe("projectProvisioning", () => {
           url: "https://github.com/evolvo-auto/habit-cli",
           defaultBranch: "main",
         },
-        cwd: resolve(workDir, "projects", "habit-cli"),
+        cwd: createManagedWorkspacePath(workDir),
         status: "failed",
         sourceIssueNumber: 318,
         createdAt: "2026-03-07T12:00:00.000Z",
@@ -190,6 +196,7 @@ describe("projectProvisioning", () => {
       trackerRepo: "evolvo-ts",
       projectName: "Habit CLI",
       requestedBy: "discord:operator-1",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual(
@@ -234,6 +241,7 @@ describe("projectProvisioning", () => {
       trackerRepo: "evolvo-ts",
       projectName: "Habit CLI",
       requestedBy: "discord:operator-1",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual(
@@ -282,17 +290,18 @@ describe("projectProvisioning", () => {
       projectName: "Habit CLI",
       requestedBy: "discord:operator-1",
       requestedAt: "2026-03-08T08:00:00.000Z",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual({
       ok: true,
       action: "created",
-      message: "Created provisioning issue #405 for project `habit-cli`.",
+      message: `Created provisioning issue #405 for project \`habit-cli\`. Canonical workspace: \`${createManagedWorkspacePath(workDir)}\`.`,
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
-        workspacePath: "projects/habit-cli",
+        workspacePath: createManagedWorkspacePath(workDir),
         status: "provisioning",
       },
       trackerIssue: {
@@ -314,6 +323,8 @@ describe("projectProvisioning", () => {
   it("resumes an existing active project without creating a new provisioning issue", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await mkdir(createManagedWorkspacePath(workDir), { recursive: true });
     await upsertProjectRecord(
       workDir,
       {
@@ -337,7 +348,7 @@ describe("projectProvisioning", () => {
           url: "https://github.com/evolvo-auto/habit-cli",
           defaultBranch: "main",
         },
-        cwd: resolve(workDir, "projects", "habit-cli"),
+        cwd: createManagedWorkspacePath(workDir),
         status: "active",
         sourceIssueNumber: 318,
         createdAt: "2026-03-07T12:00:00.000Z",
@@ -363,18 +374,19 @@ describe("projectProvisioning", () => {
       projectName: "Habit CLI",
       requestedBy: "discord:operator-1",
       requestedAt: "2026-03-08T08:05:00.000Z",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual({
       ok: true,
       action: "resumed",
-      message: "Resumed existing project `habit-cli`.",
+      message: `Resumed existing project \`habit-cli\`. Reused existing workspace directory \`${createManagedWorkspacePath(workDir)}\`, and that path is now the active working directory.`,
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
         repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
-        workspacePath: resolve(workDir, "projects", "habit-cli"),
+        workspacePath: createManagedWorkspacePath(workDir),
         status: "active",
       },
     });
@@ -387,6 +399,9 @@ describe("projectProvisioning", () => {
       requestedBy: "discord:operator-1",
       source: "start-project-command",
     });
+    expect(logSpy).toHaveBeenCalledWith(
+      `[project-workspace] resolved ${createManagedWorkspacePath(workDir)}; reused existing directory; ${createManagedWorkspacePath(workDir)} is now the active working directory for project habit-cli.`,
+    );
   });
 
   it("resumes a failed project by reusing its existing recovery issue", async () => {
@@ -415,7 +430,7 @@ describe("projectProvisioning", () => {
           url: "https://github.com/evolvo-auto/habit-cli",
           defaultBranch: "main",
         },
-        cwd: resolve(workDir, "projects", "habit-cli"),
+        cwd: createManagedWorkspacePath(workDir),
         status: "failed",
         sourceIssueNumber: 318,
         createdAt: "2026-03-07T12:00:00.000Z",
@@ -439,7 +454,7 @@ describe("projectProvisioning", () => {
             slug: "habit-cli",
             repositoryName: "habit-cli",
             issueLabel: "project:habit-cli",
-            workspaceRelativePath: "projects/habit-cli",
+            workspacePath: createManagedWorkspacePath(workDir),
             requestedBy: "discord:operator-1",
             requestedAt: "2026-03-08T07:50:00.000Z",
           }),
@@ -458,18 +473,19 @@ describe("projectProvisioning", () => {
       projectName: "Habit CLI",
       requestedBy: "discord:operator-1",
       requestedAt: "2026-03-08T08:10:00.000Z",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual({
       ok: true,
       action: "resumed",
-      message: "Resumed existing project `habit-cli` and kept recovery issue #406 active.",
+      message: `Resumed existing project \`habit-cli\` and kept recovery issue #406 active. Canonical workspace: \`${createManagedWorkspacePath(workDir)}\`.`,
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
         repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
-        workspacePath: resolve(workDir, "projects", "habit-cli"),
+        workspacePath: createManagedWorkspacePath(workDir),
         status: "failed",
       },
       trackerIssue: {
@@ -507,7 +523,7 @@ describe("projectProvisioning", () => {
           url: "https://github.com/evolvo-auto/habit-cli",
           defaultBranch: "main",
         },
-        cwd: resolve(workDir, "projects", "habit-cli"),
+        cwd: createManagedWorkspacePath(workDir),
         status: "failed",
         sourceIssueNumber: 318,
         createdAt: "2026-03-07T12:00:00.000Z",
@@ -543,18 +559,19 @@ describe("projectProvisioning", () => {
       projectName: "Habit CLI",
       requestedBy: "discord:operator-1",
       requestedAt: "2026-03-08T08:15:00.000Z",
+      workspaceRoot: workDir,
     });
 
     expect(result).toEqual({
       ok: true,
       action: "resumed",
-      message: "Resumed existing project `habit-cli` and queued recovery issue #407.",
+      message: `Resumed existing project \`habit-cli\` and queued recovery issue #407. Canonical workspace: \`${createManagedWorkspacePath(workDir)}\`.`,
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
         repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
-        workspacePath: resolve(workDir, "projects", "habit-cli"),
+        workspacePath: createManagedWorkspacePath(workDir),
         status: "failed",
       },
       trackerIssue: {
@@ -576,6 +593,7 @@ describe("projectProvisioning", () => {
   it("provisions a managed project and records active registry state on success", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     const issue = createProvisioningIssue(
       buildProjectProvisioningIssueBody({
         owner: "evolvo-auto",
@@ -583,7 +601,7 @@ describe("projectProvisioning", () => {
         slug: "habit-cli",
         repositoryName: "habit-cli",
         issueLabel: "project:habit-cli",
-        workspaceRelativePath: "projects/habit-cli",
+        workspacePath: createManagedWorkspacePath(workDir),
         requestedBy: "discord:operator-1",
         requestedAt: "2026-03-07T12:00:00.000Z",
       }),
@@ -604,6 +622,7 @@ describe("projectProvisioning", () => {
       trackerOwner: "evolvo-auto",
       trackerRepo: "evolvo-ts",
       adminClient,
+      workspaceRoot: workDir,
     });
 
     expect(isProjectProvisioningRequestIssue(issue)).toBe(true);
@@ -632,7 +651,7 @@ describe("projectProvisioning", () => {
         }),
       }),
     );
-    expect(resolve(workDir, "projects", "habit-cli")).toBe(result.record.cwd);
+    expect(createManagedWorkspacePath(workDir)).toBe(result.record.cwd);
     expect(JSON.parse(await readFile(getActiveProjectStatePath(workDir), "utf8"))).toEqual({
       version: 2,
       activeProjectSlug: "habit-cli",
@@ -641,12 +660,15 @@ describe("projectProvisioning", () => {
       requestedBy: "discord:operator-1",
       source: "project-provisioning",
     });
+    expect(logSpy).toHaveBeenCalledWith(
+      `[project-workspace] resolved ${createManagedWorkspacePath(workDir)}; created directory; ${createManagedWorkspacePath(workDir)} is now the active working directory for project habit-cli.`,
+    );
   });
 
   it("preserves partial success in failed registry state when workspace preparation fails", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
-    await writeFile(join(workDir, "projects"), "not a directory", "utf8");
+    await writeFile(createManagedWorkspacePath(workDir), "not a directory", "utf8");
     const issue = createProvisioningIssue(
       buildProjectProvisioningIssueBody({
         owner: "evolvo-auto",
@@ -654,7 +676,7 @@ describe("projectProvisioning", () => {
         slug: "habit-cli",
         repositoryName: "habit-cli",
         issueLabel: "project:habit-cli",
-        workspaceRelativePath: "projects/habit-cli",
+        workspacePath: createManagedWorkspacePath(workDir),
         requestedBy: "discord:operator-1",
         requestedAt: "2026-03-07T12:00:00.000Z",
       }),
@@ -675,6 +697,7 @@ describe("projectProvisioning", () => {
       trackerOwner: "evolvo-auto",
       trackerRepo: "evolvo-ts",
       adminClient,
+      workspaceRoot: workDir,
     });
 
     expect(result.ok).toBe(false);

--- a/src/projects/projectProvisioning.ts
+++ b/src/projects/projectProvisioning.ts
@@ -1,5 +1,4 @@
-import { mkdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdir, stat } from "node:fs/promises";
 import {
   buildProjectProvisioningIssueBody,
   buildProjectProvisioningIssueTitle,
@@ -9,7 +8,10 @@ import {
 } from "../issues/projectProvisioningIssue.js";
 import type { IssueSummary, TaskIssueManager } from "../issues/taskIssueManager.js";
 import { setActiveProjectState } from "./activeProjectState.js";
-import { normalizeProjectNameInput } from "./projectNaming.js";
+import {
+  normalizeProjectNameInput,
+  resolveManagedProjectWorkspacePath,
+} from "./projectNaming.js";
 import {
   findProjectBySlug,
   readProjectRegistry,
@@ -99,6 +101,7 @@ export type ProjectProvisioningExecutionResult = {
   metadata: ProjectProvisioningIssueMetadata;
   record: ProjectRecord;
   failureStep: "registry" | "label" | "repository" | "workspace" | "active-project" | null;
+  workspaceAction: "created" | "reused" | null;
   message: string;
 };
 
@@ -118,10 +121,45 @@ function buildDefaultProjectContext(workDir: string, owner: string, repo: string
   };
 }
 
+function canonicalizeProjectProvisioningMetadata(
+  metadata: ProjectProvisioningIssueMetadata,
+  workspaceRoot?: string,
+): ProjectProvisioningIssueMetadata {
+  return {
+    ...metadata,
+    workspacePath: resolveManagedProjectWorkspacePath(metadata.slug, workspaceRoot),
+  };
+}
+
+async function ensureManagedProjectWorkspaceDirectory(workspacePath: string): Promise<{
+  workspacePath: string;
+  workspaceAction: "created" | "reused";
+}> {
+  let workspaceAction: "created" | "reused" = "created";
+
+  try {
+    const currentPath = await stat(workspacePath);
+    if (!currentPath.isDirectory()) {
+      throw new Error(`Managed project workspace path ${workspacePath} exists but is not a directory.`);
+    }
+    workspaceAction = "reused";
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  await mkdir(workspacePath, { recursive: true });
+  return {
+    workspacePath,
+    workspaceAction,
+  };
+}
+
 function buildManagedProjectRecord(
   metadata: ProjectProvisioningIssueMetadata,
   options: {
-    workDir: string;
     trackerOwner: string;
     trackerRepo: string;
     issueNumber: number;
@@ -129,7 +167,6 @@ function buildManagedProjectRecord(
   },
   existing: ProjectRecord | null,
 ): ProjectRecord {
-  const workspacePath = resolve(options.workDir, metadata.workspaceRelativePath);
   const createdAt = existing?.createdAt ?? options.now;
 
   return {
@@ -148,7 +185,7 @@ function buildManagedProjectRecord(
       url: existing?.executionRepo.url ?? buildRepositoryUrl(metadata.owner, metadata.repositoryName),
       defaultBranch: existing?.executionRepo.defaultBranch ?? null,
     },
-    cwd: existing?.cwd ?? workspacePath,
+    cwd: metadata.workspacePath,
     status: existing?.status ?? "provisioning",
     sourceIssueNumber: options.issueNumber,
     createdAt,
@@ -185,7 +222,7 @@ function buildProjectProvisioningMetadata(options: {
     slug: options.normalizedProject.slug,
     repositoryName: options.normalizedProject.repositoryName,
     issueLabel: options.normalizedProject.issueLabel,
-    workspaceRelativePath: options.normalizedProject.workspaceRelativePath,
+    workspacePath: options.normalizedProject.workspacePath,
     requestedBy: options.requestedBy,
     requestedAt: options.requestedAt?.trim() || new Date().toISOString(),
   };
@@ -203,13 +240,13 @@ function buildCreatedStartProjectResult(options: {
     ok: true,
     action: "created",
     message: options.alreadyOpen
-      ? `Project \`${options.metadata.slug}\` is already queued for provisioning in issue #${options.issueNumber}.`
-      : `Created provisioning issue #${options.issueNumber} for project \`${options.metadata.slug}\`.`,
+      ? `Project \`${options.metadata.slug}\` is already queued for provisioning in issue #${options.issueNumber}. Canonical workspace: \`${options.metadata.workspacePath}\`.`
+      : `Created provisioning issue #${options.issueNumber} for project \`${options.metadata.slug}\`. Canonical workspace: \`${options.metadata.workspacePath}\`.`,
     project: {
       displayName: options.metadata.displayName,
       slug: options.metadata.slug,
       repositoryName: options.metadata.repositoryName,
-      workspacePath: options.metadata.workspaceRelativePath,
+      workspacePath: options.metadata.workspacePath,
       status: "provisioning",
     },
     trackerIssue: {
@@ -217,6 +254,48 @@ function buildCreatedStartProjectResult(options: {
       url: issueUrl,
       alreadyOpen: options.alreadyOpen,
     },
+  };
+}
+
+async function synchronizeManagedProjectWorkspace(options: {
+  workDir: string;
+  defaultProject: DefaultProjectContext;
+  project: ProjectRecord;
+  workspaceRoot?: string;
+}): Promise<{
+  project: ProjectRecord;
+  workspaceAction: "created" | "reused" | null;
+}> {
+  if (options.project.kind !== "managed") {
+    return {
+      project: options.project,
+      workspaceAction: null,
+    };
+  }
+
+  const { workspacePath, workspaceAction } = await ensureManagedProjectWorkspaceDirectory(
+    resolveManagedProjectWorkspacePath(options.project.slug, options.workspaceRoot),
+  );
+  const nextProject: ProjectRecord = {
+    ...options.project,
+    cwd: workspacePath,
+    updatedAt: new Date().toISOString(),
+    provisioning: {
+      ...options.project.provisioning,
+      workspacePrepared: true,
+    },
+  };
+
+  await upsertProjectRecord(options.workDir, options.defaultProject, nextProject);
+  console.log(
+    options.project.status === "active"
+      ? `[project-workspace] resolved ${workspacePath}; ${workspaceAction === "created" ? "created directory" : "reused existing directory"}; ${workspacePath} is now the active working directory for project ${options.project.slug}.`
+      : `[project-workspace] resolved ${workspacePath}; ${workspaceAction === "created" ? "created directory" : "reused existing directory"}; ${workspacePath} is the canonical project workspace for ${options.project.slug}.`,
+  );
+
+  return {
+    project: nextProject,
+    workspaceAction,
   };
 }
 
@@ -253,9 +332,12 @@ export async function createProjectProvisioningRequestIssue(options: {
   projectName: string;
   requestedBy: string;
   requestedAt?: string;
+  workspaceRoot?: string;
 }): Promise<CreateProjectProvisioningRequestResult> {
   try {
-    const normalized = normalizeProjectNameInput(options.projectName);
+    const normalized = normalizeProjectNameInput(options.projectName, {
+      workspaceRoot: options.workspaceRoot,
+    });
     const defaultProject = buildDefaultProjectContext(options.workDir, options.trackerOwner, options.trackerRepo);
     const registry = await readProjectRegistry(options.workDir, defaultProject);
     const existingProject = findProjectBySlug(registry, normalized.slug);
@@ -311,42 +393,57 @@ export async function handleStartProjectCommand(options: {
   projectName: string;
   requestedBy: string;
   requestedAt?: string;
+  workspaceRoot?: string;
 }): Promise<StartProjectCommandHandlingResult> {
   try {
-    const normalized = normalizeProjectNameInput(options.projectName);
+    const normalized = normalizeProjectNameInput(options.projectName, {
+      workspaceRoot: options.workspaceRoot,
+    });
     const defaultProject = buildDefaultProjectContext(options.workDir, options.trackerOwner, options.trackerRepo);
     const registry = await readProjectRegistry(options.workDir, defaultProject);
     const existingProject = findProjectBySlug(registry, normalized.slug);
     const duplicateIssue = await findOpenProvisioningIssueForSlug(options.issueManager, normalized.slug);
 
     if (existingProject && existingProject.status !== "failed") {
+      const synchronizedWorkspace = await synchronizeManagedProjectWorkspace({
+        workDir: options.workDir,
+        defaultProject,
+        project: existingProject,
+        workspaceRoot: options.workspaceRoot,
+      });
       await setActiveProjectState({
         workDir: options.workDir,
-        slug: existingProject.slug,
+        slug: synchronizedWorkspace.project.slug,
         requestedBy: options.requestedBy,
         source: "start-project-command",
         updatedAt: options.requestedAt,
       });
       return buildResumedStartProjectResult(
-        existingProject,
-        existingProject.status === "active"
-          ? `Resumed existing project \`${existingProject.slug}\`.`
-          : `Project \`${existingProject.slug}\` already exists with status \`${existingProject.status}\`; resuming that flow.`,
+        synchronizedWorkspace.project,
+        synchronizedWorkspace.project.status === "active"
+          ? `Resumed existing project \`${synchronizedWorkspace.project.slug}\`. ${synchronizedWorkspace.workspaceAction === "created" ? "Created missing workspace directory" : "Reused existing workspace directory"} \`${synchronizedWorkspace.project.cwd}\`, and that path is now the active working directory.`
+          : `Project \`${synchronizedWorkspace.project.slug}\` already exists with status \`${synchronizedWorkspace.project.status}\`; resuming that flow from canonical workspace \`${synchronizedWorkspace.project.cwd}\`.`,
       );
     }
 
     if (existingProject && existingProject.status === "failed") {
+      const synchronizedWorkspace = await synchronizeManagedProjectWorkspace({
+        workDir: options.workDir,
+        defaultProject,
+        project: existingProject,
+        workspaceRoot: options.workspaceRoot,
+      });
       if (duplicateIssue) {
         await setActiveProjectState({
           workDir: options.workDir,
-          slug: existingProject.slug,
+          slug: synchronizedWorkspace.project.slug,
           requestedBy: options.requestedBy,
           source: "start-project-command",
           updatedAt: options.requestedAt,
         });
         return buildResumedStartProjectResult(
-          existingProject,
-          `Resumed existing project \`${existingProject.slug}\` and kept recovery issue #${duplicateIssue.number} active.`,
+          synchronizedWorkspace.project,
+          `Resumed existing project \`${synchronizedWorkspace.project.slug}\` and kept recovery issue #${duplicateIssue.number} active. Canonical workspace: \`${synchronizedWorkspace.project.cwd}\`.`,
           {
             number: duplicateIssue.number,
             url: buildProjectProvisioningIssueUrl(options.trackerOwner, options.trackerRepo, duplicateIssue.number),
@@ -363,6 +460,7 @@ export async function handleStartProjectCommand(options: {
         projectName: options.projectName,
         requestedBy: options.requestedBy,
         requestedAt: options.requestedAt,
+        workspaceRoot: options.workspaceRoot,
       });
       if (!recoveryRequest.ok) {
         return recoveryRequest;
@@ -370,14 +468,14 @@ export async function handleStartProjectCommand(options: {
 
       await setActiveProjectState({
         workDir: options.workDir,
-        slug: existingProject.slug,
+        slug: synchronizedWorkspace.project.slug,
         requestedBy: options.requestedBy,
         source: "start-project-command",
         updatedAt: options.requestedAt,
       });
       return buildResumedStartProjectResult(
-        existingProject,
-        `Resumed existing project \`${existingProject.slug}\` and queued recovery issue #${recoveryRequest.issueNumber}.`,
+        synchronizedWorkspace.project,
+        `Resumed existing project \`${synchronizedWorkspace.project.slug}\` and queued recovery issue #${recoveryRequest.issueNumber}. Canonical workspace: \`${synchronizedWorkspace.project.cwd}\`.`,
         {
           number: recoveryRequest.issueNumber,
           url: recoveryRequest.issueUrl,
@@ -417,6 +515,7 @@ export async function handleStartProjectCommand(options: {
       projectName: options.projectName,
       requestedBy: options.requestedBy,
       requestedAt: options.requestedAt,
+      workspaceRoot: options.workspaceRoot,
     });
     if (!request.ok) {
       return request;
@@ -450,22 +549,24 @@ export async function executeProjectProvisioningIssue(options: {
   trackerOwner: string;
   trackerRepo: string;
   adminClient: ProjectProvisioningAdminClient;
+  workspaceRoot?: string;
 }): Promise<ProjectProvisioningExecutionResult> {
-  const metadata = parseProjectProvisioningIssueMetadata(options.issue.description);
-  if (!metadata) {
+  const parsedMetadata = parseProjectProvisioningIssueMetadata(options.issue.description);
+  if (!parsedMetadata) {
     throw new Error(`Issue #${options.issue.number} is not a valid project provisioning request.`);
   }
+  const metadata = canonicalizeProjectProvisioningMetadata(parsedMetadata, options.workspaceRoot);
 
   const defaultProject = buildDefaultProjectContext(options.workDir, options.trackerOwner, options.trackerRepo);
   const registry = await readProjectRegistry(options.workDir, defaultProject);
   const existingProject = findProjectBySlug(registry, metadata.slug);
   let record = buildManagedProjectRecord(metadata, {
-    workDir: options.workDir,
     trackerOwner: options.trackerOwner,
     trackerRepo: options.trackerRepo,
     issueNumber: options.issue.number,
     now: new Date().toISOString(),
   }, existingProject);
+  let workspaceAction: "created" | "reused" | null = null;
 
   const persistRecord = async (
     overrides: Partial<ProjectRecord>,
@@ -498,6 +599,7 @@ export async function executeProjectProvisioningIssue(options: {
       metadata,
       record,
       failureStep: "registry",
+      workspaceAction,
       message: error instanceof Error ? error.message : "Unknown project registry error.",
     };
   }
@@ -518,6 +620,7 @@ export async function executeProjectProvisioningIssue(options: {
       metadata,
       record,
       failureStep: "label",
+      workspaceAction,
       message,
     };
   }
@@ -547,16 +650,17 @@ export async function executeProjectProvisioningIssue(options: {
       metadata,
       record,
       failureStep: "repository",
+      workspaceAction,
       message,
     };
   }
 
   try {
-    const workspacePath = resolve(options.workDir, metadata.workspaceRelativePath);
-    await mkdir(workspacePath, { recursive: true });
+    const preparedWorkspace = await ensureManagedProjectWorkspaceDirectory(metadata.workspacePath);
+    workspaceAction = preparedWorkspace.workspaceAction;
     await persistRecord(
       {
-        cwd: workspacePath,
+        cwd: preparedWorkspace.workspacePath,
         status: "active",
       },
       {
@@ -572,6 +676,7 @@ export async function executeProjectProvisioningIssue(options: {
       metadata,
       record,
       failureStep: "workspace",
+      workspaceAction,
       message,
     };
   }
@@ -583,6 +688,9 @@ export async function executeProjectProvisioningIssue(options: {
       requestedBy: metadata.requestedBy,
       source: "project-provisioning",
     });
+    console.log(
+      `[project-workspace] resolved ${record.cwd}; ${workspaceAction === "created" ? "created directory" : "reused existing directory"}; ${record.cwd} is now the active working directory for project ${metadata.slug}.`,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown active project state update error.";
     await persistRecord({ status: "failed" }, { lastError: message }).catch(() => undefined);
@@ -591,6 +699,7 @@ export async function executeProjectProvisioningIssue(options: {
       metadata,
       record,
       failureStep: "active-project",
+      workspaceAction,
       message,
     };
   }
@@ -600,6 +709,7 @@ export async function executeProjectProvisioningIssue(options: {
     metadata,
     record,
     failureStep: null,
+    workspaceAction,
     message: `Provisioned project ${metadata.displayName}.`,
   };
 }
@@ -619,7 +729,7 @@ export function buildProjectProvisioningOutcomeComment(
     : "- Repository default branch: not available";
   const workspaceLine = result.record.provisioning.workspacePrepared
     ? `- Local workspace: \`${result.record.cwd}\``
-    : `- Local workspace: pending (\`${result.metadata.workspaceRelativePath}\`)`;
+    : `- Local workspace: pending (\`${result.metadata.workspacePath}\`)`;
 
   const lines = [
     "## Project Provisioning",
@@ -629,6 +739,10 @@ export function buildProjectProvisioningOutcomeComment(
     repositoryLine,
     branchLine,
     workspaceLine,
+    ...(result.workspaceAction === null
+      ? []
+      : [`- Workspace directory: ${result.workspaceAction === "created" ? "created" : "reused existing directory"}.`]),
+    ...(result.ok ? [`- Active working directory: \`${result.record.cwd}\`.`] : []),
     `- Registry status: \`${result.record.status}\``,
   ];
 

--- a/src/runtime/issueLifecyclePresentation.test.ts
+++ b/src/runtime/issueLifecyclePresentation.test.ts
@@ -81,7 +81,7 @@ describe("issueLifecyclePresentation", () => {
           url: "https://github.com/evolvo-auto/habit-cli",
           defaultBranch: "main",
         },
-        cwd: "/tmp/evolvo/projects/habit-cli",
+        cwd: "/home/paddy/habit-cli",
         status: "active",
         sourceIssueNumber: 318,
         createdAt: "2026-03-07T12:00:00.000Z",

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -1001,7 +1001,7 @@ describe("operatorControl", () => {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
-        workspacePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         status: "provisioning",
       },
       trackerIssue: {
@@ -1072,12 +1072,12 @@ describe("operatorControl", () => {
     const onStartProject = vi.fn().mockResolvedValue({
       ok: true,
       action: "created",
-      message: "Created provisioning issue #555 for project `habit-cli`.",
+      message: "Created provisioning issue #555 for project `habit-cli`. Canonical workspace: `/home/paddy/habit-cli`.",
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
-        workspacePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         status: "provisioning",
       },
       trackerIssue: {
@@ -1110,7 +1110,7 @@ describe("operatorControl", () => {
       slug: "habit-cli",
       repositoryName: "habit-cli",
       issueLabel: "project:habit-cli",
-      workspaceRelativePath: "projects/habit-cli",
+      workspacePath: "/home/paddy/habit-cli",
     });
     expect(fetchSpy).toHaveBeenNthCalledWith(
       3,
@@ -1120,11 +1120,11 @@ describe("operatorControl", () => {
         body: JSON.stringify({
           content: [
             "<@operator-1> Created new project for `Habit CLI`.",
-            "Created provisioning issue #555 for project `habit-cli`.",
+            "Created provisioning issue #555 for project `habit-cli`. Canonical workspace: `/home/paddy/habit-cli`.",
             "Tracker issue: #555 (https://github.com/evolvo-auto/evolvo-ts/issues/555)",
             "Planned label: `project:habit-cli`",
             "Planned repository: `habit-cli`",
-            "Planned workspace: `projects/habit-cli`",
+            "Planned workspace: `/home/paddy/habit-cli`",
           ].join("\n"),
         }),
       }),
@@ -1142,13 +1142,13 @@ describe("operatorControl", () => {
     const onStartProject = vi.fn().mockResolvedValue({
       ok: true,
       action: "resumed",
-      message: "Resumed existing project `habit-cli`.",
+      message: "Resumed existing project `habit-cli`. Reused existing workspace directory `/home/paddy/habit-cli`, and that path is now the active working directory.",
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
         repositoryUrl: "https://github.com/evolvo-auto/habit-cli",
-        workspacePath: "/tmp/evolvo/projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         status: "active",
       },
     });
@@ -1175,10 +1175,10 @@ describe("operatorControl", () => {
         body: JSON.stringify({
           content: [
             "<@operator-1> Resumed existing project `Habit CLI`.",
-            "Resumed existing project `habit-cli`.",
+            "Resumed existing project `habit-cli`. Reused existing workspace directory `/home/paddy/habit-cli`, and that path is now the active working directory.",
             "Registry status: `active`",
             "Execution repository: https://github.com/evolvo-auto/habit-cli",
-            "Workspace: `/tmp/evolvo/projects/habit-cli`",
+            "Workspace: `/home/paddy/habit-cli`",
           ].join("\n"),
         }),
       }),
@@ -1550,12 +1550,12 @@ describe("operatorControl", () => {
     const onStartProject = vi.fn().mockResolvedValue({
       ok: true,
       action: "created",
-      message: "Created provisioning issue #555 for project `habit-cli`.",
+      message: "Created provisioning issue #555 for project `habit-cli`. Canonical workspace: `/home/paddy/habit-cli`.",
       project: {
         displayName: "Habit CLI",
         slug: "habit-cli",
         repositoryName: "habit-cli",
-        workspacePath: "projects/habit-cli",
+        workspacePath: "/home/paddy/habit-cli",
         status: "provisioning",
       },
       trackerIssue: {
@@ -1582,27 +1582,27 @@ describe("operatorControl", () => {
       slug: "habit-cli",
       repositoryName: "habit-cli",
       issueLabel: "project:habit-cli",
-      workspaceRelativePath: "projects/habit-cli",
+      workspacePath: "/home/paddy/habit-cli",
     });
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: [
         "<@operator-1> Created new project for `Habit CLI`.",
-        "Created provisioning issue #555 for project `habit-cli`.",
+        "Created provisioning issue #555 for project `habit-cli`. Canonical workspace: `/home/paddy/habit-cli`.",
         "Tracker issue: #555 (https://github.com/evolvo-auto/evolvo-ts/issues/555)",
         "Planned label: `project:habit-cli`",
         "Planned repository: `habit-cli`",
-        "Planned workspace: `projects/habit-cli`",
+        "Planned workspace: `/home/paddy/habit-cli`",
       ].join("\n"),
     });
     expect(result).toEqual({
       gracefulShutdownRequest: null,
       replyContent: [
         "<@operator-1> Created new project for `Habit CLI`.",
-        "Created provisioning issue #555 for project `habit-cli`.",
+        "Created provisioning issue #555 for project `habit-cli`. Canonical workspace: `/home/paddy/habit-cli`.",
         "Tracker issue: #555 (https://github.com/evolvo-auto/evolvo-ts/issues/555)",
         "Planned label: `project:habit-cli`",
         "Planned repository: `habit-cli`",
-        "Planned workspace: `projects/habit-cli`",
+        "Planned workspace: `/home/paddy/habit-cli`",
       ].join("\n"),
     });
   });

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -43,7 +43,7 @@ export type StartProjectCommandRequest = {
   slug: string;
   repositoryName: string;
   issueLabel: string;
-  workspaceRelativePath: string;
+  workspacePath: string;
 };
 
 export type StopProjectCommandRequest = {
@@ -863,7 +863,7 @@ async function processStartProjectControlCommand(
         slug: "",
         repositoryName: "",
         issueLabel: "",
-        workspaceRelativePath: "",
+        workspacePath: "",
       },
       result: {
         ok: false,
@@ -885,7 +885,7 @@ async function processStartProjectControlCommand(
       slug: normalized.slug,
       repositoryName: normalized.repositoryName,
       issueLabel: normalized.issueLabel,
-      workspaceRelativePath: normalized.workspaceRelativePath,
+      workspacePath: normalized.workspacePath,
     };
 
     if (!handlers.onStartProject) {
@@ -903,7 +903,7 @@ async function processStartProjectControlCommand(
       slug: "",
       repositoryName: "",
       issueLabel: "",
-      workspaceRelativePath: "",
+      workspacePath: "",
     };
     commandResult = {
       ok: false,


### PR DESCRIPTION
## Summary\n- move managed project workspace resolution to canonical  paths\n- reuse or create that canonical directory during project resume/provisioning and persist it as the managed project cwd\n- add backward-compatible provisioning metadata parsing plus regression coverage for path resolution and workspace logging\n\n## Validation\n- pnpm exec tsc --noEmit -p tsconfig.json\n- pnpm exec vitest run src/projects/projectProvisioning.test.ts src/runtime/operatorControl.test.ts src/main.test.ts\n- pnpm test\n\nCloses #393