### PR TITLE
feat: add Discord runtime status command

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -844,6 +844,72 @@ describe("main", () => {
     );
   });
 
+  it("reports live self-work status while an issue is executing", async () => {
+    let resolveRun: (value: typeof DEFAULT_RUN_RESULT) => void = () => undefined;
+    const pendingRun = new Promise<typeof DEFAULT_RUN_RESULT>((resolve) => {
+      resolveRun = resolve;
+    });
+    runCodingAgentMock.mockImplementation(() => pendingRun);
+    listOpenIssuesMock
+      .mockResolvedValueOnce([
+        {
+          number: 403,
+          title: "Add status command",
+          description: "Expose runtime status in Discord.",
+          state: "open",
+          labels: [],
+        },
+      ])
+      .mockResolvedValue([]);
+    const { main } = await import("./main.js");
+
+    const mainPromise = main();
+    while (startDiscordGracefulShutdownListenerMock.mock.calls.length === 0) {
+      await Promise.resolve();
+    }
+    while (runCodingAgentMock.mock.calls.length === 0) {
+      await Promise.resolve();
+    }
+
+    const discordHandlers = startDiscordGracefulShutdownListenerMock.mock.calls[0]?.[1];
+    try {
+      const status = await discordHandlers.onStatus({
+        messageId: "7300",
+        requestedAt: "2026-03-08T11:00:00.000Z",
+        requestedBy: "discord:operator-1",
+      });
+
+      expect(status).toEqual({
+        ok: true,
+        snapshot: {
+          online: true,
+          runtimeState: "active",
+          workMode: "self-work",
+          activitySummary: "Executing issue #403.",
+          activeProject: null,
+          activeIssue: {
+            number: 403,
+            title: "Add status command",
+            repository: "owner/repo",
+            lifecycleState: "selected -> executing",
+          },
+          deferredStop: null,
+          cycle: {
+            current: 1,
+            limit: 10,
+            remaining: 9,
+          },
+        },
+      });
+      expect(console.log).toHaveBeenCalledWith(
+        "[status] served runtime status to discord:operator-1: state=active mode=self-work project=none issue=403",
+      );
+    } finally {
+      resolveRun(DEFAULT_RUN_RESULT);
+      await mainPromise;
+    }
+  });
+
   it("logs and excludes unauthorized issues before normal selection", async () => {
     listOpenIssuesMock.mockResolvedValueOnce([]);
     unauthorizedIssueClosuresMock.mockResolvedValueOnce([

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import {
 import {
   notifyCycleLimitDecisionAppliedInDiscord,
   notifyDeferredProjectStopTriggeredInDiscord,
+  type StatusCommandResult,
   type StopProjectCommandResult,
   notifyIssueStartedInDiscord,
   notifyRuntimeQuittingInDiscord,
@@ -98,6 +99,12 @@ import {
   findProjectBySlug,
   readProjectRegistry,
 } from "./projects/projectRegistry.js";
+import {
+  buildRuntimeStatusSnapshot,
+  type RuntimeStatusIssue,
+  type RuntimeStatusProject,
+  type RuntimeStatusState,
+} from "./runtime/runtimeStatus.js";
 
 const MAX_ISSUE_CYCLES = 10;
 const MIN_REPLENISH_ISSUES = 3;
@@ -276,6 +283,36 @@ function buildStopProjectResultLog(result: StopProjectCommandResult): string {
   return "[stopProject] no active project was selected. Runtime remains online.";
 }
 
+async function resolveActiveStatusProject(
+  activeProjectSlug: string | null,
+  defaultProjectContext: ReturnType<typeof buildDefaultProjectContext>,
+): Promise<RuntimeStatusProject | null> {
+  if (activeProjectSlug === null) {
+    return null;
+  }
+
+  try {
+    const registry = await readProjectRegistry(WORK_DIR, defaultProjectContext);
+    const projectRecord = findProjectBySlug(registry, activeProjectSlug);
+    if (projectRecord !== null) {
+      return {
+        displayName: projectRecord.displayName,
+        slug: projectRecord.slug,
+        repository: `${projectRecord.executionRepo.owner}/${projectRecord.executionRepo.repo}`,
+      };
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    console.error(`[status] could not resolve project metadata for ${activeProjectSlug}: ${message}`);
+  }
+
+  return {
+    displayName: activeProjectSlug,
+    slug: activeProjectSlug,
+    repository: null,
+  };
+}
+
 function issueTargetsProject(issue: UnifiedIssue, projectSlug: string): boolean {
   const normalizedProjectSlug = projectSlug.trim().toLowerCase();
   if (!normalizedProjectSlug) {
@@ -363,6 +400,11 @@ export async function main(): Promise<void> {
   });
   let activeProjectState = await readActiveProjectState(WORK_DIR);
   let stoppedProjectIdleLoggedSlug: string | null = null;
+  let runtimeStatusState: RuntimeStatusState = "starting";
+  let runtimeStatusActivitySummary = "Starting runtime.";
+  let runtimeStatusCycle: number | null = null;
+  let runtimeStatusCycleLimit: number | null = MAX_ISSUE_CYCLES;
+  let runtimeStatusIssue: RuntimeStatusIssue | null = null;
   const discordHandlers: DiscordControlHandlers = {
     onStartProject: async (request) => {
       const result = await handleStartProjectCommand({
@@ -476,6 +518,25 @@ export async function main(): Promise<void> {
       console.log(buildStopProjectResultLog(result));
       return result;
     },
+    onStatus: async (request): Promise<StatusCommandResult> => {
+      const activeProject = await resolveActiveStatusProject(activeProjectState.activeProjectSlug, defaultProjectContext);
+      const snapshot = buildRuntimeStatusSnapshot({
+        runtimeState: runtimeStatusState,
+        activitySummary: runtimeStatusActivitySummary,
+        activeProjectState,
+        activeProject,
+        activeIssue: runtimeStatusIssue,
+        currentCycle: runtimeStatusCycle,
+        cycleLimit: runtimeStatusCycleLimit,
+      });
+      console.log(
+        `[status] served runtime status to ${request.requestedBy}: state=${snapshot.runtimeState} mode=${snapshot.workMode} project=${snapshot.activeProject?.slug ?? "none"} issue=${snapshot.activeIssue?.number ?? "none"}`,
+      );
+      return {
+        ok: true,
+        snapshot,
+      };
+    },
   };
 
   console.log(`Hello from ${GITHUB_OWNER}/${GITHUB_REPO}!`);
@@ -492,15 +553,25 @@ export async function main(): Promise<void> {
 
     let cycleLimit = MAX_ISSUE_CYCLES;
     issueCycleLoop: for (let cycle = 1; ; cycle += 1) {
+      runtimeStatusState = "active";
+      runtimeStatusActivitySummary = "Selecting the next issue.";
+      runtimeStatusCycle = cycle;
+      runtimeStatusCycleLimit = cycleLimit;
+      runtimeStatusIssue = null;
       if (await stopIfSingleTaskGracefulShutdownRequested(WORK_DIR, "Stopping before starting a new task.", discordHandlers)) {
         return;
       }
 
       if (cycle > cycleLimit) {
+        runtimeStatusState = "waiting";
+        runtimeStatusActivitySummary = "Waiting for operator cycle-limit decision.";
         const operatorDecision = await requestCycleLimitDecisionFromOperator(cycleLimit);
         if (operatorDecision?.decision === "continue" && operatorDecision.additionalCycles > 0) {
           const currentLimit = cycleLimit;
           cycleLimit += operatorDecision.additionalCycles;
+          runtimeStatusState = "active";
+          runtimeStatusActivitySummary = "Resuming work after cycle-limit extension.";
+          runtimeStatusCycleLimit = cycleLimit;
           console.log(
             `Operator decision via Discord: continue (+${operatorDecision.additionalCycles} cycles). New limit=${cycleLimit}.`,
           );
@@ -514,6 +585,8 @@ export async function main(): Promise<void> {
         }
         if (operatorDecision?.decision === "quit") {
           console.error("Operator decision via Discord: quit.");
+          runtimeStatusState = "stopping";
+          runtimeStatusActivitySummary = "Stopping after operator cycle-limit quit decision.";
           await notifyCycleLimitDecisionAppliedInDiscord({
             decision: "quit",
             currentLimit: cycleLimit,
@@ -521,6 +594,8 @@ export async function main(): Promise<void> {
         }
         console.error(`Reached the maximum number of issue cycles (${cycleLimit}).`);
         if (operatorDecision?.decision !== "quit") {
+          runtimeStatusState = "stopping";
+          runtimeStatusActivitySummary = `Stopping because cycle limit ${cycleLimit} was reached.`;
           await notifyRuntimeQuittingInDiscord(
             `Cycle limit of ${cycleLimit} was reached and no continue decision was applied.`,
           );
@@ -589,6 +664,8 @@ export async function main(): Promise<void> {
             );
             if (activeProjectSelectionCandidates.length === 0) {
               if (unifiedQueue.activeManagedProject !== null) {
+                runtimeStatusState = "active";
+                runtimeStatusActivitySummary = `Replenishing project work for ${unifiedQueue.activeManagedProject.slug}.`;
                 if (
                   await stopIfGracefulShutdownPreventsNewWork(
                     WORK_DIR,
@@ -642,6 +719,8 @@ export async function main(): Promise<void> {
                 slug: activeProjectState.activeProjectSlug,
                 displayName: activeProjectState.activeProjectSlug,
               };
+              runtimeStatusState = "active";
+              runtimeStatusActivitySummary = `Deferred project stop triggered for ${completedProject.slug}. Returning to self-work.`;
               console.log(
                 `[stopProject] project ${completedProject.slug} reached completion with deferred stop active. No actionable project work remains.`,
               );
@@ -672,6 +751,9 @@ export async function main(): Promise<void> {
 
           if (!selectedIssue) {
             if (activeProjectState.selectionState === "stopped" && activeProjectState.activeProjectSlug !== null) {
+              runtimeStatusState = "waiting";
+              runtimeStatusActivitySummary =
+                `Waiting for further operator instructions while project ${activeProjectState.activeProjectSlug} remains stopped.`;
               if (
                 await stopIfGracefulShutdownPreventsNewWork(
                   WORK_DIR,
@@ -703,6 +785,10 @@ export async function main(): Promise<void> {
               return;
             }
 
+            runtimeStatusState = "active";
+            runtimeStatusActivitySummary = unifiedQueue.activeManagedProject !== null
+              ? `Replenishing project work for ${unifiedQueue.activeManagedProject.slug}.`
+              : "Replenishing self-work issue queue.";
             const plannerResult = await runPlannerAgent({
               cycle,
               openIssueCount: openIssues.length,
@@ -751,11 +837,15 @@ export async function main(): Promise<void> {
             }
 
             if (cycle === 1) {
+              runtimeStatusState = "stopping";
+              runtimeStatusActivitySummary = "Stopping because no open issues are available on startup.";
               console.log(DEFAULT_PROMPT);
               await notifyRuntimeQuittingInDiscord(
                 "No open issues are available, so Evolvo is shutting down until more work is created.",
               );
             } else {
+              runtimeStatusState = "stopping";
+              runtimeStatusActivitySummary = "Stopping because no actionable work remains.";
               console.log("No actionable open issues remaining and no new issues were created. Issue loop stopped.");
               await notifyRuntimeQuittingInDiscord(
                 "No actionable open issues remain and no new work was created, so Evolvo is shutting down.",
@@ -844,6 +934,15 @@ export async function main(): Promise<void> {
             });
           }
 
+          runtimeStatusState = "active";
+          runtimeStatusActivitySummary = `Executing issue #${selectedIssue.number}.`;
+          runtimeStatusIssue = {
+            number: selectedIssue.number,
+            title: selectedIssue.title,
+            repository: selectedIssue.repository.reference,
+            lifecycleState: "selected -> executing",
+          };
+
           const isProvisioningIssue = isTrackerIssue(selectedIssue) && isProjectProvisioningRequestIssue(selectedIssue);
           if (isTrackerIssue(selectedIssue)) {
             await transitionIssueLifecycleState(issueManager, {
@@ -923,6 +1022,9 @@ export async function main(): Promise<void> {
               }
             }
 
+            runtimeStatusIssue = null;
+            runtimeStatusActivitySummary = "Selecting the next issue.";
+
             if (
               await stopIfSingleTaskGracefulShutdownRequested(
                 WORK_DIR,
@@ -975,6 +1077,8 @@ export async function main(): Promise<void> {
           });
 
           if (runError) {
+            runtimeStatusIssue = null;
+            runtimeStatusActivitySummary = "Selecting the next issue.";
             if (isTrackerIssue(selectedIssue)) {
               await transitionIssueLifecycleState(issueManager, {
                 issue: selectedIssue,
@@ -1113,6 +1217,9 @@ export async function main(): Promise<void> {
 
             console.log("Merged pull request detected for a managed project. Continuing without self-restart.");
           }
+
+          runtimeStatusIssue = null;
+          runtimeStatusActivitySummary = "Selecting the next issue.";
 
           if (
             await stopIfSingleTaskGracefulShutdownRequested(

--- a/src/runtime/operatorControl.test.ts
+++ b/src/runtime/operatorControl.test.ts
@@ -1429,6 +1429,82 @@ describe("operatorControl", () => {
     );
   });
 
+  it("acknowledges an authorized status request with project and deferred-stop details", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStatus = vi.fn().mockResolvedValue({
+      ok: true,
+      snapshot: {
+        online: true,
+        runtimeState: "active",
+        workMode: "project-work",
+        activitySummary: "Executing issue #17.",
+        activeProject: {
+          displayName: "Habit CLI",
+          slug: "habit-cli",
+          repository: "evolvo-auto/habit-cli",
+        },
+        activeIssue: {
+          number: 17,
+          title: "Fix project status routing",
+          repository: "evolvo-auto/habit-cli",
+          lifecycleState: "selected -> executing",
+        },
+        deferredStop: "when-project-complete",
+        cycle: {
+          current: 4,
+          limit: 10,
+          remaining: 6,
+        },
+      },
+    });
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "7180", content: "boot", author: { id: "someone" } }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ id: "7181", content: "status", author: { id: "operator-1" } }]),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ack-status" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await pollDiscordGracefulShutdownCommand(workDir, { onStatus });
+
+    expect(onStatus).toHaveBeenCalledWith({
+      messageId: "7181",
+      requestedAt: expect.any(String),
+      requestedBy: "discord:operator-1",
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "https://discord.com/api/v10/channels/channel-1/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          content: [
+            "<@operator-1> Evolvo is online.",
+            "Runtime state: `active`",
+            "Work mode: `project-work`",
+            "Activity: Executing issue #17.",
+            "Project: Habit CLI (`habit-cli`) | repo: `evolvo-auto/habit-cli`",
+            "Issue: #17 Fix project status routing | repo: `evolvo-auto/habit-cli`",
+            "Lifecycle: selected -> executing",
+            "Deferred stop: current project will stop when complete, then Evolvo will return to self-work.",
+            "Cycle: 4 of 10 (6 remaining after this cycle)",
+          ].join("\n"),
+        }),
+      }),
+    );
+  });
+
   it("acknowledges invalid authorized startProject commands without calling the handler", async () => {
     const workDir = await createTempWorkDir();
     tempDirs.push(workDir);
@@ -1848,6 +1924,72 @@ describe("operatorControl", () => {
         "<@operator-1> Current project `Habit CLI` will stop when complete.",
         "Project `habit-cli` will keep running until it has no actionable issues left. Evolvo will then stop it automatically, return to self-work, and remain online.",
         "Evolvo will return to self-work afterward and remain online for further operator commands.",
+      ].join("\n"),
+    });
+  });
+
+  it("handles an authorized /status slash command", async () => {
+    const workDir = await createTempWorkDir();
+    tempDirs.push(workDir);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "bot-token");
+    vi.stubEnv("DISCORD_CONTROL_GUILD_ID", "guild-1");
+    vi.stubEnv("DISCORD_CONTROL_CHANNEL_ID", "channel-1");
+    vi.stubEnv("DISCORD_OPERATOR_USER_ID", "operator-1");
+
+    const onStatus = vi.fn().mockResolvedValue({
+      ok: true,
+      snapshot: {
+        online: true,
+        runtimeState: "waiting",
+        workMode: "idle",
+        activitySummary: "Waiting for further operator instructions.",
+        activeProject: null,
+        activeIssue: null,
+        deferredStop: null,
+        cycle: {
+          current: null,
+          limit: 10,
+          remaining: 10,
+        },
+      },
+    });
+    const interaction = createSlashInteraction({
+      id: "slash-status-1",
+      commandName: "status",
+    });
+
+    const result = await handleDiscordSlashCommandInteraction(interaction, workDir, { onStatus });
+
+    expect(onStatus).toHaveBeenCalledWith({
+      messageId: "slash-status-1",
+      requestedAt: expect.any(String),
+      requestedBy: "discord:operator-1",
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: [
+        "<@operator-1> Evolvo is online.",
+        "Runtime state: `waiting`",
+        "Work mode: `idle`",
+        "Activity: Waiting for further operator instructions.",
+        "Project: none",
+        "Issue: none",
+        "Lifecycle: none",
+        "Deferred stop: none",
+        "Cycle: not started yet (10 total budget available)",
+      ].join("\n"),
+    });
+    expect(result).toEqual({
+      gracefulShutdownRequest: null,
+      replyContent: [
+        "<@operator-1> Evolvo is online.",
+        "Runtime state: `waiting`",
+        "Work mode: `idle`",
+        "Activity: Waiting for further operator instructions.",
+        "Project: none",
+        "Issue: none",
+        "Lifecycle: none",
+        "Deferred stop: none",
+        "Cycle: not started yet (10 total budget available)",
       ].join("\n"),
     });
   });

--- a/src/runtime/operatorControl.ts
+++ b/src/runtime/operatorControl.ts
@@ -18,6 +18,7 @@ import {
 import type { IssueSummary } from "../issues/taskIssueManager.js";
 import type { ProjectExecutionContext } from "../projects/projectExecutionContext.js";
 import { normalizeProjectNameInput } from "../projects/projectNaming.js";
+import type { RuntimeStatusSnapshot } from "./runtimeStatus.js";
 
 type DiscordControlConfig = {
   botToken: string;
@@ -51,6 +52,12 @@ export type StopProjectCommandRequest = {
   requestedAt: string;
   requestedBy: string;
   mode: "now" | "when-project-complete";
+};
+
+export type StatusCommandRequest = {
+  messageId: string;
+  requestedAt: string;
+  requestedBy: string;
 };
 
 export type StartProjectCommandResult =
@@ -114,9 +121,20 @@ export type StopProjectCommandResult =
     message: string;
   };
 
+export type StatusCommandResult =
+  | {
+    ok: true;
+    snapshot: RuntimeStatusSnapshot;
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
 export type DiscordControlHandlers = {
   onStartProject?: (request: StartProjectCommandRequest) => Promise<StartProjectCommandResult>;
   onStopProject?: (request: StopProjectCommandRequest) => Promise<StopProjectCommandResult>;
+  onStatus?: (request: StatusCommandRequest) => Promise<StatusCommandResult>;
 };
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -138,6 +156,7 @@ type DiscordOperatorStep =
   | "read-control-commands"
   | "send-quit-ack"
   | "send-stop-project-ack"
+  | "send-status-ack"
   | "send-project-return-ack"
   | "send-start-project-ack"
   | "send-cycle-decision-ack"
@@ -177,7 +196,7 @@ type DiscordControlMessage = {
   author?: { id?: string };
 };
 
-type DiscordSlashCommandName = "quit" | "startproject" | "stopproject";
+type DiscordSlashCommandName = "quit" | "startproject" | "stopproject" | "status";
 
 type DiscordSlashCommandResult = {
   gracefulShutdownRequest: GracefulShutdownRequest | null;
@@ -192,6 +211,7 @@ const DISCORD_SLASH_COMMAND_NAMES = {
   quit: "quit",
   startProject: "startproject",
   stopProject: "stopproject",
+  status: "status",
 } satisfies Record<string, DiscordSlashCommandName>;
 
 function getRequiredTrimmedEnv(name: string, env: NodeJS.ProcessEnv): string | null {
@@ -295,6 +315,10 @@ function parseStopProjectCommand(content: string): string | null {
   }
 
   return match[1]?.trim() ?? "";
+}
+
+function parseStatusCommand(content: string): boolean {
+  return content.trim().toLowerCase() === "status";
 }
 
 function parseStopProjectModeFromSuffix(
@@ -563,8 +587,8 @@ function buildStartupBootMessageContent(): string {
   return [
     "🤖 Evolvo runtime booted.",
     "Operator control is online in plain-text mode, and the live bot session will register slash commands when it connects.",
-    "Slash commands: `/quit`, `/startproject`, `/stopproject mode:now|when-project-complete`.",
-    "Plain-text fallback: `quit after current task`, `quit after tasks`, `startProject <project-name>`, `stopProject`, `stopProject whenProjectComplete`.",
+    "Slash commands: `/status`, `/quit`, `/startproject`, `/stopproject mode:now|when-project-complete`.",
+    "Plain-text fallback: `status`, `quit after current task`, `quit after tasks`, `startProject <project-name>`, `stopProject`, `stopProject whenProjectComplete`.",
     "When Evolvo posts a cycle-limit prompt, reply with `continue` or `quit`.",
     `Started at: ${startedAt}`,
   ].join("\n");
@@ -794,6 +818,97 @@ async function sendStopProjectAcknowledgement(
   });
 }
 
+function formatStatusProjectLine(snapshot: RuntimeStatusSnapshot): string {
+  if (snapshot.activeProject === null) {
+    return "Project: none";
+  }
+
+  const repositorySuffix = snapshot.activeProject.repository
+    ? ` | repo: \`${snapshot.activeProject.repository}\``
+    : "";
+  return `Project: ${snapshot.activeProject.displayName} (\`${snapshot.activeProject.slug}\`)${repositorySuffix}`;
+}
+
+function formatStatusIssueLine(snapshot: RuntimeStatusSnapshot): string {
+  if (snapshot.activeIssue === null) {
+    return "Issue: none";
+  }
+
+  const repositorySuffix = snapshot.activeIssue.repository
+    ? ` | repo: \`${snapshot.activeIssue.repository}\``
+    : "";
+  return `Issue: #${snapshot.activeIssue.number} ${snapshot.activeIssue.title}${repositorySuffix}`;
+}
+
+function formatStatusLifecycleLine(snapshot: RuntimeStatusSnapshot): string {
+  if (snapshot.activeIssue === null) {
+    return "Lifecycle: none";
+  }
+
+  return `Lifecycle: ${snapshot.activeIssue.lifecycleState ?? "unknown"}`;
+}
+
+function formatStatusDeferredStopLine(snapshot: RuntimeStatusSnapshot): string {
+  if (snapshot.deferredStop !== "when-project-complete") {
+    return "Deferred stop: none";
+  }
+
+  return "Deferred stop: current project will stop when complete, then Evolvo will return to self-work.";
+}
+
+function formatStatusCycleLine(snapshot: RuntimeStatusSnapshot): string {
+  if (snapshot.cycle === null) {
+    return "Cycle: unavailable";
+  }
+
+  if (snapshot.cycle.current !== null && snapshot.cycle.limit !== null) {
+    return `Cycle: ${snapshot.cycle.current} of ${snapshot.cycle.limit} (${snapshot.cycle.remaining ?? "unknown"} remaining after this cycle)`;
+  }
+
+  if (snapshot.cycle.limit !== null) {
+    return `Cycle: not started yet (${snapshot.cycle.limit} total budget available)`;
+  }
+
+  return `Cycle: ${snapshot.cycle.current ?? "unknown"} (limit unavailable)`;
+}
+
+function buildStatusAcknowledgementContent(
+  operatorUserId: string,
+  result: StatusCommandResult,
+): string {
+  if (!result.ok) {
+    return [
+      `<@${operatorUserId}> Could not read the current Evolvo status.`,
+      result.message,
+    ].join("\n");
+  }
+
+  const snapshot = result.snapshot;
+  return [
+    `<@${operatorUserId}> Evolvo is online.`,
+    `Runtime state: \`${snapshot.runtimeState}\``,
+    `Work mode: \`${snapshot.workMode}\``,
+    `Activity: ${snapshot.activitySummary ?? "unavailable"}`,
+    formatStatusProjectLine(snapshot),
+    formatStatusIssueLine(snapshot),
+    formatStatusLifecycleLine(snapshot),
+    formatStatusDeferredStopLine(snapshot),
+    formatStatusCycleLine(snapshot),
+  ].join("\n");
+}
+
+async function sendStatusAcknowledgement(
+  config: DiscordControlConfig,
+  result: StatusCommandResult,
+): Promise<void> {
+  await fetchDiscordJson<{ id: string }>(config, `/channels/${config.controlChannelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify({
+      content: buildStatusAcknowledgementContent(config.operatorUserId, result),
+    }),
+  });
+}
+
 export async function notifyDeferredProjectStopTriggeredInDiscord(project: {
   displayName: string;
   slug: string;
@@ -859,6 +974,10 @@ async function sendRuntimeQuitNotification(
 
 function buildDiscordSlashCommandDefinitions(): RESTPostAPIChatInputApplicationCommandsJSONBody[] {
   return [
+    {
+      name: DISCORD_SLASH_COMMAND_NAMES.status,
+      description: "Show the current Evolvo runtime and work status",
+    },
     {
       name: DISCORD_SLASH_COMMAND_NAMES.quit,
       description: "Request a graceful Evolvo shutdown",
@@ -1081,9 +1200,33 @@ async function processStopProjectControlCommand(
   }
 }
 
+async function processStatusControlCommand(
+  messageId: string,
+  requestedBy: string,
+  handlers: DiscordControlHandlers,
+): Promise<StatusCommandResult> {
+  try {
+    if (!handlers.onStatus) {
+      throw new Error("Status commands are not available in this runtime.");
+    }
+
+    return await handlers.onStatus({
+      messageId,
+      requestedAt: new Date().toISOString(),
+      requestedBy,
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Unknown status request error.",
+    };
+  }
+}
+
 function getSlashCommandName(interaction: ChatInputCommandInteraction): DiscordSlashCommandName | null {
   if (
-    interaction.commandName === DISCORD_SLASH_COMMAND_NAMES.quit
+    interaction.commandName === DISCORD_SLASH_COMMAND_NAMES.status
+    || interaction.commandName === DISCORD_SLASH_COMMAND_NAMES.quit
     || interaction.commandName === DISCORD_SLASH_COMMAND_NAMES.startProject
     || interaction.commandName === DISCORD_SLASH_COMMAND_NAMES.stopProject
   ) {
@@ -1123,6 +1266,20 @@ export async function handleDiscordSlashCommandInteraction(
   }
 
   await interaction.deferReply();
+
+  if (commandName === DISCORD_SLASH_COMMAND_NAMES.status) {
+    const result = await processStatusControlCommand(
+      interaction.id,
+      `discord:${interaction.user.id}`,
+      handlers,
+    );
+    const replyContent = buildStatusAcknowledgementContent(config.operatorUserId, result);
+    await interaction.editReply({ content: replyContent });
+    return {
+      gracefulShutdownRequest: null,
+      replyContent,
+    };
+  }
 
   if (commandName === DISCORD_SLASH_COMMAND_NAMES.quit) {
     const mode = interaction.options.getString("mode", true) as GracefulShutdownMode;
@@ -1398,6 +1555,22 @@ export async function pollDiscordGracefulShutdownCommand(
         continue;
       }
 
+      if (parseStatusCommand(message.content) && handlers.onStatus) {
+        const result = await processStatusControlCommand(
+          message.id,
+          `discord:${config.operatorUserId}`,
+          handlers,
+        );
+        try {
+          await sendStatusAcknowledgement(config, result);
+        } catch (error) {
+          const sendMessage = buildStepFailureMessage("send-status-ack", error);
+          console.error(`Discord status acknowledgement failed: ${sendMessage}`);
+          logDiscordMissingAccessHint(sendMessage);
+        }
+        continue;
+      }
+
       const stopProjectCommandSuffix = parseStopProjectCommand(message.content);
       if (stopProjectCommandSuffix !== null && handlers.onStopProject) {
         const parsedStopMode = parseStopProjectModeFromSuffix(stopProjectCommandSuffix);
@@ -1503,7 +1676,7 @@ async function startDiscordSlashCommandListener(
     void registerDiscordSlashCommands(readyClient, config)
       .then(() => {
         console.log(
-          `Discord slash commands registered in guild ${config.guildId}: /${DISCORD_SLASH_COMMAND_NAMES.quit}, /${DISCORD_SLASH_COMMAND_NAMES.startProject}, /${DISCORD_SLASH_COMMAND_NAMES.stopProject}.`,
+          `Discord slash commands registered in guild ${config.guildId}: /${DISCORD_SLASH_COMMAND_NAMES.status}, /${DISCORD_SLASH_COMMAND_NAMES.quit}, /${DISCORD_SLASH_COMMAND_NAMES.startProject}, /${DISCORD_SLASH_COMMAND_NAMES.stopProject}.`,
         );
       })
       .catch((error: unknown) => {

--- a/src/runtime/runtimeStatus.test.ts
+++ b/src/runtime/runtimeStatus.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { buildRuntimeStatusSnapshot } from "./runtimeStatus.js";
+
+describe("runtimeStatus", () => {
+  it("reports self-work with cycle remaining when no managed project is active", () => {
+    const snapshot = buildRuntimeStatusSnapshot({
+      runtimeState: "active",
+      activitySummary: "Selecting next issue.",
+      activeProjectState: {
+        activeProjectSlug: null,
+        selectionState: null,
+        deferredStopMode: null,
+      },
+      activeProject: null,
+      activeIssue: {
+        number: 404,
+        title: "Default Codex model",
+        repository: "evolvo-auto/evolvo-ts",
+        lifecycleState: "selected -> executing",
+      },
+      currentCycle: 3,
+      cycleLimit: 10,
+    });
+
+    expect(snapshot).toEqual({
+      online: true,
+      runtimeState: "active",
+      workMode: "self-work",
+      activitySummary: "Selecting next issue.",
+      activeProject: null,
+      activeIssue: {
+        number: 404,
+        title: "Default Codex model",
+        repository: "evolvo-auto/evolvo-ts",
+        lifecycleState: "selected -> executing",
+      },
+      deferredStop: null,
+      cycle: {
+        current: 3,
+        limit: 10,
+        remaining: 7,
+      },
+    });
+  });
+
+  it("reports project work and deferred stop when a managed project remains active", () => {
+    const snapshot = buildRuntimeStatusSnapshot({
+      runtimeState: "active",
+      activitySummary: "Executing current project issue.",
+      activeProjectState: {
+        activeProjectSlug: "habit-cli",
+        selectionState: "active",
+        deferredStopMode: "when-project-complete",
+      },
+      activeProject: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repository: "evolvo-auto/habit-cli",
+      },
+      activeIssue: {
+        number: 17,
+        title: "Polish project command routing",
+        repository: "evolvo-auto/habit-cli",
+        lifecycleState: "selected -> executing",
+      },
+      currentCycle: 5,
+      cycleLimit: 12,
+    });
+
+    expect(snapshot.workMode).toBe("project-work");
+    expect(snapshot.deferredStop).toBe("when-project-complete");
+    expect(snapshot.activeProject).toEqual({
+      displayName: "Habit CLI",
+      slug: "habit-cli",
+      repository: "evolvo-auto/habit-cli",
+    });
+    expect(snapshot.cycle).toEqual({
+      current: 5,
+      limit: 12,
+      remaining: 7,
+    });
+  });
+
+  it("reports idle mode when a project is explicitly stopped", () => {
+    const snapshot = buildRuntimeStatusSnapshot({
+      runtimeState: "waiting",
+      activitySummary: "Waiting for further operator instructions.",
+      activeProjectState: {
+        activeProjectSlug: "habit-cli",
+        selectionState: "stopped",
+        deferredStopMode: null,
+      },
+      activeProject: {
+        displayName: "Habit CLI",
+        slug: "habit-cli",
+        repository: "evolvo-auto/habit-cli",
+      },
+      activeIssue: null,
+      currentCycle: null,
+      cycleLimit: 10,
+    });
+
+    expect(snapshot.workMode).toBe("idle");
+    expect(snapshot.cycle).toEqual({
+      current: null,
+      limit: 10,
+      remaining: 10,
+    });
+  });
+});

--- a/src/runtime/runtimeStatus.ts
+++ b/src/runtime/runtimeStatus.ts
@@ -1,0 +1,105 @@
+import type { ActiveProjectState } from "../projects/activeProjectState.js";
+
+export type RuntimeStatusState = "starting" | "active" | "idle" | "waiting" | "stopping";
+export type RuntimeWorkMode = "self-work" | "project-work" | "idle";
+
+export type RuntimeStatusProject = {
+  displayName: string;
+  slug: string;
+  repository: string | null;
+};
+
+export type RuntimeStatusIssue = {
+  number: number;
+  title: string;
+  repository: string | null;
+  lifecycleState: string | null;
+};
+
+export type RuntimeStatusCycle = {
+  current: number | null;
+  limit: number | null;
+  remaining: number | null;
+};
+
+export type RuntimeStatusSnapshot = {
+  online: true;
+  runtimeState: RuntimeStatusState;
+  workMode: RuntimeWorkMode;
+  activitySummary: string | null;
+  activeProject: RuntimeStatusProject | null;
+  activeIssue: RuntimeStatusIssue | null;
+  deferredStop: ActiveProjectState["deferredStopMode"] | null;
+  cycle: RuntimeStatusCycle | null;
+};
+
+function normalizePositiveInteger(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  return Math.floor(value);
+}
+
+function deriveWorkMode(
+  activeProjectState: Pick<ActiveProjectState, "activeProjectSlug" | "selectionState">,
+  runtimeState: RuntimeStatusState,
+): RuntimeWorkMode {
+  if (activeProjectState.selectionState === "stopped") {
+    return "idle";
+  }
+
+  if (activeProjectState.activeProjectSlug !== null) {
+    return "project-work";
+  }
+
+  if (runtimeState === "idle" || runtimeState === "waiting") {
+    return "idle";
+  }
+
+  return "self-work";
+}
+
+function buildCycleStatus(
+  currentCycle: number | null | undefined,
+  cycleLimit: number | null | undefined,
+): RuntimeStatusCycle | null {
+  const current = normalizePositiveInteger(currentCycle);
+  const limit = normalizePositiveInteger(cycleLimit);
+  if (current === null && limit === null) {
+    return null;
+  }
+
+  const remaining = limit === null
+    ? null
+    : current === null
+      ? limit
+      : Math.max(limit - current, 0);
+
+  return {
+    current,
+    limit,
+    remaining,
+  };
+}
+
+export function buildRuntimeStatusSnapshot(input: {
+  runtimeState: RuntimeStatusState;
+  activitySummary: string | null;
+  activeProjectState: Pick<ActiveProjectState, "activeProjectSlug" | "selectionState" | "deferredStopMode">;
+  activeProject: RuntimeStatusProject | null;
+  activeIssue: RuntimeStatusIssue | null;
+  currentCycle: number | null;
+  cycleLimit: number | null;
+}): RuntimeStatusSnapshot {
+  return {
+    online: true,
+    runtimeState: input.runtimeState,
+    workMode: deriveWorkMode(input.activeProjectState, input.runtimeState),
+    activitySummary: input.activitySummary?.trim() || null,
+    activeProject: input.activeProject,
+    activeIssue: input.activeIssue,
+    deferredStop: input.activeProjectState.deferredStopMode ?? null,
+    cycle: buildCycleStatus(input.currentCycle, input.cycleLimit),
+  };
+}


### PR DESCRIPTION
## Summary
- add  support to the Discord control surface and plain-text fallback polling
- track live runtime status in the main loop so operators can see mode, active issue, project, deferred stop, and cycle budget
- cover self-work, project-work, deferred-stop, idle, and live execution status with tests

Closes #403