### PR TITLE
fix: store managed project tracker metadata in projects.json

### DIFF
--- a/src/projects/projectProvisioning.test.ts
+++ b/src/projects/projectProvisioning.test.ts
@@ -401,8 +401,23 @@ describe("projectProvisioning", () => {
       requestedBy: "discord:operator-1",
       source: "start-project-command",
     });
+    const registry = JSON.parse(await readFile(getProjectRegistryPath(workDir), "utf8")) as {
+      projects: Array<{ slug: string; trackerRepo: { owner: string; repo: string; url: string } }>;
+    };
+    expect(registry.projects.find((project) => project.slug === "habit-cli")).toEqual(
+      expect.objectContaining({
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "habit-cli",
+          url: "https://github.com/evolvo-auto/habit-cli",
+        },
+      }),
+    );
     expect(logSpy).toHaveBeenCalledWith(
       `[project-workspace] resolved ${createManagedWorkspacePath(workDir)}; reused existing directory; ${createManagedWorkspacePath(workDir)} is now the active working directory for project habit-cli.`,
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "[project-registry] corrected tracker repository for project habit-cli; projects.json now records evolvo-auto/habit-cli.",
     );
   });
 
@@ -647,6 +662,11 @@ describe("projectProvisioning", () => {
     expect(result.ok).toBe(true);
     expect(result.failureStep).toBeNull();
     expect(result.record.status).toBe("active");
+    expect(result.record.trackerRepo).toEqual({
+      owner: "evolvo-auto",
+      repo: "habit-cli",
+      url: "https://github.com/evolvo-auto/habit-cli",
+    });
     expect(result.record.provisioning).toEqual({
       labelCreated: true,
       repoCreated: true,
@@ -666,13 +686,23 @@ describe("projectProvisioning", () => {
     expect(buildProjectProvisioningOutcomeComment(result)).toContain("- Deployment: skipped for `evolvo-auto/habit-cli`.");
 
     const registry = JSON.parse(await readFile(getProjectRegistryPath(workDir), "utf8")) as {
-      projects: Array<{ slug: string; status: string; provisioning: { repoCreated: boolean } }>;
+      projects: Array<{
+        slug: string;
+        status: string;
+        trackerRepo: { owner: string; repo: string; url: string };
+        provisioning: { repoCreated: boolean };
+      }>;
     };
     const managedProject = registry.projects.find((project) => project.slug === "habit-cli");
     expect(managedProject).toEqual(
       expect.objectContaining({
         slug: "habit-cli",
         status: "active",
+        trackerRepo: {
+          owner: "evolvo-auto",
+          repo: "habit-cli",
+          url: "https://github.com/evolvo-auto/habit-cli",
+        },
         provisioning: expect.objectContaining({
           repoCreated: true,
         }),
@@ -690,6 +720,9 @@ describe("projectProvisioning", () => {
     });
     expect(logSpy).toHaveBeenCalledWith(
       `[project-workspace] resolved ${createManagedWorkspacePath(workDir)}; created directory; ${createManagedWorkspacePath(workDir)} is now the active working directory for project habit-cli.`,
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "[project-registry] project habit-cli repository created: evolvo-auto/habit-cli; tracker repository written to projects.json: evolvo-auto/habit-cli.",
     );
     expect(deployRepository).toHaveBeenCalledWith({
       repository: {

--- a/src/projects/projectProvisioning.ts
+++ b/src/projects/projectProvisioning.ts
@@ -164,14 +164,15 @@ async function ensureManagedProjectWorkspaceDirectory(workspacePath: string): Pr
 function buildManagedProjectRecord(
   metadata: ProjectProvisioningIssueMetadata,
   options: {
-    trackerOwner: string;
-    trackerRepo: string;
     issueNumber: number;
     now: string;
   },
   existing: ProjectRecord | null,
 ): ProjectRecord {
   const createdAt = existing?.createdAt ?? options.now;
+  const repositoryOwner = existing?.executionRepo.owner ?? metadata.owner;
+  const repositoryName = existing?.executionRepo.repo ?? metadata.repositoryName;
+  const repositoryUrl = existing?.executionRepo.url ?? buildRepositoryUrl(metadata.owner, metadata.repositoryName);
 
   return {
     slug: metadata.slug,
@@ -179,14 +180,14 @@ function buildManagedProjectRecord(
     kind: "managed",
     issueLabel: metadata.issueLabel,
     trackerRepo: {
-      owner: options.trackerOwner,
-      repo: options.trackerRepo,
-      url: buildRepositoryUrl(options.trackerOwner, options.trackerRepo),
+      owner: repositoryOwner,
+      repo: repositoryName,
+      url: repositoryUrl,
     },
     executionRepo: {
-      owner: existing?.executionRepo.owner ?? metadata.owner,
-      repo: existing?.executionRepo.repo ?? metadata.repositoryName,
-      url: existing?.executionRepo.url ?? buildRepositoryUrl(metadata.owner, metadata.repositoryName),
+      owner: repositoryOwner,
+      repo: repositoryName,
+      url: repositoryUrl,
       defaultBranch: existing?.executionRepo.defaultBranch ?? null,
     },
     cwd: metadata.workspacePath,
@@ -280,8 +281,19 @@ async function synchronizeManagedProjectWorkspace(options: {
   const { workspacePath, workspaceAction } = await ensureManagedProjectWorkspaceDirectory(
     resolveManagedProjectWorkspacePath(options.project.slug, options.workspaceRoot),
   );
+  const trackerRepo = {
+    owner: options.project.executionRepo.owner,
+    repo: options.project.executionRepo.repo,
+    url: options.project.executionRepo.url,
+  };
+  const trackerRepoReference = `${trackerRepo.owner}/${trackerRepo.repo}`;
+  const trackerRepoChanged =
+    options.project.trackerRepo.owner !== trackerRepo.owner
+    || options.project.trackerRepo.repo !== trackerRepo.repo
+    || options.project.trackerRepo.url !== trackerRepo.url;
   const nextProject: ProjectRecord = {
     ...options.project,
+    trackerRepo,
     cwd: workspacePath,
     updatedAt: new Date().toISOString(),
     provisioning: {
@@ -296,6 +308,11 @@ async function synchronizeManagedProjectWorkspace(options: {
       ? `[project-workspace] resolved ${workspacePath}; ${workspaceAction === "created" ? "created directory" : "reused existing directory"}; ${workspacePath} is now the active working directory for project ${options.project.slug}.`
       : `[project-workspace] resolved ${workspacePath}; ${workspaceAction === "created" ? "created directory" : "reused existing directory"}; ${workspacePath} is the canonical project workspace for ${options.project.slug}.`,
   );
+  if (trackerRepoChanged) {
+    console.log(
+      `[project-registry] corrected tracker repository for project ${options.project.slug}; projects.json now records ${trackerRepoReference}.`,
+    );
+  }
 
   return {
     project: nextProject,
@@ -566,8 +583,6 @@ export async function executeProjectProvisioningIssue(options: {
   const registry = await readProjectRegistry(options.workDir, defaultProject);
   const existingProject = findProjectBySlug(registry, metadata.slug);
   let record = buildManagedProjectRecord(metadata, {
-    trackerOwner: options.trackerOwner,
-    trackerRepo: options.trackerRepo,
     issueNumber: options.issue.number,
     now: new Date().toISOString(),
   }, existingProject);
@@ -643,6 +658,11 @@ export async function executeProjectProvisioningIssue(options: {
     });
     await persistRecord(
       {
+        trackerRepo: {
+          owner: repositoryMetadata.owner,
+          repo: repositoryMetadata.repo,
+          url: repositoryMetadata.url,
+        },
         executionRepo: {
           owner: repositoryMetadata.owner,
           repo: repositoryMetadata.repo,
@@ -651,6 +671,9 @@ export async function executeProjectProvisioningIssue(options: {
         },
       },
       { repoCreated: true },
+    );
+    console.log(
+      `[project-registry] project ${metadata.slug} repository created: ${repositoryMetadata.owner}/${repositoryMetadata.repo}; tracker repository written to projects.json: ${repositoryMetadata.owner}/${repositoryMetadata.repo}.`,
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown managed repository provisioning error.";


### PR DESCRIPTION
## Summary
- write managed project `trackerRepo` metadata from the managed repository identity instead of the Evolvo control repo
- normalize legacy managed records on resume so stale tracker metadata is corrected from `executionRepo`
- add provisioning logs and regression coverage for new-project and resumed-project tracker metadata

Closes #406

## Validation
- pnpm vitest run src/projects/projectProvisioning.test.ts src/projects/projectExecutionContext.test.ts src/issues/unifiedIssueQueue.test.ts