### PR TITLE
fix: use project-aware GitHub links in Discord issue embeds

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -993,6 +993,8 @@ describe("main", () => {
       issue: {
         number: 12,
         title: "Fix login redirect",
+        repository: "owner/repo",
+        url: "https://github.com/owner/repo/issues/12",
       },
       executionContext: {
         trackerRepository: "owner/repo",
@@ -1099,6 +1101,8 @@ describe("main", () => {
       issue: {
         number: 14,
         title: "Managed repo issue",
+        repository: "owner/repo",
+        url: "https://github.com/owner/repo/issues/14",
       },
       executionContext: {
         trackerRepository: "tracker-org/issue-tracker",
@@ -1417,6 +1421,14 @@ describe("main", () => {
     expect(runPlannerAgentMock).toHaveBeenCalledWith(expect.objectContaining({
       openIssueCount: 0,
       workDir: "/home/paddy/habit-cli",
+    }));
+    expect(notifyIssueStartedInDiscordMock).toHaveBeenCalledWith(expect.objectContaining({
+      issue: {
+        number: 31,
+        title: "Generated project follow-up",
+        repository: "owner/habit-cli",
+        url: "https://github.com/owner/habit-cli/issues/31",
+      },
     }));
     expect(markInProgressMock).toHaveBeenCalledWith(31);
     expect(runCodingAgentMock).toHaveBeenCalledWith(

--- a/src/main.ts
+++ b/src/main.ts
@@ -829,6 +829,8 @@ export async function main(): Promise<void> {
               issue: {
                 number: selectedIssue.number,
                 title: selectedIssue.title,
+                repository: selectedIssue.repository.reference,
+                url: `${selectedIssue.repository.url}/issues/${selectedIssue.number}`,
               },
               executionContext: {
                 trackerRepository: executionContext.trackerRepository,

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -254,6 +254,7 @@ describe("operatorControl", () => {
     vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
     vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
     vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
     const fetchSpy = vi.fn()
       .mockResolvedValueOnce(
@@ -266,6 +267,8 @@ describe("operatorControl", () => {
       issue: {
         number: 298,
         title: "Send a Discord embed notification with GitHub issue link when starting a new issue",
+        repository: "evolvo-auto/evolvo-ts",
+        url: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
       },
       executionContext: {
         trackerRepository: "evolvo-auto/evolvo-ts",
@@ -279,6 +282,9 @@ describe("operatorControl", () => {
     });
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledWith(
+      "[discord-issue-start] project=evolvo issueRepository=evolvo-auto/evolvo-ts trackerRepository=evolvo-auto/evolvo-ts executionRepository=evolvo-auto/evolvo-ts issueUrl=https://github.com/evolvo-auto/evolvo-ts/issues/298",
+    );
     expect(fetchSpy).toHaveBeenNthCalledWith(
       1,
       "https://discord.com/api/v10/channels/channel-1",
@@ -333,6 +339,95 @@ describe("operatorControl", () => {
                   style: 5,
                   label: "Open GitHub Issue",
                   url: "https://github.com/evolvo-auto/evolvo-ts/issues/298",
+                },
+              ],
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("uses the project issue repository for project-mode embed links", async () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "channel-1", guild_id: "guild-1" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "message-2" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await notifyIssueStartedInDiscord({
+      issue: {
+        number: 14,
+        title: "Fix project-mode links",
+        repository: "evolvo-auto/habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli/issues/14",
+      },
+      executionContext: {
+        trackerRepository: "evolvo-auto/evolvo-ts",
+        executionRepository: "evolvo-auto/habit-cli",
+        project: {
+          displayName: "Habit CLI",
+          slug: "habit-cli",
+        },
+      },
+      lifecycleState: "selected -> executing",
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "[discord-issue-start] project=habit-cli issueRepository=evolvo-auto/habit-cli trackerRepository=evolvo-auto/evolvo-ts executionRepository=evolvo-auto/habit-cli issueUrl=https://github.com/evolvo-auto/habit-cli/issues/14",
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: "<@operator-1>",
+          embeds: [
+            {
+              title: "Started Issue #14",
+              description: "Fix project-mode links",
+              url: "https://github.com/evolvo-auto/habit-cli/issues/14",
+              fields: [
+                {
+                  name: "State",
+                  value: "selected -> executing",
+                  inline: true,
+                },
+                {
+                  name: "Tracker Repository",
+                  value: "evolvo-auto/evolvo-ts",
+                  inline: true,
+                },
+                {
+                  name: "Execution Project",
+                  value: "Habit CLI (`habit-cli`)",
+                  inline: true,
+                },
+                {
+                  name: "Execution Repository",
+                  value: "evolvo-auto/habit-cli",
+                  inline: true,
+                },
+              ],
+            },
+          ],
+          components: [
+            {
+              type: 1,
+              components: [
+                {
+                  type: 2,
+                  style: 5,
+                  label: "Open GitHub Issue",
+                  url: "https://github.com/evolvo-auto/habit-cli/issues/14",
                 },
               ],
             },

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -156,7 +156,10 @@ export type CycleLimitDecisionConfirmation =
   };
 
 type DiscordIssueStartNotification = {
-  issue: Pick<IssueSummary, "number" | "title">;
+  issue: Pick<IssueSummary, "number" | "title"> & {
+    repository?: string | null;
+    url?: string | null;
+  };
   executionContext: {
     trackerRepository: ProjectExecutionContext["trackerRepository"] | null;
     executionRepository: ProjectExecutionContext["executionRepository"] | null;
@@ -349,6 +352,16 @@ function buildIssueStartProjectLabel(notification: DiscordIssueStartNotification
 }
 
 function buildIssueStartIssueUrl(notification: DiscordIssueStartNotification): string | null {
+  const explicitIssueUrl = normalizeInlineText(notification.issue.url);
+  if (explicitIssueUrl) {
+    return explicitIssueUrl;
+  }
+
+  const issueRepository = normalizeInlineText(notification.issue.repository);
+  if (issueRepository && /^[^/\s]+\/[^/\s]+$/.test(issueRepository)) {
+    return `https://github.com/${issueRepository}/issues/${notification.issue.number}`;
+  }
+
   const trackerRepository = normalizeInlineText(notification.executionContext.trackerRepository);
   if (!trackerRepository || !/^[^/\s]+\/[^/\s]+$/.test(trackerRepository)) {
     return null;
@@ -571,9 +584,14 @@ async function sendIssueStartNotification(
   const issueUrl = buildIssueStartIssueUrl(notification);
   const issueTitle = normalizeInlineText(notification.issue.title) ?? "unavailable";
   const lifecycleState = normalizeInlineText(notification.lifecycleState) ?? "unknown";
+  const issueRepository = normalizeInlineText(notification.issue.repository) ?? "unknown";
   const trackerRepository = normalizeInlineText(notification.executionContext.trackerRepository) ?? "unknown";
   const executionProject = buildIssueStartProjectLabel(notification);
   const executionRepository = normalizeInlineText(notification.executionContext.executionRepository) ?? "unknown";
+  const projectSlug = normalizeInlineText(notification.executionContext.project?.slug) ?? "none";
+  console.log(
+    `[discord-issue-start] project=${projectSlug} issueRepository=${issueRepository} trackerRepository=${trackerRepository} executionRepository=${executionRepository} issueUrl=${issueUrl ?? "unavailable"}`,
+  );
   await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
     method: "POST",
     body: JSON.stringify({


### PR DESCRIPTION
## Summary
- pass the selected issue repository and explicit issue URL into Discord issue-start notifications
- build embed links from the actual issue source instead of guessing from tracker context
- add logging and regression coverage for self-work, tracker-backed project work, and project-repo issue work

Closes #405

## Validation
- pnpm vitest run src/runtime/operatorControl.test.ts src/main.test.ts