### PR TITLE
feat(projects): inspect project repository issues

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -44,6 +44,9 @@ const readActiveProjectStateMock = vi.fn();
 const stopActiveProjectStateMock = vi.fn();
 const resolveProjectExecutionContextForIssueMock = vi.fn();
 const buildProjectRoutingBlockedCommentMock = vi.fn();
+const inspectProjectRepositoryIssuesMock = vi.fn();
+const buildProjectRepositoryIssueInspectionLogLinesMock = vi.fn();
+const buildProjectRepositoryIssuePromptSectionMock = vi.fn();
 const handleStartProjectCommandMock = vi.fn();
 const executeProjectProvisioningIssueMock = vi.fn();
 const isProjectProvisioningRequestIssueMock = vi.fn();
@@ -211,6 +214,14 @@ vi.mock("./projects/projectExecutionContext.js", () => ({
   PROJECT_ROUTING_BLOCKED_LABEL: "blocked",
   buildProjectRoutingBlockedComment: buildProjectRoutingBlockedCommentMock,
   resolveProjectExecutionContextForIssue: resolveProjectExecutionContextForIssueMock,
+}));
+
+vi.mock("./projects/projectRepositoryIssues.js", () => ({
+  ProjectRepositoryIssueInspector: class {
+    inspectProject = inspectProjectRepositoryIssuesMock;
+  },
+  buildProjectRepositoryIssueInspectionLogLines: buildProjectRepositoryIssueInspectionLogLinesMock,
+  buildProjectRepositoryIssuePromptSection: buildProjectRepositoryIssuePromptSectionMock,
 }));
 
 vi.mock("./issues/runIssueCommand.js", () => ({
@@ -390,6 +401,27 @@ describe("main", () => {
     });
     buildProjectRoutingBlockedCommentMock.mockReset();
     buildProjectRoutingBlockedCommentMock.mockReturnValue("## Project Routing Blocked");
+    inspectProjectRepositoryIssuesMock.mockReset();
+    inspectProjectRepositoryIssuesMock.mockResolvedValue({
+      projectSlug: "habit-cli",
+      repository: {
+        owner: "owner",
+        repo: "habit-cli",
+        reference: "owner/habit-cli",
+        url: "https://github.com/owner/habit-cli",
+      },
+      openIssues: [],
+      recentClosedIssues: [],
+    });
+    buildProjectRepositoryIssueInspectionLogLinesMock.mockReset();
+    buildProjectRepositoryIssueInspectionLogLinesMock.mockReturnValue([
+      "[project-issues] inspected project=habit-cli repository=owner/habit-cli open=0 recentClosed=0",
+    ]);
+    buildProjectRepositoryIssuePromptSectionMock.mockReset();
+    buildProjectRepositoryIssuePromptSectionMock.mockImplementation((state: { repository: { reference: string } }) => [
+      "## Project Repository Issue State",
+      `- Project repository: ${state.repository.reference}`,
+    ].join("\n"));
     runIssueCommandMock.mockReset();
     runIssueCommandMock.mockResolvedValue(false);
     getGitHubConfigMock.mockReset();
@@ -947,7 +979,20 @@ describe("main", () => {
       14,
       expect.stringContaining("Execution repository: `owner/habit-cli`."),
     );
-    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #14: Managed repo issue\n\nUse project context");
+    expect(inspectProjectRepositoryIssuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "habit-cli",
+      }),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      "[project-issues] inspected project=habit-cli repository=owner/habit-cli open=0 recentClosed=0",
+    );
+    expect(runCodingAgentMock).toHaveBeenCalledWith(
+      expect.stringContaining("## Project Repository Issue State"),
+    );
+    expect(runCodingAgentMock).toHaveBeenCalledWith(
+      expect.stringContaining("Project repository: owner/habit-cli"),
+    );
   });
 
   it("prefers issues for the active project when one is selected", async () => {
@@ -991,7 +1036,12 @@ describe("main", () => {
     await main();
 
     expect(markInProgressMock).toHaveBeenCalledWith(22);
-    expect(runCodingAgentMock).toHaveBeenCalledWith("Issue #22: Managed issue\n\nproject");
+    expect(runCodingAgentMock).toHaveBeenCalledWith(
+      expect.stringContaining("Issue #22: Managed issue\n\nproject"),
+    );
+    expect(runCodingAgentMock).toHaveBeenCalledWith(
+      expect.stringContaining("## Project Repository Issue State"),
+    );
   });
 
   it("keeps the runtime online and idle when the active project is stopped", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,11 @@ import {
   resolveProjectExecutionContextForIssue,
 } from "./projects/projectExecutionContext.js";
 import {
+  ProjectRepositoryIssueInspector,
+  buildProjectRepositoryIssueInspectionLogLines,
+  type ProjectRepositoryIssueState,
+} from "./projects/projectRepositoryIssues.js";
+import {
   buildDefaultProjectContext,
   ensureProjectRegistry,
   findProjectBySlug,
@@ -300,6 +305,7 @@ export async function main(): Promise<void> {
   const githubClient = new GitHubClient(githubConfig);
   const issueManager = new TaskIssueManager(githubClient);
   const adminClient = new GitHubAdminClient(githubClient, githubConfig);
+  const projectRepositoryIssueInspector = new ProjectRepositoryIssueInspector(githubClient);
   const defaultProjectContext = buildDefaultProjectContext({
     owner: GITHUB_OWNER,
     repo: GITHUB_REPO,
@@ -741,7 +747,29 @@ export async function main(): Promise<void> {
             break;
           }
 
-          const prompt = buildPromptFromIssue(selectedIssue);
+          let projectRepositoryIssueState: ProjectRepositoryIssueState | null = null;
+          if (executionContext.project.kind === "managed") {
+            try {
+              projectRepositoryIssueState = await projectRepositoryIssueInspector.inspectProject(executionContext.project);
+              for (const logLine of buildProjectRepositoryIssueInspectionLogLines(projectRepositoryIssueState)) {
+                console.log(logLine);
+              }
+              console.log(
+                `[project-issues] using ${projectRepositoryIssueState.repository.reference} issue state to shape execution planning for tracker issue #${selectedIssue.number}.`,
+              );
+            } catch (error) {
+              const repositoryReference =
+                `${executionContext.project.executionRepo.owner}/${executionContext.project.executionRepo.repo}`;
+              const message = error instanceof Error ? error.message : "unknown error";
+              console.error(
+                `[project-issues] failed to inspect project=${executionContext.project.slug} repository=${repositoryReference}: ${message}`,
+              );
+            }
+          }
+
+          const prompt = buildPromptFromIssue(selectedIssue, {
+            projectRepositoryIssueState,
+          });
           console.log(`Prompt: ${prompt}`);
           configureCodingAgentExecutionContext({
             workDir: executionContext.project.cwd,

--- a/src/projects/projectRepositoryIssues.test.ts
+++ b/src/projects/projectRepositoryIssues.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProjectRecord } from "./projectRegistry.js";
+import {
+  ProjectRepositoryIssueInspector,
+  buildProjectRepositoryIssueInspectionLogLines,
+} from "./projectRepositoryIssues.js";
+
+function createProjectRecord(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
+  return {
+    slug: "habit-cli",
+    displayName: "Habit CLI",
+    kind: "managed",
+    issueLabel: "project:habit-cli",
+    trackerRepo: {
+      owner: "evolvo-auto",
+      repo: "evolvo-ts",
+      url: "https://github.com/evolvo-auto/evolvo-ts",
+    },
+    executionRepo: {
+      owner: "evolvo-auto",
+      repo: "habit-cli",
+      url: "https://github.com/evolvo-auto/habit-cli",
+      defaultBranch: "main",
+    },
+    cwd: "/tmp/projects/habit-cli",
+    status: "active",
+    sourceIssueNumber: 398,
+    createdAt: "2026-03-08T10:00:00.000Z",
+    updatedAt: "2026-03-08T10:00:00.000Z",
+    provisioning: {
+      labelCreated: true,
+      repoCreated: true,
+      workspacePrepared: true,
+      lastError: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("projectRepositoryIssues", () => {
+  it("inspects open and recent closed issues from the managed project repository", async () => {
+    const client = {
+      getApi: vi.fn()
+        .mockResolvedValueOnce([
+          {
+            number: 11,
+            title: "Open project issue",
+            body: "Still open",
+            state: "open",
+            labels: [{ name: "bug" }],
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            number: 10,
+            title: "Recently closed project issue",
+            body: "Done",
+            state: "closed",
+            labels: [{ name: "completed" }],
+          },
+        ]),
+    };
+    const inspector = new ProjectRepositoryIssueInspector(client as never);
+
+    const state = await inspector.inspectProject(createProjectRecord(), { recentClosedLimit: 5 });
+
+    expect(client.getApi).toHaveBeenNthCalledWith(
+      1,
+      "/repos/evolvo-auto/habit-cli/issues?state=open&per_page=100&page=1",
+    );
+    expect(client.getApi).toHaveBeenNthCalledWith(
+      2,
+      "/repos/evolvo-auto/habit-cli/issues?state=closed&sort=updated&direction=desc&per_page=5&page=1",
+    );
+    expect(state).toEqual({
+      projectSlug: "habit-cli",
+      repository: {
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+        reference: "evolvo-auto/habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli",
+      },
+      openIssues: [
+        {
+          number: 11,
+          title: "Open project issue",
+          description: "Still open",
+          state: "open",
+          labels: ["bug"],
+        },
+      ],
+      recentClosedIssues: [
+        {
+          number: 10,
+          title: "Recently closed project issue",
+          description: "Done",
+          state: "closed",
+          labels: ["completed"],
+        },
+      ],
+    });
+  });
+
+  it("formats inspection logs with explicit project and repository context", () => {
+    const lines = buildProjectRepositoryIssueInspectionLogLines({
+      projectSlug: "habit-cli",
+      repository: {
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+        reference: "evolvo-auto/habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli",
+      },
+      openIssues: [
+        {
+          number: 11,
+          title: "Open project issue",
+          description: "Still open",
+          state: "open",
+          labels: [],
+        },
+      ],
+      recentClosedIssues: [],
+    });
+
+    expect(lines).toEqual([
+      "[project-issues] inspected project=habit-cli repository=evolvo-auto/habit-cli open=1 recentClosed=0",
+      "[project-issues] open sample for evolvo-auto/habit-cli: #11 Open project issue",
+      "[project-issues] recent closed sample for evolvo-auto/habit-cli: none",
+    ]);
+  });
+});

--- a/src/projects/projectRepositoryIssues.ts
+++ b/src/projects/projectRepositoryIssues.ts
@@ -1,0 +1,181 @@
+import { GitHubClient } from "../github/githubClient.js";
+import type { IssueSummary } from "../issues/taskIssueManager.js";
+import type { ProjectRecord } from "./projectRegistry.js";
+
+const ISSUES_PER_PAGE = 100;
+const DEFAULT_RECENT_CLOSED_LIMIT = 10;
+const ISSUE_SAMPLE_LIMIT = 5;
+
+type GitHubLabel = {
+  name: string;
+};
+
+type GitHubIssue = {
+  number: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  labels: GitHubLabel[];
+  pull_request?: unknown;
+};
+
+export type ProjectRepositoryIssueState = {
+  projectSlug: string;
+  repository: {
+    owner: string;
+    repo: string;
+    reference: string;
+    url: string;
+  };
+  openIssues: IssueSummary[];
+  recentClosedIssues: IssueSummary[];
+};
+
+function formatIssue(issue: GitHubIssue): IssueSummary {
+  return {
+    number: issue.number,
+    title: issue.title,
+    description: issue.body ?? "",
+    state: issue.state,
+    labels: issue.labels.map((label) => label.name),
+  };
+}
+
+function formatRepositoryReference(repository: { owner: string; repo: string }): string {
+  return `${repository.owner}/${repository.repo}`;
+}
+
+function buildRepositoryIssuesPath(
+  repository: { owner: string; repo: string },
+  query: URLSearchParams,
+): string {
+  const owner = encodeURIComponent(repository.owner);
+  const repo = encodeURIComponent(repository.repo);
+  return `/repos/${owner}/${repo}/issues?${query.toString()}`;
+}
+
+async function listRepositoryOpenIssues(
+  client: GitHubClient,
+  repository: { owner: string; repo: string },
+): Promise<IssueSummary[]> {
+  const issues: IssueSummary[] = [];
+  let page = 1;
+
+  while (true) {
+    const query = new URLSearchParams({
+      state: "open",
+      per_page: String(ISSUES_PER_PAGE),
+      page: String(page),
+    });
+    const batch = await client.getApi<GitHubIssue[]>(buildRepositoryIssuesPath(repository, query));
+    issues.push(...batch.filter((issue) => issue.pull_request === undefined).map(formatIssue));
+
+    if (batch.length < ISSUES_PER_PAGE) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return issues;
+}
+
+async function listRepositoryRecentClosedIssues(
+  client: GitHubClient,
+  repository: { owner: string; repo: string },
+  limit: number,
+): Promise<IssueSummary[]> {
+  const requestedLimit = Math.max(1, Math.floor(limit));
+  const perPage = Math.max(1, Math.min(ISSUES_PER_PAGE, requestedLimit));
+  const issues: IssueSummary[] = [];
+  let page = 1;
+
+  while (issues.length < requestedLimit) {
+    const query = new URLSearchParams({
+      state: "closed",
+      sort: "updated",
+      direction: "desc",
+      per_page: String(perPage),
+      page: String(page),
+    });
+    const batch = await client.getApi<GitHubIssue[]>(buildRepositoryIssuesPath(repository, query));
+    issues.push(...batch.filter((issue) => issue.pull_request === undefined).map(formatIssue));
+
+    if (batch.length < perPage) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return issues.slice(0, requestedLimit);
+}
+
+function formatIssueSample(issues: IssueSummary[]): string {
+  if (issues.length === 0) {
+    return "none";
+  }
+
+  const sample = issues.slice(0, ISSUE_SAMPLE_LIMIT).map((issue) => `#${issue.number} ${issue.title}`);
+  const remainingCount = issues.length - sample.length;
+  return remainingCount > 0 ? `${sample.join("; ")}; +${remainingCount} more` : sample.join("; ");
+}
+
+function formatPromptIssueList(issues: IssueSummary[]): string[] {
+  if (issues.length === 0) {
+    return ["- none"];
+  }
+
+  return issues.slice(0, ISSUE_SAMPLE_LIMIT).map((issue) => `- #${issue.number} ${issue.title}`);
+}
+
+export class ProjectRepositoryIssueInspector {
+  public constructor(private readonly client: GitHubClient) {}
+
+  public async inspectProject(
+    project: ProjectRecord,
+    options: { recentClosedLimit?: number } = {},
+  ): Promise<ProjectRepositoryIssueState> {
+    const repository = {
+      owner: project.executionRepo.owner,
+      repo: project.executionRepo.repo,
+    };
+    const recentClosedLimit = Math.max(1, Math.floor(options.recentClosedLimit ?? DEFAULT_RECENT_CLOSED_LIMIT));
+    const [openIssues, recentClosedIssues] = await Promise.all([
+      listRepositoryOpenIssues(this.client, repository),
+      listRepositoryRecentClosedIssues(this.client, repository, recentClosedLimit),
+    ]);
+
+    return {
+      projectSlug: project.slug,
+      repository: {
+        ...repository,
+        reference: formatRepositoryReference(repository),
+        url: project.executionRepo.url,
+      },
+      openIssues,
+      recentClosedIssues,
+    };
+  }
+}
+
+export function buildProjectRepositoryIssueInspectionLogLines(state: ProjectRepositoryIssueState): string[] {
+  return [
+    `[project-issues] inspected project=${state.projectSlug} repository=${state.repository.reference} open=${state.openIssues.length} recentClosed=${state.recentClosedIssues.length}`,
+    `[project-issues] open sample for ${state.repository.reference}: ${formatIssueSample(state.openIssues)}`,
+    `[project-issues] recent closed sample for ${state.repository.reference}: ${formatIssueSample(state.recentClosedIssues)}`,
+  ];
+}
+
+export function buildProjectRepositoryIssuePromptSection(state: ProjectRepositoryIssueState): string {
+  return [
+    "## Project Repository Issue State",
+    `- Project repository: ${state.repository.reference}`,
+    `- Project repository URL: ${state.repository.url}`,
+    "- Use this project-repository issue state to avoid duplicating work, resume existing project threads, and align planning with the managed repository rather than treating the tracker issue queue as the only source of truth.",
+    "- Open project repository issues:",
+    ...formatPromptIssueList(state.openIssues),
+    "- Recent closed project repository issues:",
+    ...formatPromptIssueList(state.recentClosedIssues),
+  ].join("\n");
+}

--- a/src/runtime/loopUtils.test.ts
+++ b/src/runtime/loopUtils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GitHubApiError } from "../github/githubClient.js";
 import {
+  buildPromptFromIssue,
   getRunLoopRetryDelayMs,
   isTransientGitHubError,
   prioritizeIssuesForWork,
@@ -203,5 +204,51 @@ describe("loopUtils retry handling", () => {
     );
 
     expect(selected?.number).toBe(8);
+  });
+
+  it("appends managed project repository issue state to coding prompts", () => {
+    const prompt = buildPromptFromIssue(
+      {
+        number: 44,
+        title: "Inspect managed project queue",
+        description: "Use project context",
+        state: "open",
+        labels: ["project:habit-cli"],
+      },
+      {
+        projectRepositoryIssueState: {
+          projectSlug: "habit-cli",
+          repository: {
+            owner: "owner",
+            repo: "habit-cli",
+            reference: "owner/habit-cli",
+            url: "https://github.com/owner/habit-cli",
+          },
+          openIssues: [
+            {
+              number: 9,
+              title: "Existing project thread",
+              description: "Still open",
+              state: "open",
+              labels: [],
+            },
+          ],
+          recentClosedIssues: [
+            {
+              number: 7,
+              title: "Recently finished project task",
+              description: "Closed",
+              state: "closed",
+              labels: [],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(prompt).toContain("## Project Repository Issue State");
+    expect(prompt).toContain("Project repository: owner/habit-cli");
+    expect(prompt).toContain("- #9 Existing project thread");
+    expect(prompt).toContain("- #7 Recently finished project task");
   });
 });

--- a/src/runtime/loopUtils.ts
+++ b/src/runtime/loopUtils.ts
@@ -9,6 +9,10 @@ import {
   isChallengeRetryReadyIssue,
 } from "../issues/challengeIssue.js";
 import { PROJECT_LABEL_PREFIX } from "../projects/projectNaming.js";
+import {
+  buildProjectRepositoryIssuePromptSection,
+  type ProjectRepositoryIssueState,
+} from "../projects/projectRepositoryIssues.js";
 
 const OUTDATED_LABELS = new Set(["outdated", "obsolete", "wontfix", "invalid", "duplicate"]);
 const MIN_REPLENISH_ISSUES = 3;
@@ -429,9 +433,15 @@ export function isOutdatedIssue(issue: IssueSummary): boolean {
   return issue.labels.some((label) => OUTDATED_LABELS.has(label.toLowerCase()));
 }
 
-export function buildPromptFromIssue(issue: IssueSummary): string {
+export function buildPromptFromIssue(
+  issue: IssueSummary,
+  options: { projectRepositoryIssueState?: ProjectRepositoryIssueState | null } = {},
+): string {
   const description = issue.description.trim() || "No description provided.";
-  return `Issue #${issue.number}: ${issue.title}\n\n${description}`;
+  const projectRepositoryIssueSection = options.projectRepositoryIssueState
+    ? `\n\n${buildProjectRepositoryIssuePromptSection(options.projectRepositoryIssueState)}`
+    : "";
+  return `Issue #${issue.number}: ${issue.title}\n\n${description}${projectRepositoryIssueSection}`;
 }
 
 export function formatIssueForLog(issue: IssueSummary): string {


### PR DESCRIPTION
## Summary
- add a read-only project repository issue inspector for managed projects
- log project/repository issue state during managed project execution
- append project-repo issue state to managed project coding prompts so planning and resume behavior uses repository context

## Testing
- pnpm vitest run src/projects/projectRepositoryIssues.test.ts src/runtime/loopUtils.test.ts src/main.test.ts
- pnpm tsc --noEmit

Closes #398