### PR TITLE
feat(queue): include all active project issues

### DIFF
--- a/src/issues/unifiedIssueQueue.test.ts
+++ b/src/issues/unifiedIssueQueue.test.ts
@@ -2,10 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const readProjectRegistryMock = vi.fn();
 const findProjectBySlugMock = vi.fn();
+const readActiveProjectsStateMock = vi.fn();
 
 vi.mock("../projects/projectRegistry.js", () => ({
   readProjectRegistry: readProjectRegistryMock,
   findProjectBySlug: findProjectBySlugMock,
+}));
+
+vi.mock("../projects/activeProjectsState.js", () => ({
+  readActiveProjectsState: readActiveProjectsStateMock,
 }));
 
 describe("unifiedIssueQueue", () => {
@@ -13,6 +18,11 @@ describe("unifiedIssueQueue", () => {
     vi.resetModules();
     readProjectRegistryMock.mockReset();
     findProjectBySlugMock.mockReset();
+    readActiveProjectsStateMock.mockReset();
+    readActiveProjectsStateMock.mockResolvedValue({
+      version: 1,
+      projects: [],
+    });
   });
 
   it("returns tracker issues only when there is no active project", async () => {
@@ -52,12 +62,13 @@ describe("unifiedIssueQueue", () => {
     });
 
     expect(result.activeManagedProject).toBeNull();
+    expect(result.activeManagedProjects).toEqual([]);
     expect(result.issues.map((issue) => issue.queueKey)).toEqual(["tracker:evolvo-auto/evolvo-ts#1"]);
     expect(trackerIssueManager.forRepository).not.toHaveBeenCalled();
   });
 
-  it("adds active managed project issues ahead of tracker issues", async () => {
-    const projectIssueManager = {
+  it("adds issues from every active managed project ahead of tracker issues", async () => {
+    const evolvoWebIssueManager = {
       listOpenIssues: vi.fn().mockResolvedValue([
         {
           number: 5,
@@ -65,6 +76,17 @@ describe("unifiedIssueQueue", () => {
           description: "Build the shell.",
           state: "open",
           labels: ["frontend"],
+        },
+      ]),
+    };
+    const habitCliIssueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          number: 7,
+          title: "Habit sync",
+          description: "Add sync support.",
+          state: "open",
+          labels: ["backend"],
         },
       ]),
     };
@@ -79,6 +101,137 @@ describe("unifiedIssueQueue", () => {
             labels: [],
           },
         ],
+        unauthorizedClosures: [],
+      }),
+      forRepository: vi.fn().mockImplementation(({ repo }: { repo: string }) => {
+        if (repo === "evolvo-web") {
+          return evolvoWebIssueManager;
+        }
+
+        if (repo === "habit-cli") {
+          return habitCliIssueManager;
+        }
+
+        throw new Error(`Unexpected repository ${repo}`);
+      }),
+    };
+    const activeProject = {
+      slug: "evolvo-web",
+      displayName: "evolvo-web",
+      kind: "managed",
+      issueLabel: "project:evolvo-web",
+      trackerRepo: {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        url: "https://github.com/evolvo-auto/evolvo-ts",
+      },
+      executionRepo: {
+        owner: "evolvo-auto",
+        repo: "evolvo-web",
+        url: "https://github.com/evolvo-auto/evolvo-web",
+        defaultBranch: "main",
+      },
+      cwd: "/home/paddy/evolvo-web",
+      status: "active",
+      sourceIssueNumber: 10,
+      createdAt: "2026-03-08T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      provisioning: {
+        labelCreated: true,
+        repoCreated: true,
+        workspacePrepared: true,
+        lastError: null,
+      },
+    };
+    const secondaryProject = {
+      ...activeProject,
+      slug: "habit-cli",
+      displayName: "Habit CLI",
+      issueLabel: "project:habit-cli",
+      executionRepo: {
+        owner: "evolvo-auto",
+        repo: "habit-cli",
+        url: "https://github.com/evolvo-auto/habit-cli",
+        defaultBranch: "main",
+      },
+      cwd: "/home/paddy/habit-cli",
+    };
+    readActiveProjectsStateMock.mockResolvedValue({
+      version: 1,
+      projects: [
+        {
+          slug: "habit-cli",
+          updatedAt: "2026-03-08T00:01:00.000Z",
+          requestedBy: "operator",
+          source: "start-project-command",
+        },
+        {
+          slug: "evolvo-web",
+          updatedAt: "2026-03-08T00:00:00.000Z",
+          requestedBy: "operator",
+          source: "start-project-command",
+        },
+      ],
+    });
+    readProjectRegistryMock.mockResolvedValue({ projects: [activeProject, secondaryProject] });
+    findProjectBySlugMock.mockImplementation((registry: { projects: Array<{ slug: string }> }, slug: string) =>
+      registry.projects.find((project) => project.slug === slug) ?? null
+    );
+
+    const { buildUnifiedIssueQueue } = await import("./unifiedIssueQueue.js");
+    const result = await buildUnifiedIssueQueue({
+      trackerIssueManager: trackerIssueManager as never,
+      workDir: "/tmp/evolvo",
+      defaultProject: {
+        owner: "evolvo-auto",
+        repo: "evolvo-ts",
+        workDir: "/tmp/evolvo",
+      },
+      activeProjectState: {
+        version: 2,
+        activeProjectSlug: "evolvo-web",
+        selectionState: "active",
+        updatedAt: "2026-03-08T00:00:00.000Z",
+        requestedBy: "operator",
+        source: "start-project-command",
+      },
+    });
+
+    expect(trackerIssueManager.forRepository).toHaveBeenCalledWith({
+      owner: "evolvo-auto",
+      repo: "habit-cli",
+    });
+    expect(trackerIssueManager.forRepository).toHaveBeenCalledWith({
+      owner: "evolvo-auto",
+      repo: "evolvo-web",
+    });
+    expect(result.activeManagedProject?.slug).toBe("evolvo-web");
+    expect(result.activeManagedProjects.map((project) => project.slug)).toEqual([
+      "evolvo-web",
+      "habit-cli",
+    ]);
+    expect(result.issues.map((issue) => issue.queueKey)).toEqual([
+      "project:evolvo-web#5",
+      "project:habit-cli#7",
+      "tracker:evolvo-auto/evolvo-ts#1",
+    ]);
+  });
+
+  it("keeps the focused managed project visible even if the active-project set has not caught up yet", async () => {
+    const projectIssueManager = {
+      listOpenIssues: vi.fn().mockResolvedValue([
+        {
+          number: 5,
+          title: "Homepage shell",
+          description: "Build the shell.",
+          state: "open",
+          labels: ["frontend"],
+        },
+      ]),
+    };
+    const trackerIssueManager = {
+      listAuthorizedOpenIssues: vi.fn().mockResolvedValue({
+        issues: [],
         unauthorizedClosures: [],
       }),
       forRepository: vi.fn().mockReturnValue(projectIssueManager),
@@ -112,7 +265,9 @@ describe("unifiedIssueQueue", () => {
       },
     };
     readProjectRegistryMock.mockResolvedValue({ projects: [activeProject] });
-    findProjectBySlugMock.mockReturnValue(activeProject);
+    findProjectBySlugMock.mockImplementation((registry: { projects: Array<{ slug: string }> }, slug: string) =>
+      registry.projects.find((project) => project.slug === slug) ?? null
+    );
 
     const { buildUnifiedIssueQueue } = await import("./unifiedIssueQueue.js");
     const result = await buildUnifiedIssueQueue({
@@ -133,14 +288,10 @@ describe("unifiedIssueQueue", () => {
       },
     });
 
-    expect(trackerIssueManager.forRepository).toHaveBeenCalledWith({
-      owner: "evolvo-auto",
-      repo: "evolvo-web",
-    });
     expect(result.activeManagedProject?.slug).toBe("evolvo-web");
+    expect(result.activeManagedProjects.map((project) => project.slug)).toEqual(["evolvo-web"]);
     expect(result.issues.map((issue) => issue.queueKey)).toEqual([
       "project:evolvo-web#5",
-      "tracker:evolvo-auto/evolvo-ts#1",
     ]);
   });
 
@@ -180,6 +331,7 @@ describe("unifiedIssueQueue", () => {
     });
 
     expect(result.activeManagedProject).toBeNull();
+    expect(result.activeManagedProjects).toEqual([]);
     expect(trackerIssueManager.forRepository).not.toHaveBeenCalled();
   });
 });

--- a/src/issues/unifiedIssueQueue.ts
+++ b/src/issues/unifiedIssueQueue.ts
@@ -1,6 +1,7 @@
 import type { DefaultProjectContext, ProjectRecord } from "../projects/projectRegistry.js";
 import { findProjectBySlug, readProjectRegistry } from "../projects/projectRegistry.js";
 import type { ActiveProjectState } from "../projects/activeProjectState.js";
+import { readActiveProjectsState } from "../projects/activeProjectsState.js";
 import type {
   IssueSummary,
   TaskIssueManager,
@@ -24,6 +25,7 @@ export type UnifiedIssueQueue = {
   issues: UnifiedIssue[];
   unauthorizedClosures: UnauthorizedIssueClosureResult[];
   activeManagedProject: ProjectRecord | null;
+  activeManagedProjects: ProjectRecord[];
 };
 
 function buildRepositoryReference(repository: { owner: string; repo: string }): string {
@@ -65,25 +67,51 @@ function buildProjectUnifiedIssue(issue: IssueSummary, project: ProjectRecord): 
   };
 }
 
-async function resolveActiveManagedProject(
+function isActiveManagedProject(project: ProjectRecord | null): project is ProjectRecord {
+  return project !== null && project.kind === "managed" && project.status === "active";
+}
+
+async function resolveManagedProjectQueueState(
   workDir: string,
   defaultProject: DefaultProjectContext,
   activeProjectState: ActiveProjectState,
-): Promise<ProjectRecord | null> {
+): Promise<{
+  activeManagedProject: ProjectRecord | null;
+  activeManagedProjects: ProjectRecord[];
+}> {
+  const [registry, activeProjectsState] = await Promise.all([
+    readProjectRegistry(workDir, defaultProject),
+    readActiveProjectsState(workDir),
+  ]);
+
+  const activeManagedProjectsBySlug = new Map<string, ProjectRecord>();
+  for (const entry of activeProjectsState.projects) {
+    const project = findProjectBySlug(registry, entry.slug);
+    if (!isActiveManagedProject(project)) {
+      continue;
+    }
+
+    activeManagedProjectsBySlug.set(project.slug, project);
+  }
+
+  let activeManagedProject: ProjectRecord | null = null;
   if (
-    activeProjectState.selectionState !== "active" ||
-    activeProjectState.activeProjectSlug === null
+    activeProjectState.selectionState === "active"
+    && activeProjectState.activeProjectSlug !== null
   ) {
-    return null;
+    const focusedProject = findProjectBySlug(registry, activeProjectState.activeProjectSlug);
+    if (isActiveManagedProject(focusedProject)) {
+      activeManagedProject = focusedProject;
+      activeManagedProjectsBySlug.set(focusedProject.slug, focusedProject);
+    }
   }
 
-  const registry = await readProjectRegistry(workDir, defaultProject);
-  const project = findProjectBySlug(registry, activeProjectState.activeProjectSlug);
-  if (!project || project.kind !== "managed" || project.status !== "active") {
-    return null;
-  }
-
-  return project;
+  return {
+    activeManagedProject,
+    activeManagedProjects: [...activeManagedProjectsBySlug.values()].sort((left, right) =>
+      left.slug.localeCompare(right.slug)
+    ),
+  };
 }
 
 export async function buildUnifiedIssueQueue(options: {
@@ -93,26 +121,31 @@ export async function buildUnifiedIssueQueue(options: {
   activeProjectState: ActiveProjectState;
 }): Promise<UnifiedIssueQueue> {
   const trackerInventory = await options.trackerIssueManager.listAuthorizedOpenIssues();
-  const activeManagedProject = await resolveActiveManagedProject(
+  const managedProjectQueueState = await resolveManagedProjectQueueState(
     options.workDir,
     options.defaultProject,
     options.activeProjectState,
   );
+  const { activeManagedProject, activeManagedProjects } = managedProjectQueueState;
 
   const issues: UnifiedIssue[] = trackerInventory.issues.map((issue) => buildTrackerUnifiedIssue(issue, options.defaultProject));
 
-  if (activeManagedProject !== null) {
-    const projectIssueManager = options.trackerIssueManager.forRepository({
-      owner: activeManagedProject.executionRepo.owner,
-      repo: activeManagedProject.executionRepo.repo,
-    });
-    const projectIssues = await projectIssueManager.listOpenIssues();
-    issues.unshift(...projectIssues.map((issue) => buildProjectUnifiedIssue(issue, activeManagedProject)));
+  if (activeManagedProjects.length > 0) {
+    const projectIssues = await Promise.all(activeManagedProjects.map(async (project) => {
+      const projectIssueManager = options.trackerIssueManager.forRepository({
+        owner: project.executionRepo.owner,
+        repo: project.executionRepo.repo,
+      });
+      const issuesForProject = await projectIssueManager.listOpenIssues();
+      return issuesForProject.map((issue) => buildProjectUnifiedIssue(issue, project));
+    }));
+    issues.unshift(...projectIssues.flat());
   }
 
   return {
     issues,
     unauthorizedClosures: trackerInventory.unauthorizedClosures,
     activeManagedProject,
+    activeManagedProjects,
   };
 }


### PR DESCRIPTION
## Summary
- make the unified issue queue read from the canonical active-project set
- include repository issues for every active managed project, not just the focused one
- keep the focused project visible as a fallback while the active-project set catches up

## Validation
- pnpm validate

## Notes
- Part of #407
- This improves multi-project queue visibility only; execution is still single-agent and single-focus.
